### PR TITLE
Change division to floor division for time calculations

### DIFF
--- a/IPTVPlayer/tools/iptvsubtitles.py
+++ b/IPTVPlayer/tools/iptvsubtitles.py
@@ -152,7 +152,7 @@ class IPTVSubtitlesHandler:
         printDBG("OpenSubOrg.getSubtitles(currTimeMS = %s, prevMarker = %s)" % (currTimeMS, prevMarker))
         # time1 = time.time()
         subsText = []
-        tmp = currTimeMS / self.CAPACITY
+        tmp = currTimeMS // self.CAPACITY
         tmpList = self.pailsOfAtoms.get(tmp, [])
 
         if len(tmpList) == 0:
@@ -220,17 +220,13 @@ class IPTVSubtitlesHandler:
     def _fillPailsOfAtoms(self):
         self.pailsOfAtoms = {}
         for idx in range(len(self.subAtoms)):
-            tmp = self.subAtoms[idx]['start'] / self.CAPACITY
-            if tmp not in self.pailsOfAtoms:
-                self.pailsOfAtoms[tmp] = [idx]
-            elif idx not in self.pailsOfAtoms[tmp]:
-                self.pailsOfAtoms[tmp].append(idx)
-
-            tmp = self.subAtoms[idx]['end'] / self.CAPACITY
-            if tmp not in self.pailsOfAtoms:
-                self.pailsOfAtoms[tmp] = [idx]
-            elif idx not in self.pailsOfAtoms[tmp]:
-                self.pailsOfAtoms[tmp].append(idx)
+            startBucket = self.subAtoms[idx]['start'] // self.CAPACITY
+            endBucket = self.subAtoms[idx]['end'] // self.CAPACITY
+            for tmp in range(startBucket, endBucket + 1):
+                if tmp not in self.pailsOfAtoms:
+                    self.pailsOfAtoms[tmp] = [idx]
+                elif idx not in self.pailsOfAtoms[tmp]:
+                    self.pailsOfAtoms[tmp].append(idx)
         self.pailsOfAtoms = dict(sorted(self.pailsOfAtoms.items()))
         if 1:  # for tests
             with codecs.open('/tmp/pailsOfAtoms.json', 'w', 'utf-8') as fp:
@@ -357,17 +353,13 @@ class IPTVEmbeddedSubtitlesHandler:
                     idx = len(self.subAtoms)
                     self.subAtoms.append({'start': inAtom['start'], 'end': inAtom['end'], 'text': text})
 
-                    tmp = self.subAtoms[idx]['start'] / self.CAPACITY
-                    if tmp not in self.pailsOfAtoms:
-                        self.pailsOfAtoms[tmp] = [idx]
-                    elif idx not in self.pailsOfAtoms[tmp]:
-                        self.pailsOfAtoms[tmp].append(idx)
-
-                    tmp = self.subAtoms[idx]['end'] / self.CAPACITY
-                    if tmp not in self.pailsOfAtoms:
-                        self.pailsOfAtoms[tmp] = [idx]
-                    elif idx not in self.pailsOfAtoms[tmp]:
-                        self.pailsOfAtoms[tmp].append(idx)
+                    startBucket = self.subAtoms[idx]['start'] // self.CAPACITY
+                    endBucket = self.subAtoms[idx]['end'] // self.CAPACITY
+                    for tmp in range(startBucket, endBucket + 1):
+                        if tmp not in self.pailsOfAtoms:
+                            self.pailsOfAtoms[tmp] = [idx]
+                        elif idx not in self.pailsOfAtoms[tmp]:
+                            self.pailsOfAtoms[tmp].append(idx)
         except Exception:
             pass
 
@@ -375,7 +367,7 @@ class IPTVEmbeddedSubtitlesHandler:
         if prevMarker is None:
             prevMarker = []
         subsText = []
-        tmp = currTimeMS / self.CAPACITY
+        tmp = currTimeMS // self.CAPACITY
         tmp = self.pailsOfAtoms.get(tmp, [])
 
         ret = None


### PR DESCRIPTION

The embedded subtitle track is selected in components/iptvextmovieplayer.py, then exteplayer3 sends subtitle atoms through the "s_a" event into IPTVEmbeddedSubtitlesHandler. The rendering lookup happens in tools/iptvsubtitles.py:367.

The bug was Python 2 vs Python 3 division: subtitle time buckets used /. On Python 2 that gave integer buckets, but on Python 3 it gives floats, so the player could receive embedded subtitle packets but fail to find them when drawing. That matches your symptom: language/track appears selectable, but no text appears.

I changed the bucket math to use // and made subtitles index every bucket they span. This affects both embedded subtitles and normal parsed subtitle files.
modification by my friend rachidb13

<img width="1600" height="900" alt="1780103488135" src="https://github.com/user-attachments/assets/aa4abceb-8b72-4653-9aa0-4fdca1bfbce4" />
<img width="1600" height="900" alt="1780103459938" src="https://github.com/user-attachments/assets/374d28c9-7b01-46e2-86d3-74701d535728" />
