### PR TITLE
Fix page parameter update in ihost.py

### DIFF
--- a/IPTVPlayer/components/ihost.py
+++ b/IPTVPlayer/components/ihost.py
@@ -979,6 +979,6 @@ class CBaseHostClass:
         if url:
             params.update({'url': url})
         if page:
-            params.update({page})
+            params.update({'page': page})
         params.update({'title': _("Next page")})
         self.addDir(params)


### PR DESCRIPTION
>> Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/components/asynccall.py", line 179, in run
    result = self.Callable(*args, **kwargs)
  File "/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/components/ihost.py", line 538, in getListForItem
    self.host.handleService(Index, refresh, self.searchPattern, self.searchType)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/hosts/hostaflaam.py", line 331, in handleService
    self.listItems(self.currItem, 'explore_item')
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/hosts/hostaflaam.py", line 167, in listItems
    self.applyNextPage(cItem, url=nextPage, page=page + 1)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/components/ihost.py", line 998, in applyNextPage
    params.update({page})
    ~~~~~~~~~~~~~^^^^^^^^
TypeError: cannot convert dictionary update sequence element #0 to a sequence