### PR TITLE
Search History + T9 Letter Jump improvments + Some Fixes

### DIFF
--- a/components/iptvconfigmenu.py
+++ b/components/iptvconfigmenu.py
@@ -1,0 +1,705 @@
+# -*- coding: utf-8 -*-
+#
+#  Konfigurator dla iptv 2013
+#  autorzy: j00zek, samsamsam
+#
+
+###################################################
+# LOCAL import
+###################################################
+
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, GetSkinsList, GetHostsList, GetEnabledHostsList, \
+                                                          IsExecutable, CFakeMoviePlayerOption
+from Plugins.Extensions.IPTVPlayer.components.configbase import ConfigBaseWidget, ConfigIPTVFileSelection, COLORS_DEFINITONS
+from Plugins.Extensions.IPTVPlayer.components.confighost import ConfigHostsMenu
+from Plugins.Extensions.IPTVPlayer.components.iptvdirbrowser import IPTVDirectorySelectorWidget
+from Plugins.Extensions.IPTVPlayer.components.configextmovieplayer import ConfigExtMoviePlayer
+from Plugins.Extensions.IPTVPlayer.__init__ import _, GRIDSUPPORT
+from .iptvpin import IPTVPinWidget
+###################################################
+
+###################################################
+# FOREIGN import
+###################################################
+from Screens.MessageBox import MessageBox
+
+from Components.config import config, ConfigSubsection, ConfigSelection, ConfigDirectory, ConfigYesNo, ConfigOnOff, ConfigInteger, \
+                              ConfigText, ConfigSelectionNumber, getConfigListEntry, configfile
+from Tools.BoundFunction import boundFunction
+###################################################
+
+
+###################################################
+# Config options for HOST
+###################################################
+config.plugins.iptvplayer = ConfigSubsection()
+
+config.plugins.iptvplayer.plarformfpuabi = ConfigSelection(default="", choices=[("", ""), ("hard_float", _("Hardware floating point")), ("soft_float", _("Software floating point"))])
+config.plugins.iptvplayer.exteplayer3path = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.set_curr_title = ConfigYesNo(default=False)
+config.plugins.iptvplayer.curr_title_file = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.showcover = ConfigYesNo(default=True)
+config.plugins.iptvplayer.deleteIcons = ConfigSelection(default="3", choices=[("0", _("after closing")), ("1", _("after day")), ("3", _("after three days")), ("7", _("after a week"))])
+# config.plugins.iptvplayer.allowedcoverformats = ConfigSelection(default="jpeg,png", choices=[("jpeg,png,gif", _("jpeg,png,gif")), ("jpeg,png", _("jpeg,png")), ("jpeg", _("jpeg")), ("all", _("all"))])
+config.plugins.iptvplayer.showinextensions = ConfigYesNo(default=True)
+# "T" (tree list) is intentionally not offered here - never implemented,
+# would silently behave like "G" if selected
+config.plugins.iptvplayer.hostsListType = ConfigSelection(default="G", choices=[("G", _("Graphic services selector")), ("S", _("List view")), ("P", _("Simple list"))])
+config.plugins.iptvplayer.showinMainMenu = ConfigYesNo(default=False)
+# config.plugins.iptvplayer.ListaGraficzna = ConfigYesNo(default=True)
+config.plugins.iptvplayer.group_hosts = ConfigYesNo(default=True)
+config.plugins.iptvplayer.NaszaSciezka = ConfigDirectory(default="/hdd/movie/")  # , fixed_size = False)
+config.plugins.iptvplayer.bufferingPath = ConfigDirectory(default=config.plugins.iptvplayer.NaszaSciezka.value)  # , fixed_size = False)
+config.plugins.iptvplayer.buforowanie = ConfigYesNo(default=False)
+config.plugins.iptvplayer.buforowanie_m3u8 = ConfigYesNo(default=True)
+config.plugins.iptvplayer.buforowanie_rtmp = ConfigYesNo(default=False)
+config.plugins.iptvplayer.requestedBuffSize = ConfigInteger(2, (1, 120))
+config.plugins.iptvplayer.requestedAudioBuffSize = ConfigInteger(256, (1, 10240))
+
+config.plugins.iptvplayer.IPTVDMRunAtStart = ConfigYesNo(default=False)
+config.plugins.iptvplayer.IPTVDMShowAfterAdd = ConfigYesNo(default=True)
+config.plugins.iptvplayer.IPTVDMMaxDownloadItem = ConfigSelection(default="1", choices=[("1", "1"), ("2", "2"), ("3", "3"), ("4", "4"), ("5", "5"), ("10", "10"), ("20", "20"), ("30", "30"), ("40", "40"), ("50", "50")])
+
+config.plugins.iptvplayer.sortuj = ConfigYesNo(default=True)
+config.plugins.iptvplayer.remove_diabled_hosts = ConfigYesNo(default=False)
+config.plugins.iptvplayer.IPTVWebIterface = ConfigYesNo(default=False)
+config.plugins.iptvplayer.plugin_autostart = ConfigYesNo(default=False)
+config.plugins.iptvplayer.plugin_autostart_method = ConfigSelection(default="wizard", choices=[("wizard", "wizard"), ("infobar", "infobar")])
+
+config.plugins.iptvplayer.osk_type = ConfigSelection(default="", choices=[("", _("Auto")), ("system", _("System")), ("own", _("Own model"))])
+config.plugins.iptvplayer.osk_layout = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.osk_allow_suggestions = ConfigYesNo(default=True)
+config.plugins.iptvplayer.osk_allow_search_history = ConfigYesNo(default=True)
+config.plugins.iptvplayer.osk_remember_last_search = ConfigYesNo(default=True)
+config.plugins.iptvplayer.osk_default_suggestions = ConfigSelection(default="", choices=[("", _("Auto")), ("none", _("None")), ("google", "google.com"), ("bing", "bing.com"), ("duckduckgo", "duckduckgo.com"), ("filmweb", "filmweb.pl"), ("imdb", "imdb.com")])
+config.plugins.iptvplayer.osk_allow_host_suggestions = ConfigYesNo(default=True)
+config.plugins.iptvplayer.osk_background_color = ConfigSelection(default="", choices=[('', _('Default')), ('transparent', _('Transparent')), ('#000000', _('Black')), ('#80000000', _('Darkgray')), ('#cc000000', _('Lightgray'))])
+# the tightest element (the HD/SD input line: 26pt base in a fixed 36px-tall
+# row) is already close to its limit, so the positive end is kept modest to
+# avoid clipping instead of matching NewVirtualKeyBoard's wider 0-30 range
+config.plugins.iptvplayer.osk_font_size_offset = ConfigSelectionNumber(min=-6, max=6, stepwidth=1, default=0, wraparound=False)
+config.plugins.iptvplayer.osk_searchfield_align = ConfigSelection(default="left", choices=[("left", _("Left")), ("right", _("Right"))])
+config.plugins.iptvplayer.osk_show_flags = ConfigYesNo(default=True)
+
+
+def GetMoviePlayerName(player):
+    map = {"auto": _("auto"), "mini": _("internal"), "standard": _("standard"), 'exteplayer': _("external eplayer3"), 'extgstplayer': _("external gstplayer")}
+    return map.get(player, _('unknown'))
+
+
+def ConfigPlayer(player):
+    return (player, GetMoviePlayerName(player))
+
+
+config.plugins.iptvplayer.defaultMoviePlayer0 = ConfigSelection(default="auto", choices=[ConfigPlayer("auto"), ConfigPlayer("mini"), ConfigPlayer("standard"), ConfigPlayer('extgstplayer'), ConfigPlayer('exteplayer')])
+config.plugins.iptvplayer.alternativeMoviePlayer0 = ConfigSelection(default="auto", choices=[ConfigPlayer("auto"), ConfigPlayer("mini"), ConfigPlayer("standard"), ConfigPlayer('extgstplayer'), ConfigPlayer('exteplayer')])
+config.plugins.iptvplayer.defaultMoviePlayer = ConfigSelection(default="auto", choices=[ConfigPlayer("auto"), ConfigPlayer("mini"), ConfigPlayer("standard"), ConfigPlayer('extgstplayer'), ConfigPlayer('exteplayer')])
+config.plugins.iptvplayer.alternativeMoviePlayer = ConfigSelection(default="auto", choices=[ConfigPlayer("auto"), ConfigPlayer("mini"), ConfigPlayer("standard"), ConfigPlayer('extgstplayer'), ConfigPlayer('exteplayer')])
+# "standard" keeps the blue-key "Select movie player" picker showing just
+# the 4 configured default/alternative slots (+ Auto), like before
+# GetAvailableMoviePlayers() started listing every player directly -
+# "extended" opts into that full list instead
+config.plugins.iptvplayer.moviePlayerPickerMode = ConfigSelection(default="standard", choices=[("standard", _("Standard")), ("extended", _("Extended"))])
+
+config.plugins.iptvplayer.SciezkaCache = ConfigDirectory(default="/hdd/IPTVCache/")  # , fixed_size = False)
+config.plugins.iptvplayer.NaszaTMP = ConfigDirectory(default="/tmp/")  # , fixed_size = False)
+config.plugins.iptvplayer.ZablokujWMV = ConfigYesNo(default=True)
+
+config.plugins.iptvplayer.vkcom_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.vkcom_password = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.fichiercom_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.fichiercom_password = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.iptvplayer_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.iptvplayer_password = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.useSubtitlesParserExtension = ConfigYesNo(default=True)
+config.plugins.iptvplayer.subsourceapi = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.subdlapi = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.opensuborg_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.opensuborg_password = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.napisy24pl_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.napisy24pl_password = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.debugprint = ConfigSelection(default="", choices=[("", _("No")), ("console", _("Yes, to console")),
+                                                                            ("debugfile", _("Yes, to file /hdd/iptv.dbg")),
+                                                                            ("/tmp/iptv.dbg", _("Yes, to file /tmp/iptv.dbg")),
+                                                                            ("/home/root/logs/iptv.dbg", _("Yes, to file /home/root/logs/iptv.dbg")),
+                                                                            ])
+
+# icons
+config.plugins.iptvplayer.IconsSize = ConfigSelection(default="100", choices=[("100", "100x100"), ("120", "120x120"), ("135", "135x135")])
+config.plugins.iptvplayer.numOfRow = ConfigSelection(default="0", choices=[("1", "1"), ("2", "2"), ("3", "3"), ("4", "4"), ("0", "auto")])
+config.plugins.iptvplayer.numOfCol = ConfigSelection(default="0", choices=[("1", "1"), ("2", "2"), ("3", "3"), ("4", "4"), ("5", "5"), ("6", "6"), ("7", "7"), ("8", "8"), ("0", "auto")])
+
+config.plugins.iptvplayer.skinforceinternal = ConfigYesNo(default=False)
+config.plugins.iptvplayer.skin = ConfigSelection(default="", choices=GetSkinsList())
+config.plugins.iptvplayer.use_colors = ConfigYesNo(default=True)
+
+# Pin code
+config.plugins.iptvplayer.fakePin = ConfigSelection(default="fake", choices=[("fake", "****")])
+config.plugins.iptvplayer.pin = ConfigText(default="0000", fixed_size=False)
+config.plugins.iptvplayer.disable_live = ConfigYesNo(default=False)
+config.plugins.iptvplayer.configProtectedByPin = ConfigYesNo(default=False)
+config.plugins.iptvplayer.pluginProtectedByPin = ConfigYesNo(default=False)
+
+config.plugins.iptvplayer.httpssslcertvalidation = ConfigYesNo(default=False)
+
+# PROXY
+config.plugins.iptvplayer.proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+config.plugins.iptvplayer.german_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+config.plugins.iptvplayer.russian_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+config.plugins.iptvplayer.ukrainian_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+config.plugins.iptvplayer.alternative_proxy1 = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+config.plugins.iptvplayer.alternative_proxy2 = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+
+# config.plugins.iptvplayer.captcha_bypass_order = ConfigSelection(default="", choices=[("", _("Internal, then external")), ("free", _("Only free")), ("free_pay", _("External free, then paid")), ("pay", _("External paid"))])
+# config.plugins.iptvplayer.captcha_bypass_free = ConfigSelection(default="", choices=[("", _("None")), ("myjd", "MyJDownloader")])
+# config.plugins.iptvplayer.captcha_bypass_pay = ConfigSelection(default="", choices=[("", _("None")), ("2captcha.com", "2captcha.com"), ("9kw.eu", "9kw.eu")])
+config.plugins.iptvplayer.captcha_bypass = ConfigSelection(default="", choices=[("", _("Auto")), ("mye2i", "MyE2i"), ("2captcha.com", "2captcha.com"), ("9kw.eu", "9kw.eu")])
+
+config.plugins.iptvplayer.api_key_9kweu = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.api_key_2captcha = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.myjd_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.myjd_password = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.myjd_jdname = ConfigText(default="", fixed_size=False)
+
+config.plugins.iptvplayer.api_key_youtube = ConfigText(default="", fixed_size=False)
+
+# Hosts lists
+config.plugins.iptvplayer.fakeHostsList = ConfigSelection(default="fake", choices=[("fake", "  ")])
+
+
+# External movie player settings
+config.plugins.iptvplayer.fakExtMoviePlayerList = ConfigSelection(default="fake", choices=[("fake", "  ")])
+
+# hidden options
+# config.plugins.iptvplayer.hiddenAllVersionInUpdate = ConfigYesNo(default=False)
+config.plugins.iptvplayer.hidden_ext_player_def_aspect_ratio = ConfigSelection(default="-1", choices=[("-1", _("default")), ("0", _("4:3 Letterbox")), ("1", _("4:3 PanScan")), ("2", _("16:9")), ("3", _("16:9 always")), ("4", _("16:10 Letterbox")), ("5", _("16:10 PanScan")), ("6", _("16:9 Letterbox"))])
+
+config.plugins.iptvplayer.search_history_size = ConfigInteger(50, (0, 1000000))
+config.plugins.iptvplayer.enableT9MainList = ConfigYesNo(default=True)
+config.plugins.iptvplayer.rememberHistorySelection = ConfigYesNo(default=True)
+config.plugins.iptvplayer.autoplay_start_delay = ConfigInteger(3, (0, 9))
+
+config.plugins.iptvplayer.favourites_use_watched_flag = ConfigYesNo(default=True)
+config.plugins.iptvplayer.watched_item_color = ConfigSelection(default="#808080", choices=COLORS_DEFINITONS)
+config.plugins.iptvplayer.started_item_color = ConfigSelection(default="#FFFF00", choices=COLORS_DEFINITONS)
+config.plugins.iptvplayer.sidecar_enabled = ConfigYesNo(default=True)
+
+
+def IsSidecarEnabled():
+    # single central place hosts ask whether to create sidecar .txt/.jpg files,
+    # instead of each host keeping its own copy of this config option
+    return config.plugins.iptvplayer.sidecar_enabled.value
+
+
+config.plugins.iptvplayer.usepycurl = ConfigYesNo(default=False)
+
+config.plugins.iptvplayer.prefer_hlsdl_for_pls_with_alt_media = ConfigYesNo(default=True)
+
+###################################################
+
+config.plugins.iptvplayer.extplayer_summary = ConfigSelection(default="yes", choices=[('auto', _('Auto')), ('yes', _('Yes')), ('no', _('No'))])
+config.plugins.iptvplayer.use_clear_iframe = ConfigYesNo(default=False)
+config.plugins.iptvplayer.show_iframe = ConfigYesNo(default=True)
+config.plugins.iptvplayer.iframe_file = ConfigIPTVFileSelection(fileMatch=r"^.*\.mvi$", default="/usr/share/enigma2/radio.mvi")
+config.plugins.iptvplayer.clear_iframe_file = ConfigIPTVFileSelection(fileMatch=r"^.*\.mvi$", default="/usr/share/enigma2/black.mvi")
+
+config.plugins.iptvplayer.remember_last_position = ConfigYesNo(default=False)
+config.plugins.iptvplayer.remember_last_position_time = ConfigInteger(0, (0, 99))
+config.plugins.iptvplayer.fakeExtePlayer3 = ConfigSelection(default="fake", choices=[("fake", " ")])
+config.plugins.iptvplayer.rambuffer_sizemb_network_proto = ConfigInteger(0, (0, 999))
+config.plugins.iptvplayer.rambuffer_sizemb_files = ConfigInteger(0, (0, 999))
+config.plugins.iptvplayer.aac_software_decode = ConfigYesNo(default=False)
+config.plugins.iptvplayer.ac3_software_decode = ConfigYesNo(default=False)
+config.plugins.iptvplayer.eac3_software_decode = ConfigYesNo(default=False)
+config.plugins.iptvplayer.dts_software_decode = ConfigYesNo(default=False)
+config.plugins.iptvplayer.wma_software_decode = ConfigYesNo(default=True)
+config.plugins.iptvplayer.mp3_software_decode = ConfigYesNo(default=False)
+config.plugins.iptvplayer.stereo_software_decode = ConfigYesNo(default=False)
+config.plugins.iptvplayer.software_decode_as = ConfigSelection(default="pcm", choices=[("pcm", "PCM"), ("lpcm", "LPCM")])
+config.plugins.iptvplayer.aac_mix = ConfigSelection(default=None, choices=[(None, _("from E2 settings"))])
+config.plugins.iptvplayer.ac3_mix = ConfigSelection(default=None, choices=[(None, _("from E2 settings"))])
+
+config.plugins.iptvplayer.extplayer_infobar_timeout = ConfigSelection(default="5", choices=[
+    ("1", "1 " + _("second")), ("2", "2 " + _("seconds")), ("3", "3 " + _("seconds")),
+    ("4", "4 " + _("seconds")), ("5", "5 " + _("seconds")), ("6", "6 " + _("seconds")), ("7", "7 " + _("seconds")),
+    ("8", "8 " + _("seconds")), ("9", "9 " + _("seconds")), ("10", "10 " + _("seconds"))
+])
+config.plugins.iptvplayer.extplayer_aspect = ConfigSelection(default=None, choices=[(None, _("from E2 settings"))])
+config.plugins.iptvplayer.extplayer_policy = ConfigSelection(default=None, choices=[(None, _("from E2 settings"))])
+config.plugins.iptvplayer.extplayer_policy2 = ConfigSelection(default=None, choices=[(None, _("from E2 settings"))])
+
+config.plugins.iptvplayer.extplayer_subtitle_auto_enable = ConfigYesNo(default=True)
+config.plugins.iptvplayer.extplayer_subtitle_font = ConfigSelection(default="Regular", choices=[("Regular", "Regular")])
+config.plugins.iptvplayer.extplayer_subtitle_font_size = ConfigInteger(40, (20, 90))
+config.plugins.iptvplayer.extplayer_subtitle_font_color = ConfigSelection(default="#FFFFFF", choices=COLORS_DEFINITONS)
+config.plugins.iptvplayer.extplayer_subtitle_wrapping_enabled = ConfigYesNo(default=False)
+config.plugins.iptvplayer.extplayer_subtitle_line_height = ConfigInteger(40, (20, 999))
+config.plugins.iptvplayer.extplayer_subtitle_line_spacing = ConfigInteger(4, (0, 99))
+config.plugins.iptvplayer.extplayer_subtitle_background = ConfigSelection(default="#000000", choices=[('transparent', _('Transparent')), ('#000000', _('Black')), ('#80000000', _('Darkgray')), ('#cc000000', _('Lightgray'))])
+
+config.plugins.iptvplayer.extplayer_subtitle_border_color = ConfigSelection(default="#000000", choices=COLORS_DEFINITONS)
+config.plugins.iptvplayer.extplayer_subtitle_shadow_color = ConfigSelection(default="#000000", choices=COLORS_DEFINITONS)
+
+config.plugins.iptvplayer.extplayer_subtitle_border_enabled = ConfigYesNo(default=True)
+config.plugins.iptvplayer.extplayer_subtitle_shadow_enabled = ConfigYesNo(default=False)
+
+config.plugins.iptvplayer.extplayer_subtitle_border_width = ConfigInteger(3, (1, 6))
+config.plugins.iptvplayer.extplayer_subtitle_shadow_xoffset = ConfigInteger(3, (-6, 6))
+config.plugins.iptvplayer.extplayer_subtitle_shadow_yoffset = ConfigInteger(3, (-6, 6))
+config.plugins.iptvplayer.extplayer_subtitle_pos = ConfigInteger(50, (0, 400))
+config.plugins.iptvplayer.extplayer_subtitle_box_valign = ConfigSelection(default="bottom", choices=[("bottom", _("bottom")), ("center", _("center")), ("top", _("top"))])
+config.plugins.iptvplayer.extplayer_subtitle_box_height = ConfigInteger(240, (50, 400))
+
+config.plugins.iptvplayer.extplayer_infobanner_clockformat = ConfigSelection(default="", choices=[("", _("None")), ("24", _("24 hour format")), ("12", _("12 hour format"))])
+
+config.plugins.iptvplayer.GSTplayer_no_IFD = ConfigYesNo(default=False)
+config.plugins.iptvplayer.extplayer_skin = ConfigSelection(default="default", choices=[("default", _("default")), ("black", _("black")), ("red", _("red")), ("blue", _("blue")), ("green", _("green")), ("black-white", _("black&white")), ("cobalt", _("cobalt")), ("jersey", _("jersey")), ("navy", _("navy")), ("line", _("line"))])
+
+
+########################################################
+# Generate list of hosts options for Enabling/Disabling
+########################################################
+
+class ConfigIPTVHostOnOff(ConfigOnOff):
+    def __init__(self, default=False):
+        ConfigOnOff.__init__(self, default=default)
+
+
+gListOfHostsNames = GetHostsList()
+for hostName in gListOfHostsNames:
+    try:
+        # as default all hosts are enabled
+        enabledByDefault = hostName not in ['ipla']
+        setattr(config.plugins.iptvplayer, 'host' + hostName, ConfigIPTVHostOnOff(default=enabledByDefault))
+    except Exception:
+        printExc(hostName)
+
+
+def GetListOfHostsNames():
+    global gListOfHostsNames
+    return gListOfHostsNames
+
+
+###################################################
+
+
+def GetOskOwnModelConfigList(indent=True):
+    # the "Own model" keyboard's own options - shared by ConfigMenu's
+    # "Grundkonfiguration" section (indented, nested under "Virtual Keyboard
+    # type") and E2iVKQuickSettings (the keyboard's own MENU -> Settings
+    # screen, shown standalone since that screen only exists while the "own"
+    # model is already active) so both stay in sync
+    #
+    # The indent is purely presentational, so it's applied to the already-
+    # translated result instead of being baked into the msgid - that used to
+    # be the case (msgid "    Show suggestions") and every .po's msgstr had
+    # the same 4 spaces baked in too, so this only works untranslated for
+    # E2iVKQuickSettings (indent=False) before now. Migrated all 12 locales'
+    # existing translations onto the unindented msgid instead of leaving
+    # them stuck on a dead, presentation-specific key.
+    prefix = '    ' if indent else ''
+    list = []
+    list.append(getConfigListEntry(prefix + _("Background color"), config.plugins.iptvplayer.osk_background_color))
+    list.append(getConfigListEntry(prefix + _("Show suggestions"), config.plugins.iptvplayer.osk_allow_suggestions))
+    list.append(getConfigListEntry(prefix + _("Default suggestions provider"), config.plugins.iptvplayer.osk_default_suggestions))
+    list.append(getConfigListEntry(prefix + _("Allow host to override suggestions provider"), config.plugins.iptvplayer.osk_allow_host_suggestions))
+    list.append(getConfigListEntry(prefix + _("Show search history"), config.plugins.iptvplayer.osk_allow_search_history))
+    list.append(getConfigListEntry(prefix + _("Show flags"), config.plugins.iptvplayer.osk_show_flags))
+    list.append(getConfigListEntry(prefix + _("Font size offset"), config.plugins.iptvplayer.osk_font_size_offset))
+    list.append(getConfigListEntry(prefix + _("Text field alignment"), config.plugins.iptvplayer.osk_searchfield_align))
+    return list
+
+
+def GetOskConfigList():
+    list = []
+    list.append(getConfigListEntry(_("Virtual Keyboard type"), config.plugins.iptvplayer.osk_type))
+    list.append(getConfigListEntry(_("Remember last search entry"), config.plugins.iptvplayer.osk_remember_last_search))
+    if config.plugins.iptvplayer.osk_type.value == 'own':
+        list.extend(GetOskOwnModelConfigList(indent=True))
+    return list
+
+
+class E2iVKQuickSettings(ConfigBaseWidget):
+    def __init__(self, session):
+        self.list = []
+        ConfigBaseWidget.__init__(self, session)
+
+    def layoutFinished(self):
+        ConfigBaseWidget.layoutFinished(self)
+        self.setTitle(_("E2iPlayer - keyboard settings"))
+
+    def runSetup(self):
+        self.list = GetOskOwnModelConfigList(indent=False)
+        ConfigBaseWidget.runSetup(self)
+
+    def getSubOptionsList(self):
+        return []
+
+    def keyDefaults(self):
+        # ConfigBaseWidget's own keyDefaults() is a no-op stub; ConfigMenu
+        # overrides it for the full settings list, this does the same but
+        # scoped to just the keyboard options shown here.
+        def keyDefaultsConfirm(result):
+            if result:
+                for item in self.list:
+                    if len(item) > 1:
+                        configItem = item[1]
+                        if not isinstance(configItem, ConfigText):
+                            configItem.value = configItem.default
+                self.close()
+        message = _("Are you sure you want to reset all settings to their default values?")
+        self.session.openWithCallback(keyDefaultsConfirm, MessageBox, text=message, type=MessageBox.TYPE_YESNO)
+
+
+class ConfigMenu(ConfigBaseWidget):
+
+    def __init__(self, session):
+        printDBG("ConfigMenu.__init__ -------------------------------")
+        self.list = []
+        ConfigBaseWidget.__init__(self, session)
+        # remember old
+        self.showcoverOld = config.plugins.iptvplayer.showcover.value
+        self.SciezkaCacheOld = config.plugins.iptvplayer.SciezkaCache.value
+        self.remove_diabled_hostsOld = config.plugins.iptvplayer.remove_diabled_hosts.value
+        self.enabledHostsListOld = GetEnabledHostsList()
+        self.runtimeOptionsValues = self.getRuntimeOptionsValues()
+
+    def __del__(self):
+        printDBG("ConfigMenu.__del__ -------------------------------")
+
+    def __onClose(self):
+        printDBG("ConfigMenu.__onClose -----------------------------")
+        ConfigBaseWidget.__onClose(self)
+
+    def layoutFinished(self):
+        ConfigBaseWidget.layoutFinished(self)
+        self.setTitle(_("E2iPlayer - settings"))
+
+    @staticmethod
+    def fillConfigList(list,):
+        list.append(getConfigListEntry(_("----- BASIC CONFIGURATION -----"),))
+        list.extend(GetOskConfigList())
+        list.append(getConfigListEntry(_("Initialize web interface"), config.plugins.iptvplayer.IPTVWebIterface))
+        list.append(getConfigListEntry(_("Show IPTVPlayer in extension list"), config.plugins.iptvplayer.showinextensions))
+        list.append(getConfigListEntry(_("Show IPTVPlayer in main menu"), config.plugins.iptvplayer.showinMainMenu))
+        list.append(getConfigListEntry(_("E2iPlayer auto start at Enigma2 start"), config.plugins.iptvplayer.plugin_autostart))
+        if config.plugins.iptvplayer.plugin_autostart.value:
+            list.append(getConfigListEntry(_("Auto start method"), config.plugins.iptvplayer.plugin_autostart_method))
+        list.append(getConfigListEntry(_("Disable live at plugin start"), config.plugins.iptvplayer.disable_live))
+        list.append(getConfigListEntry(_("Use the PyCurl for HTTP(S) requests"), config.plugins.iptvplayer.usepycurl))
+        list.append(getConfigListEntry(_("https - validate SSL certificates"), config.plugins.iptvplayer.httpssslcertvalidation))
+        list.append(getConfigListEntry(_("----- SERVICE CONFIGURATION -----"),))
+        list.append(getConfigListEntry(_("Services configuration"), config.plugins.iptvplayer.fakeHostsList))
+        list.append(getConfigListEntry(_("Remove disabled services"), config.plugins.iptvplayer.remove_diabled_hosts))
+        list.append(getConfigListEntry(_("Allow watched flag to be set"), config.plugins.iptvplayer.favourites_use_watched_flag))
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+            list.append(getConfigListEntry("    " + _("The color of the viewed item"), config.plugins.iptvplayer.watched_item_color))
+            list.append(getConfigListEntry("    " + _("The color of the started item"), config.plugins.iptvplayer.started_item_color))
+        list.append(getConfigListEntry(_("Create sidecar files (.txt/.jpg)"), config.plugins.iptvplayer.sidecar_enabled))
+        list.append(getConfigListEntry(_("----- SECURITY CONFIGURATION -----"),))
+        list.append(getConfigListEntry(_("Pin protection for plugin"), config.plugins.iptvplayer.pluginProtectedByPin))
+        list.append(getConfigListEntry(_("Pin protection for configuration"), config.plugins.iptvplayer.configProtectedByPin))
+        if config.plugins.iptvplayer.pluginProtectedByPin.value or config.plugins.iptvplayer.configProtectedByPin.value:
+            list.append(getConfigListEntry(_("Set pin code"), config.plugins.iptvplayer.fakePin))
+
+        list.append(getConfigListEntry(_("----- SKIN CONFIGURATION -----"),))
+        list.append(getConfigListEntry(_("Skin"), config.plugins.iptvplayer.skin))
+        list.append(getConfigListEntry(_("Force internal Skin"), config.plugins.iptvplayer.skinforceinternal))
+        list.append(getConfigListEntry(_("Use colors"), config.plugins.iptvplayer.use_colors))
+        list.append(getConfigListEntry(_("Info bar clock format"), config.plugins.iptvplayer.extplayer_infobanner_clockformat))
+        list.append(getConfigListEntry(_("Player Skin"), config.plugins.iptvplayer.extplayer_skin))
+        list.append(getConfigListEntry(_("Display thumbnails"), config.plugins.iptvplayer.showcover))
+        if config.plugins.iptvplayer.showcover.value:
+            # list.append(getConfigListEntry(_("    Allowed formats of thumbnails"), config.plugins.iptvplayer.allowedcoverformats))
+            list.append(getConfigListEntry("    " + _("Remove thumbnails"), config.plugins.iptvplayer.deleteIcons))
+        # list.append(getConfigListEntry("Sort the lists?", config.plugins.iptvplayer.sortuj))
+        # list.append(getConfigListEntry(_("Graphic services selector"), config.plugins.iptvplayer.ListaGraficzna))
+        # if config.plugins.iptvplayer.ListaGraficzna.value is True:
+        list.append(getConfigListEntry(_("Hosts list type"), config.plugins.iptvplayer.hostsListType))
+        list.append(getConfigListEntry("    " + _("Enable hosts groups"), config.plugins.iptvplayer.group_hosts))
+        if config.plugins.iptvplayer.hostsListType.value == "G":
+            list.append(getConfigListEntry("    " + _("Service icon size"), config.plugins.iptvplayer.IconsSize))
+        if not GRIDSUPPORT and config.plugins.iptvplayer.hostsListType.value == "G":
+            list.append(getConfigListEntry("    " + _("Number of rows"), config.plugins.iptvplayer.numOfRow))
+            list.append(getConfigListEntry("    " + _("Number of columns"), config.plugins.iptvplayer.numOfCol))
+        # list.append(getConfigListEntry(_("VFD set current title:"), config.plugins.iptvplayer.set_curr_title))
+        list.append(getConfigListEntry(_("Create LCD/VFD summary screen"), config.plugins.iptvplayer.extplayer_summary))
+
+        list.append(getConfigListEntry(_("----- PROXIES CONFIGURATION -----"),))
+        list.append(getConfigListEntry(_("Alternative proxy server (1)"), config.plugins.iptvplayer.alternative_proxy1))
+        list.append(getConfigListEntry(_("Alternative proxy server (2)"), config.plugins.iptvplayer.alternative_proxy2))
+        list.append(getConfigListEntry(_("Polish proxy server url"), config.plugins.iptvplayer.proxyurl))
+        list.append(getConfigListEntry(_("German proxy server url"), config.plugins.iptvplayer.german_proxyurl))
+        list.append(getConfigListEntry(_("Russian proxy server url"), config.plugins.iptvplayer.russian_proxyurl))
+        list.append(getConfigListEntry(_("Ukrainian proxy server url"), config.plugins.iptvplayer.ukrainian_proxyurl))
+
+        list.append(getConfigListEntry(_("----- STORAGE CONFIGURATION -----"),))
+        list.append(getConfigListEntry(_("Folder for cache data"), config.plugins.iptvplayer.SciezkaCache))
+        list.append(getConfigListEntry(_("Folder for temporary data"), config.plugins.iptvplayer.NaszaTMP))
+
+        list.append(getConfigListEntry(_("----- BUFFERING CONFIGURATION -----"), ))
+        list.append(getConfigListEntry(_("[HTTP] buffering"), config.plugins.iptvplayer.buforowanie))
+        list.append(getConfigListEntry(_("[HLS/M3U8] buffering"), config.plugins.iptvplayer.buforowanie_m3u8))
+        list.append(getConfigListEntry(_("[RTMP] buffering (rtmpdump required)"), config.plugins.iptvplayer.buforowanie_rtmp))
+        if config.plugins.iptvplayer.buforowanie.value or config.plugins.iptvplayer.buforowanie_m3u8.value or config.plugins.iptvplayer.buforowanie_rtmp.value:
+            list.append(getConfigListEntry("    " + _("Video buffer size [MB]"), config.plugins.iptvplayer.requestedBuffSize))
+            list.append(getConfigListEntry("    " + _("Audio buffer size [KB]"), config.plugins.iptvplayer.requestedAudioBuffSize))
+            list.append(getConfigListEntry(_("Buffering location"), config.plugins.iptvplayer.bufferingPath))
+
+        list.append(getConfigListEntry(_("----- DOWNLOADING CONFIGURATION -----"), ))
+        list.append(getConfigListEntry(_("Downloads location"), config.plugins.iptvplayer.NaszaSciezka))
+        list.append(getConfigListEntry(_("Start download manager per default"), config.plugins.iptvplayer.IPTVDMRunAtStart))
+        list.append(getConfigListEntry(_("Show download manager after adding new item"), config.plugins.iptvplayer.IPTVDMShowAfterAdd))
+        list.append(getConfigListEntry(_("Number of downloaded files simultaneously"), config.plugins.iptvplayer.IPTVDMMaxDownloadItem))
+        list.append(getConfigListEntry(_("%s e-mail") % ('My JDownloader'), config.plugins.iptvplayer.myjd_login))
+        list.append(getConfigListEntry(_("%s password") % ('My JDownloader'), config.plugins.iptvplayer.myjd_password))
+        list.append(getConfigListEntry(_("%s device name") % ('My JDownloader'), config.plugins.iptvplayer.myjd_jdname))
+        list.append(getConfigListEntry(_("%s API KEY") % 'http://youtube.com/', config.plugins.iptvplayer.api_key_youtube))
+
+        list.append(getConfigListEntry(_("----- CAPTCHA CONFIGURATION -----"), ))
+        list.append(getConfigListEntry(_("Default captcha bypass"), config.plugins.iptvplayer.captcha_bypass))
+        # list.append(getConfigListEntry(_("Captcha solver order"), config.plugins.iptvplayer.captcha_bypass_order))
+        # list.append(getConfigListEntry(_("Captcha bypass free service"), config.plugins.iptvplayer.captcha_bypass_free))
+        # list.append(getConfigListEntry(_("Captcha bypass paid service"), config.plugins.iptvplayer.captcha_bypass_pay))
+        # if config.plugins.iptvplayer.captcha_bypass_pay.value == "9kw.eu":
+        list.append(getConfigListEntry(_("%s API KEY") % 'https://9kw.eu/', config.plugins.iptvplayer.api_key_9kweu))
+        # if config.plugins.iptvplayer.captcha_bypass_pay.value == "2captcha.com":
+        list.append(getConfigListEntry(_("%s API KEY") % 'http://2captcha.com/', config.plugins.iptvplayer.api_key_2captcha))
+
+        list.append(getConfigListEntry(_("----- SUBTITLES CONFIGURATION -----"), ))
+        list.append(getConfigListEntry(_("Use subtitles parser extension if available"), config.plugins.iptvplayer.useSubtitlesParserExtension))
+        list.append(getConfigListEntry("https://subsource.net/ " + _("API_KEY"), config.plugins.iptvplayer.subsourceapi))
+        list.append(getConfigListEntry("https://subdl.com/ " + _("API Key"), config.plugins.iptvplayer.subdlapi))
+        list.append(getConfigListEntry("http://opensubtitles.org/ " + _("login"), config.plugins.iptvplayer.opensuborg_login))
+        list.append(getConfigListEntry("http://opensubtitles.org/ " + _("password"), config.plugins.iptvplayer.opensuborg_password))
+        list.append(getConfigListEntry("http://napisy24.pl/ " + _("login"), config.plugins.iptvplayer.napisy24pl_login))
+        list.append(getConfigListEntry("http://napisy24.pl/ " + _("password"), config.plugins.iptvplayer.napisy24pl_password))
+        list.append(getConfigListEntry("http://vk.com/ " + _("login"), config.plugins.iptvplayer.vkcom_login))
+        list.append(getConfigListEntry("http://vk.com/ " + _("password"), config.plugins.iptvplayer.vkcom_password))
+        list.append(getConfigListEntry("http://1fichier.com/ " + _("e-mail"), config.plugins.iptvplayer.fichiercom_login))
+        list.append(getConfigListEntry("http://1fichier.com/ " + _("password"), config.plugins.iptvplayer.fichiercom_password))
+
+        list.append(getConfigListEntry(_("----- PLAYERS & PLAYBACK CONFIGURATION -----"), ))
+        list.append(getConfigListEntry(_("Autoplay start delay"), config.plugins.iptvplayer.autoplay_start_delay))
+        list.append(getConfigListEntry(_("Block wmv files"), config.plugins.iptvplayer.ZablokujWMV))
+        players = []
+        list.append(getConfigListEntry(_("Movie player selection list"), config.plugins.iptvplayer.moviePlayerPickerMode))
+        list.append(getConfigListEntry(_("First movie player without buffering mode"), config.plugins.iptvplayer.defaultMoviePlayer0))
+        players.append(config.plugins.iptvplayer.defaultMoviePlayer0)
+        list.append(getConfigListEntry(_("Second movie player without buffering mode"), config.plugins.iptvplayer.alternativeMoviePlayer0))
+        players.append(config.plugins.iptvplayer.alternativeMoviePlayer0)
+        list.append(getConfigListEntry(_("First movie player in buffering mode"), config.plugins.iptvplayer.defaultMoviePlayer))
+        players.append(config.plugins.iptvplayer.defaultMoviePlayer)
+        list.append(getConfigListEntry(_("Second movie player in buffering mode"), config.plugins.iptvplayer.alternativeMoviePlayer))
+        players.append(config.plugins.iptvplayer.alternativeMoviePlayer)
+        playersValues = [player.value for player in players]
+        if 'exteplayer' in playersValues or 'extgstplayer' in playersValues or 'auto' in playersValues:
+            list.append(getConfigListEntry(_("External movie player config"), config.plugins.iptvplayer.fakExtMoviePlayerList))
+        list.append(getConfigListEntry(_("The default aspect ratio for the external player"), config.plugins.iptvplayer.hidden_ext_player_def_aspect_ratio))
+
+        list.append(getConfigListEntry(_("----- OTHER SETTINGS -----"), ))
+        list.append(getConfigListEntry(_("The number of items in the search history"), config.plugins.iptvplayer.search_history_size))
+        list.append(getConfigListEntry(_("Remember last search history selection"), config.plugins.iptvplayer.rememberHistorySelection))
+        list.append(getConfigListEntry(_("T9 letter jump in lists"), config.plugins.iptvplayer.enableT9MainList))
+        list.append(getConfigListEntry(_("Write current title to file:"), config.plugins.iptvplayer.curr_title_file))
+        list.append(getConfigListEntry(_("MIPS Floating Point Architecture"), config.plugins.iptvplayer.plarformfpuabi))
+        list.append(getConfigListEntry(_("Prefer hlsld for playlist with alt. media"), config.plugins.iptvplayer.prefer_hlsdl_for_pls_with_alt_media))
+        list.append(getConfigListEntry(_("Debug logs"), config.plugins.iptvplayer.debugprint))
+
+    def runSetup(self):
+        self.list = []
+        ConfigMenu.fillConfigList(self.list)
+        ConfigBaseWidget.runSetup(self)
+
+    def onSelectionChanged(self):
+        currItem = self["config"].getCurrent()[1]
+        if currItem in [config.plugins.iptvplayer.fakePin, config.plugins.iptvplayer.fakeHostsList, config.plugins.iptvplayer.fakExtMoviePlayerList]:
+            self.isOkEnabled = True
+            self.isSelectable = False
+            self.setOKLabel()
+        else:
+            ConfigBaseWidget.onSelectionChanged(self)
+
+    """
+    def saveAndClose(self):
+        ConfigBaseWidget.saveAndClose(self)
+        if self.showcoverOld != config.plugins.iptvplayer.showcover.value or \
+            self.SciezkaCacheOld != config.plugins.iptvplayer.SciezkaCache.value:
+            pass
+            # plugin must be restarted if we wont to this options take effect
+    """
+
+    def getRuntimeOptionsValues(self):
+        valTab = []
+        valTab.append(config.plugins.iptvplayer.IPTVWebIterface.value)
+        valTab.append(config.plugins.iptvplayer.showinextensions.value)
+        valTab.append(config.plugins.iptvplayer.showinMainMenu.value)
+        valTab.append(config.plugins.iptvplayer.plugin_autostart.value)
+        valTab.append(config.plugins.iptvplayer.plugin_autostart_method.value)
+        valTab.append(config.plugins.iptvplayer.disable_live.value)
+        valTab.append(config.plugins.iptvplayer.pluginProtectedByPin.value)
+        valTab.append(config.plugins.iptvplayer.skin.value)
+        valTab.append(config.plugins.iptvplayer.skinforceinternal.value)
+        return valTab
+
+    def getMessageAfterSave(self):
+        if self.runtimeOptionsValues != self.getRuntimeOptionsValues():
+            return _('Some settings will be applied only after GUI restart.')
+        else:
+            return ''
+
+    def getMessageBeforeClose(self, afterSave):
+        return ''
+
+    def closeAfterMessage(self, arg=None):
+        self.close()
+        """
+        if arg:
+            # self.doUpdate(True)
+            self.close()
+        else:
+            self.close()
+        """
+
+    def keyOK(self):
+        curIndex = self["config"].getCurrentIndex()
+        currItem = self["config"].list[curIndex][1]
+        if isinstance(currItem, ConfigDirectory):
+            def SetDirPathCallBack(curIndex, newPath):
+                if None is not newPath:
+                    self["config"].list[curIndex][1].value = newPath
+            self.session.openWithCallback(boundFunction(SetDirPathCallBack, curIndex), IPTVDirectorySelectorWidget, currDir=currItem.value, title=_("Select directory"))
+        elif config.plugins.iptvplayer.fakePin == currItem:
+            self.changePin(start=True)
+        elif config.plugins.iptvplayer.fakeHostsList == currItem:
+            self.hostsList()
+        elif config.plugins.iptvplayer.fakExtMoviePlayerList == currItem:
+            self.extMoviePlayerList()
+        else:
+            ConfigBaseWidget.keyOK(self)
+
+    def keyDefaults(self):
+        def keyDefaultsConfirm(result):
+            if result:
+                for item in self.list:
+                    if len(item) > 1:
+                        configItem = item[1]
+                        if not isinstance(configItem, ConfigText):
+                            configItem.value = configItem.default
+                self.close()
+        message = _("Are you sure you want to reset all settings to their default values?")
+        self.session.openWithCallback(keyDefaultsConfirm, MessageBox, text=message, type=MessageBox.TYPE_YESNO)
+
+    def getSubOptionsList(self):
+        tab = [
+            config.plugins.iptvplayer.buforowanie,
+            config.plugins.iptvplayer.buforowanie_m3u8,
+            config.plugins.iptvplayer.buforowanie_rtmp,
+            config.plugins.iptvplayer.showcover,
+            # config.plugins.iptvplayer.ListaGraficzna,
+            config.plugins.iptvplayer.pluginProtectedByPin,
+            config.plugins.iptvplayer.configProtectedByPin,
+            config.plugins.iptvplayer.osk_type,
+            config.plugins.iptvplayer.plugin_autostart,
+            config.plugins.iptvplayer.favourites_use_watched_flag,
+            config.plugins.iptvplayer.hostsListType
+            # config.plugins.iptvplayer.captcha_bypass_free,
+            # config.plugins.iptvplayer.captcha_bypass_pay
+        ]
+        players = []
+        players.append(config.plugins.iptvplayer.defaultMoviePlayer0)
+        players.append(config.plugins.iptvplayer.alternativeMoviePlayer0)
+        players.append(config.plugins.iptvplayer.defaultMoviePlayer)
+        players.append(config.plugins.iptvplayer.alternativeMoviePlayer)
+        tab.extend(players)
+        return tab
+
+    def changePin(self, pin=None, start=False):
+        # 'PUT_OLD_PIN', 'PUT_NEW_PIN', 'CONFIRM_NEW_PIN'
+        if True is start:
+            self.changingPinState = 'PUT_OLD_PIN'
+            self.session.openWithCallback(self.changePin, IPTVPinWidget, title=_("Enter old pin"))
+        else:
+            if pin is None:
+                return
+            if 'PUT_OLD_PIN' == self.changingPinState:
+                if pin == config.plugins.iptvplayer.pin.value:
+                    self.changingPinState = 'PUT_NEW_PIN'
+                    self.session.openWithCallback(self.changePin, IPTVPinWidget, title=_("Enter new pin"))
+                else:
+                    self.session.open(MessageBox, _("Pin incorrect!"), type=MessageBox.TYPE_INFO, timeout=5)
+            elif 'PUT_NEW_PIN' == self.changingPinState:
+                self.newPin = pin
+                self.changingPinState = 'CONFIRM_NEW_PIN'
+                self.session.openWithCallback(self.changePin, IPTVPinWidget, title=_("Confirm new pin"))
+            elif 'CONFIRM_NEW_PIN' == self.changingPinState:
+                if self.newPin == pin:
+                    config.plugins.iptvplayer.pin.value = pin
+                    config.plugins.iptvplayer.pin.save()
+                    configfile.save()
+                    self.session.open(MessageBox, _("Pin has been changed."), type=MessageBox.TYPE_INFO, timeout=5)
+                else:
+                    self.session.open(MessageBox, _("Confirmation error."), type=MessageBox.TYPE_INFO, timeout=5)
+
+    def hostsList(self):
+        self.session.open(ConfigHostsMenu, GetListOfHostsNames())
+
+    def extMoviePlayerList(self):
+        self.session.open(ConfigExtMoviePlayer)
+
+
+def GetAvailableMoviePlayers():
+    # 'mini'/'standard' are always available (built in); the external ones
+    # only when their binary is actually present. Shared by GetMoviePlayer()
+    # (default/alternative slot resolution) and the "Select movie player"
+    # blue-key menu (lists every one of these directly, not just the two
+    # configured slots)
+    availablePlayers = []
+    if IsExecutable("/usr/bin/exteplayer3"):  # config.plugins.iptvplayer.exteplayer3path.value):
+        availablePlayers.append('exteplayer')
+    if IsExecutable('/usr/bin/gstplayer'):
+        availablePlayers.append('extgstplayer')
+    availablePlayers.append('mini')
+    availablePlayers.append('standard')
+    return availablePlayers
+
+
+def GetMoviePlayer(buffering=False, useAlternativePlayer=False):
+    printDBG("GetMoviePlayer buffering[%r], useAlternativePlayer[%r]" % (buffering, useAlternativePlayer))
+    # select movie player
+    availablePlayers = GetAvailableMoviePlayers()
+
+    player = None
+    alternativePlayer = None
+
+    if buffering:
+        player = config.plugins.iptvplayer.defaultMoviePlayer
+        alternativePlayer = config.plugins.iptvplayer.alternativeMoviePlayer
+    else:
+        player = config.plugins.iptvplayer.defaultMoviePlayer0
+        alternativePlayer = config.plugins.iptvplayer.alternativeMoviePlayer0
+
+    if player.value == 'auto':
+        player = CFakeMoviePlayerOption(availablePlayers[0], GetMoviePlayerName(availablePlayers[0]))
+    try:
+        availablePlayers.remove(player.value)
+    except Exception:
+        printExc()
+
+    if alternativePlayer.value == 'auto':
+        alternativePlayer = CFakeMoviePlayerOption(availablePlayers[0], GetMoviePlayerName(availablePlayers[0]))
+    try:
+        availablePlayers.remove(alternativePlayer.value)
+    except Exception:
+        printExc()
+
+    if useAlternativePlayer:
+        return alternativePlayer
+
+    return player

--- a/components/iptvfavouriteswidgets.py
+++ b/components/iptvfavouriteswidgets.py
@@ -1,0 +1,702 @@
+# -*- coding: utf-8 -*-
+# Last Modified: 2026-07-26 - Added blue key "Edit" option in favourites manager. - Kamikaze24
+########################################################
+# 29.07.2026 - HD Skin - WQHD Skin added by @stein17
+########################################################
+# LOCAL import
+###################################################
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, IsValidFileName, GetFavouritesDir, GetIconDir, findT9JumpIndex
+from Plugins.Extensions.IPTVPlayer.tools.iptvfavourites import IPTVFavourites
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
+from Plugins.Extensions.IPTVPlayer.components.ihost import CDisplayListItem
+from Plugins.Extensions.IPTVPlayer.components.iptvmultipleinputbox import IPTVMultipleInputBox
+from Plugins.Extensions.IPTVPlayer.components.iptvlist import IPTVMainNavigatorList
+###################################################
+
+###################################################
+# FOREIGN import
+###################################################
+from enigma import getDesktop, gRGB
+from Screens.Screen import Screen
+from Screens.MessageBox import MessageBox
+from Screens.ChoiceBox import ChoiceBox
+from Components.config import config
+from Components.Label import Label
+from Components.ActionMap import ActionMap
+from Tools.NumericalTextInput import NumericalTextInput
+###################################################
+
+
+class IPTVFavouritesAddNewGroupWidget(Screen):
+    def __init__(self, session, favourites):
+        self.session = session
+        Screen.__init__(self, session)
+
+        self.onShown.append(self.onStart)
+        self.favourites = favourites
+        self.started = False
+        self.group = None
+
+    def onStart(self):
+        self.onShown.remove(self.onStart)
+        from copy import deepcopy
+        params = deepcopy(IPTVMultipleInputBox.DEF_PARAMS)
+        params['title'] = _("Add new group of favorites")
+        params['with_accept_button'] = True
+        params['list'] = []
+
+        for input in [[self._validate, _("Name:"), _("Group %d") % (len(self.favourites.getGroups()) + 1), ], [None, _("Description:"), " "]]:
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = input[0]
+            item['title'] = input[1]
+            item['input']['text'] = input[2]
+            params['list'].append(item)
+        self.session.openWithCallback(self.iptvRetCallback, IPTVMultipleInputBox, params)
+
+    def _validate(self, text):
+        if 0 == len(text):
+            return False, _("Name cannot be empty.")
+        elif not IsValidFileName(text):
+            return False, _("Name is not valid.\nPlease remove special characters.")
+        else:
+            group_id = text.lower()
+            idx = self.favourites._getGroupIdx(group_id)
+            if -1 != idx:
+                return False, _("Group \"%s\" already exists.") % group_id
+        return True, ""
+
+    def iptvRetCallback(self, retArg):
+        self.group = None
+        if retArg and 2 == len(retArg):
+            group = {"title": retArg[0], "group_id": retArg[0].lower(), "desc": retArg[1]}
+            result = self.favourites.addGroup(group)
+            if result:
+                self.group = group
+            else:
+                self.session.openWithCallback(self.iptvDoFinish, MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+        self.iptvDoFinish()
+
+    def iptvDoFinish(self, ret=None):
+        self.close(self.group)
+
+
+class IPTVFavouritesAddItemWidget(Screen):
+    def __init__(self, session, favItem, favourites=None, canAddNewGroup=True, ignoredGroups=[]):
+        self.session = session
+        Screen.__init__(self, session)
+
+        self.onShown.append(self.onStart)
+        self.started = False
+        self.result = False
+
+        self.favItem = favItem
+        if None is not favourites:
+            self.saveLoad = False
+        else:
+            self.saveLoad = True
+        self.favourites = favourites
+        self.canAddNewGroup = canAddNewGroup
+        self.ignoredGroups = ignoredGroups
+
+    def onStart(self):
+        self.onShown.remove(self.onStart)
+        if None is self.favourites:
+            self.favourites = IPTVFavourites(GetFavouritesDir())
+            sts = self.favourites.load(groupsOnly=True)
+            if not sts:
+                self.session.openWithCallback(self.iptvDoFinish, MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+        options = []
+        groups = self.favourites.getGroups()
+        for item in groups:
+            if item['group_id'] in self.ignoredGroups:
+                continue
+            options.append((item['title'], item['group_id']))
+        if self.canAddNewGroup:
+            options.append((_("Add new group of favorites"), None))
+        if len(options):
+            self.session.openWithCallback(self.addFavouriteToGroup, ChoiceBox, title=_("Select favorite group"), list=options)
+        else:
+            self.session.openWithCallback(self.iptvDoFinish, MessageBox, _("There are no other favorite groups"), type=MessageBox.TYPE_INFO, timeout=10)
+
+    def addFavouriteToGroup(self, retArg):
+        if retArg and 2 == len(retArg):
+            if None is not retArg[1]:
+                sts = self.favourites.loadGroupItems(retArg[1], force=False)
+                if sts:
+                    sts = self.favourites.addGroupItem(self.favItem, retArg[1])
+                if sts:
+                    sts = self.favourites.saveGroupItems(retArg[1])
+                if sts:
+                    self.result = True
+                    self.iptvDoFinish()
+                    return
+                else:
+                    self.session.openWithCallback(self.iptvDoFinish, MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+            else:  # addn new group
+                self.session.openWithCallback(self.addNewFavouriteGroup, IPTVFavouritesAddNewGroupWidget, self.favourites)
+        else:
+            self.iptvDoFinish()
+
+    def addNewFavouriteGroup(self, group):
+        if None is not group:
+            sts = True
+            if self.saveLoad:
+                sts = self.favourites.save(True)
+            if sts:
+                self.addFavouriteToGroup((group['title'], group['group_id']))
+            else:
+                self.session.openWithCallback(self.iptvDoFinish, MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+        else:
+            self.iptvDoFinish()
+
+    def iptvDoFinish(self, ret=None):
+        self.close(self.result)
+
+
+class IPTVFavouritesMainWidget(Screen):
+    screenwidth = getDesktop(0).size().width()
+
+    if screenwidth >= 2560:
+        # WQHD 2560x1440 - FHD icons are scaled because no WQHD icon set exists.
+        skin = """
+        <screen name="IPTVFavouritesMainWidget" position="center,center" size="2240,1300" title="Favorites manager" backgroundColor="#34111112" flags="wfNoBorder">
+            <widget source="Title" render="Label" position="360,20" size="1570,80" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" transparent="1" zPosition="1" font="Regular;48" valign="center" />
+
+            <widget name="title" position="40,136" size="2160,60" font="Regular;48" halign="left" valign="center" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" zPosition="1" transparent="1" />
+
+            <widget name="list" position="40,220" size="2160,936" itemHeight="72" font="Regular;40" scrollbarMode="showOnDemand" scrollbarSliderBorderWidth="2" scrollbarForegroundColor="#1b5a91" scrollbarBorderColor="#00b6b6b6" enableWrapAround="1" foregroundColor="white" backgroundColor="black" foregroundColorSelected="white" backgroundColorSelected="#1b5a91" borderWidth="2" borderColor="black" transparent="1" />
+
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/red.png" position="280,1230" size="40,40" alphatest="blend" scale="1" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/green.png" position="730,1230" size="40,40" alphatest="blend" scale="1" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/yellow.png" position="1270,1230" size="40,40" alphatest="blend" scale="1" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/blue.png" position="1820,1230" size="40,40" alphatest="blend" scale="1" transparent="1" />
+
+            <widget name="label_red" position="330,1222" size="400,56" zPosition="1" font="Regular;40" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_green" position="780,1222" size="490,56" zPosition="1" font="Regular;40" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_yellow" position="1320,1222" size="490,56" zPosition="1" font="Regular;40" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_blue" position="1870,1222" size="400,56" zPosition="1" font="Regular;40" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+
+            <eLabel name="BG_Title" position="0,0" size="2240,120" backgroundColor="#100d0f16" zPosition="-1" />
+            <eLabel name="BG_Buttons" position="0,1200" size="2240,96" backgroundColor="#100d0f16" zPosition="-1" />
+
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/smallshadowline.png" position="0,120" size="2240,4" scale="1" zPosition="2" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/smallshadowline.png" position="0,1200" size="2240,4" scale="1" zPosition="2" />
+
+            <ePixmap position="40,1224" size="80,52" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/ok.png" transparent="1" scale="1" alphatest="blend" />
+            <ePixmap position="148,1224" size="80,52" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/exit.png" transparent="1" scale="1" alphatest="blend" />
+            <ePixmap name="playerlogo" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/logos/favouriteslogo.png" zPosition="4" position="40,20" size="240,80" scale="1" alphatest="blend" transparent="1" backgroundColor="black" />
+
+            <widget source="global.CurrentTime" render="Label" position="1920,20" size="300,80" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" transparent="1" zPosition="1" font="Regular;48" valign="center" halign="right">
+                <convert type="ClockToText">Format:%H:%M</convert>
+            </widget>
+
+            <widget source="global.CurrentTime" render="Label" position="1440,40" size="600,48" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" transparent="1" zPosition="1" font="Regular;32" valign="center" halign="right">
+                <convert type="ClockToText">Date</convert>
+            </widget>
+        </screen>
+        """
+
+    elif screenwidth >= 1920:
+        # FHD 1920x1080
+        skin = """
+        <screen name="IPTVFavouritesMainWidget" position="center,center" size="1680,975" title="Favorites manager" backgroundColor="#34111112" flags="wfNoBorder">
+            <widget source="Title" render="Label" position="240,15" size="1178,60" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" transparent="1" zPosition="1" font="Regular;36" valign="center" />
+
+            <widget name="title" position="30,102" size="1620,45" font="Regular;36" halign="left" valign="center" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" zPosition="1" transparent="1" />
+
+            <widget name="list" position="30,165" size="1620,702" itemHeight="54" font="Regular;30" scrollbarMode="showOnDemand" scrollbarSliderBorderWidth="1" scrollbarForegroundColor="#1b5a91" scrollbarBorderColor="#00b6b6b6" enableWrapAround="1" foregroundColor="white" backgroundColor="black" foregroundColorSelected="white" backgroundColorSelected="#1b5a91" borderWidth="2" borderColor="black" transparent="1" />
+
+             <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/red.png" position="200,923" size="30,30" alphatest="blend" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/green.png" position="550,923" size="30,30" alphatest="blend" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/yellow.png" position="950,923" size="30,30" alphatest="blend" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/blue.png" position="1350,923" size="30,30" alphatest="blend" transparent="1" />
+
+            <widget name="label_red" position="240,917" size="300,42" zPosition="1" font="Regular;30" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_green" position="590,917" size="350,42" zPosition="1" font="Regular;30" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_yellow" position="990,917" size="350,42" zPosition="1" font="Regular;30" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_blue" position="1390,917" size="300,42" zPosition="1" font="Regular;30" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+
+            <eLabel name="BG_Title" position="0,0" size="1680,90" backgroundColor="#100d0f16" zPosition="-1" />
+            <eLabel name="BG_Buttons" position="0,900" size="1680,72" backgroundColor="#100d0f16" zPosition="-1" />
+
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/smallshadowline.png" position="0,90" size="1680,3" zPosition="2" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/smallshadowline.png" position="0,900" size="1680,3" zPosition="2" />
+
+            <ePixmap position="30,918" size="60,38" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/ok.png" transparent="1" alphatest="blend" />
+            <ePixmap position="111,918" size="60,38" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/FHD/exit.png" transparent="1" alphatest="blend" />
+            <ePixmap name="playerlogo" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/logos/favouriteslogo.png" zPosition="4" position="30,15" size="180,60" scale="1" alphatest="blend" transparent="1" backgroundColor="black" />
+
+            <widget source="global.CurrentTime" render="Label" position="1440,15" size="225,60" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" transparent="1" zPosition="1" font="Regular;36" valign="center" halign="right">
+                <convert type="ClockToText">Format:%H:%M</convert>
+            </widget>
+
+            <widget source="global.CurrentTime" render="Label" position="1080,30" size="450,36" foregroundColor="white" backgroundColor="black" borderWidth="2" borderColor="black" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="right">
+                <convert type="ClockToText">Date</convert>
+            </widget>
+        </screen>
+        """
+
+    else:
+        # HD 1280x720
+        skin = """
+        <screen name="IPTVFavouritesMainWidget" position="center,center" size="1120,650" title="Favorites manager" backgroundColor="#34111112" flags="wfNoBorder">
+            <widget source="Title" render="Label" position="180,9" size="785,40" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" transparent="1" zPosition="1" font="Regular;24" valign="center" />
+
+            <widget name="title" position="20,68" size="1080,30" font="Regular;24" halign="left" valign="center" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" zPosition="1" transparent="1" />
+
+            <widget name="list" position="20,110" size="1080,468" itemHeight="36" font="Regular;20" scrollbarMode="showOnDemand" scrollbarSliderBorderWidth="1" scrollbarForegroundColor="#1b5a91" scrollbarBorderColor="#00b6b6b6" enableWrapAround="1" foregroundColor="white" backgroundColor="black" foregroundColorSelected="white" backgroundColorSelected="#1b5a91" borderWidth="1" borderColor="black" transparent="1" />
+
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/red.png" position="140,615" size="20,20" alphatest="blend" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/green.png" position="370,615" size="20,20" alphatest="blend" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/yellow.png" position="640,615" size="20,20" alphatest="blend" transparent="1" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/blue.png" position="910,615" size="20,20" alphatest="blend" transparent="1" />
+
+            <widget name="label_red" position="170,611" size="200,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_green" position="395,611" size="240,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_yellow" position="665,611" size="240,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+            <widget name="label_blue" position="935,611" size="200,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+
+            <eLabel name="BG_Title" position="0,0" size="1120,60" backgroundColor="#100d0f16" zPosition="-1" />
+            <eLabel name="BG_Buttons" position="0,600" size="1120,48" backgroundColor="#100d0f16" zPosition="-1" />
+
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/smallshadowline.png" position="0,60" size="1120,2" zPosition="2" />
+            <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/smallshadowline.png" position="0,600" size="1120,2" zPosition="2" />
+
+            <ePixmap position="20,612" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/ok.png" transparent="1" alphatest="blend" />
+            <ePixmap position="74,612" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/exit.png" transparent="1" alphatest="blend" />
+            <ePixmap name="playerlogo" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/logos/favouriteslogo.png" zPosition="4" position="20,10" size="120,40" alphatest="blend" transparent="1" backgroundColor="black" />
+
+
+            <widget source="global.CurrentTime" render="Label" position="960,10" size="150,40" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="right">
+                <convert type="ClockToText">Format:%H:%M</convert>
+            </widget>
+
+            <widget source="global.CurrentTime" render="Label" position="720,20" size="300,24" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" transparent="1" zPosition="1" font="Regular;16" valign="center" halign="right">
+                <convert type="ClockToText">Date</convert>
+            </widget>
+        </screen>
+        """
+
+    def __init__(self, session):
+        self.session = session
+        Screen.__init__(self, session)
+        self.setTitle(_("Favorites manager"))
+
+        self.onShown.append(self.onStart)
+        self.onClose.append(self.__onClose)
+        self.favourites = None
+        self.started = False
+        self.menu = ":groups:"  # "items"
+        self.modified = False
+
+        self.IDS_ENABLE_REORDERING = _('Enable reordering')
+        self.IDS_DISABLE_REORDERING = _('Disable reordering')
+        self.reorderingMode = False
+        self.t9Input = NumericalTextInput(handleTimeout=False)
+
+        self["title"] = Label(_("Favorites groups"))
+        self["label_red"] = Label(_("Remove group"))
+        self["label_yellow"] = Label(self.IDS_ENABLE_REORDERING)
+        self["label_green"] = Label(_("Add new group"))
+        self["label_blue"] = Label(_("Edit"))
+
+        self["list"] = IPTVMainNavigatorList()
+        self["list"].connectSelChanged(self.onSelectionChanged)
+
+        actions = {
+            "back": self.keyExit,
+            "cancel": self.keyExit,
+            "ok": self.keyOK,
+            "red": self.keyRed,
+            "yellow": self.keyYellow,
+            "green": self.keyGreen,
+            "blue": self.keyBlue,
+
+            "up": self.keyUp,
+            "down": self.keyDown,
+            "left": self.keyLeft,
+            "right": self.keyRight,
+            "moveUp": self.keyDrop,
+            "moveDown": self.keyDrop,
+            "moveTop": self.keyDrop,
+            "moveEnd": self.keyDrop,
+            "home": self.keyDrop,
+            "end": self.keyDrop,
+            "pageUp": self.keyDrop,
+            "pageDown": self.keyDrop
+        }
+        for digit in '123456789':
+            actions[digit] = self.makeNumberJump(digit)
+
+        self["actions"] = ActionMap(["ColorActions", "WizardActions", "ListboxActions", "NumberActions"],
+            actions, -2)
+
+        self.prevIdx = 0
+        self.duringMoving = False
+
+    def __onClose(self):
+        self["list"].disconnectSelChanged(self.onSelectionChanged)
+
+    def onStart(self):
+        self.onShown.remove(self.onStart)
+        self.favourites = IPTVFavourites(GetFavouritesDir())
+        sts = self.favourites.load(groupsOnly=True)
+        if not sts:
+            self.session.openWithCallback(self.iptvDoFinish, MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+            return
+        self.displayList()
+
+    def iptvDoFinish(self, ret=None):
+        self.close()
+
+    def displayList(self):
+        list = []
+        if ":groups:" == self.menu:
+            groups = self.favourites.getGroups()
+            for item in groups:
+                dItem = CDisplayListItem(name=item['title'], type=CDisplayListItem.TYPE_CATEGORY)
+                dItem.privateData = item['group_id']
+                list.append((dItem,))
+        else:
+            if not self.loadGroupItems(self.menu):
+                return
+            sts, items = self.favourites.getGroupItems(self.menu)
+            if not sts:
+                self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+            for idx in range(len(items)):
+                item = items[idx]
+                dItem = CDisplayListItem(name=item.name, type=item.type)
+                dItem.privateData = idx
+                list.append((dItem,))
+        self["list"].setList(list)
+
+    def loadGroupItems(self, groupId):
+        sts = self.favourites.loadGroupItems(groupId)
+        if not sts:
+            self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+            return False
+        return True
+
+    def onSelectionChanged(self):
+        pass
+
+    def keyExit(self):
+        if ":groups:" == self.menu:
+            if self.duringMoving:
+                self._changeMode()
+            if self.modified:
+                self.askForSave()
+            else:
+                self.close(False)
+        else:
+            self["title"].setText(_("Favorites groups"))
+            self["label_red"].setText(_("Remove group"))
+            self["label_green"].setText(_("Add new group"))
+            self["label_blue"].setText(_("Edit"))
+
+            self.menu = ":groups:"
+            self.displayList()
+            try:
+                self["list"].moveToIndex(self.prevIdx)
+            except Exception:
+                pass
+
+    def askForSave(self):
+        self.session.openWithCallback(self.save, MessageBox, text=_("Save changes?"), type=MessageBox.TYPE_YESNO)
+
+    def save(self, ret):
+        if ret:
+            if not self.favourites.save():
+                self.session.openWithCallback(self.closeAfterSave, MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+            self.closeAfterSave()
+        self.close(False)
+
+    def closeAfterSave(self):
+        self.close(True)
+
+    def keyOK(self):
+        if self.reorderingMode:
+            if None is not self.getSelectedItem():
+                self._changeMode()
+            return
+        if ":groups:" == self.menu:
+            sel = self.getSelectedItem()
+            if None is sel:
+                return
+
+            self.menu = sel.privateData
+            try:
+                self["title"].setText(_("Items in group \"%s\"") % self.favourites.getGroup(self.menu)['title'])
+            except Exception:
+                printExc()
+            self["label_red"].setText(_("Remove item"))
+            self["label_green"].setText(_("Add item to group"))
+            self["label_blue"].setText(_("Edit"))
+
+            try:
+                self.prevIdx = self["list"].getCurrentIndex()
+            except Exception:
+                self.prevIdx = 0
+            self.displayList()
+            try:
+                self["list"].moveToIndex(0)
+            except Exception:
+                pass
+
+    def keyRed(self):
+        if self.duringMoving:
+            return
+        sel = self.getSelectedItem()
+        if None is sel:
+            return
+        sts = True
+        if ":groups:" == self.menu:
+            sts = self.favourites.delGroup(sel.privateData)
+        else:
+            sts = self.favourites.delGroupItem(sel.privateData, self.menu)
+        if not sts:
+            self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+            return
+        self.modified = True
+        self.displayList()
+
+    def keyYellow(self):
+        if None is not self.getSelectedItem():
+            if self.reorderingMode:
+                self.reorderingMode = False
+                self["label_yellow"].setText(self.IDS_ENABLE_REORDERING)
+            else:
+                self.reorderingMode = True
+                self["label_yellow"].setText(self.IDS_DISABLE_REORDERING)
+
+            if self.duringMoving and not self.reorderingMode:
+                self._changeMode()
+            elif not self.duringMoving and self.reorderingMode:
+                self._changeMode()
+
+    def keyGreen(self):
+        printDBG(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> keyGreen 1")
+        if ":groups:" == self.menu:
+            self.session.openWithCallback(self._groupAdded, IPTVFavouritesAddNewGroupWidget, self.favourites)
+        else:
+            if None is self.getSelectedItem():
+                return
+            if not self.loadGroupItems(self.menu):
+                return
+            sts, items = self.favourites.getGroupItems(self.menu)
+            if not sts:
+                self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+            favItem = items[self["list"].getCurrentIndex()]
+            self.session.openWithCallback(self._itemCloned, IPTVFavouritesAddItemWidget, favItem, self.favourites, False, [self.menu])
+
+    def keyBlue(self):
+        if self.duringMoving:
+            return
+        sel = self.getSelectedItem()
+        if None is sel:
+            return
+
+        from copy import deepcopy
+        params = deepcopy(IPTVMultipleInputBox.DEF_PARAMS)
+        params['with_accept_button'] = True
+        params['list'] = []
+
+        if ":groups:" == self.menu:
+            group = self.favourites.getGroup(sel.privateData)
+            if None is group:
+                return
+
+            params['title'] = _("Edit favorite group")
+
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = self._validateGroup
+            item['title'] = _("Name:")
+            item['input']['text'] = group.get('title', '')
+            params['list'].append(item)
+
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = None
+            item['title'] = _("Description:")
+            item['input']['text'] = group.get('desc', '')
+            params['list'].append(item)
+
+            self.session.openWithCallback(self._groupEdited, IPTVMultipleInputBox, params)
+        else:
+            if not self.loadGroupItems(self.menu):
+                return
+            sts, items = self.favourites.getGroupItems(self.menu)
+            if not sts:
+                self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+
+            idx = self["list"].getCurrentIndex()
+            if idx < 0 or idx >= len(items):
+                return
+
+            params['title'] = _("Edit favorite item")
+
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = self._validateItem
+            item['title'] = _("Name:")
+            item['input']['text'] = items[idx].name
+            params['list'].append(item)
+
+            self.session.openWithCallback(self._itemEdited, IPTVMultipleInputBox, params)
+
+    def _validateGroup(self, text):
+        if 0 == len(text):
+            return False, _("Name cannot be empty.")
+        elif not IsValidFileName(text):
+            return False, _("Name is not valid.\nPlease remove special characters.")
+        return True, ""
+
+    def _validateItem(self, text):
+        if 0 == len(text):
+            return False, _("Name cannot be empty.")
+        return True, ""
+
+    def _groupEdited(self, retArg):
+        sel = self.getSelectedItem()
+        if None is sel or not retArg or 2 != len(retArg):
+            return
+
+        group = self.favourites.getGroup(sel.privateData)
+        if None is group:
+            return
+
+        group['title'] = retArg[0]
+        group['desc'] = retArg[1]
+        self.modified = True
+        self.displayList()
+
+    def _itemEdited(self, retArg):
+        sel = self.getSelectedItem()
+        if None is sel or not retArg or 1 > len(retArg):
+            return
+        if not self.loadGroupItems(self.menu):
+            return
+
+        sts, items = self.favourites.getGroupItems(self.menu)
+        if not sts:
+            self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+            return
+
+        idx = self["list"].getCurrentIndex()
+        if idx < 0 or idx >= len(items):
+            return
+
+        items[idx].name = retArg[0]
+        self.modified = True
+        self.displayList()
+        try:
+            self["list"].moveToIndex(idx)
+        except Exception:
+            pass
+
+    def _groupAdded(self, group):
+        if None is not group:
+            self.modified = True
+            self.displayList()
+            try:
+                self["list"].moveToIndex(len(self.favourites.getGroups()) - 1)
+            except Exception:
+                pass
+
+    def _itemCloned(self, ret):
+        if ret:
+            self.modified = True
+
+    def _changeMode(self):
+        if not self.duringMoving:
+            self["list"].instance.setForegroundColorSelected(gRGB(0xFF0505))
+            self.duringMoving = True
+        else:
+            self["list"].instance.setForegroundColorSelected(gRGB(0xFFFFFF))
+            self.duringMoving = False
+        self.displayList()
+
+    def moveItem(self, key):
+        if self["list"].instance is not None:
+            if self.duringMoving:
+                curIndex = self["list"].getCurrentIndex()
+                self["list"].instance.moveSelection(key)
+                newIndex = self["list"].getCurrentIndex()
+                if ":groups:" == self.menu:
+                    sts = self.favourites.moveGroup(curIndex, newIndex)
+                else:
+                    sts = self.favourites.moveGroupItem(curIndex, newIndex, self.menu)
+                if sts:
+                    self.modified = True
+                    self.displayList()
+            else:
+                self["list"].instance.moveSelection(key)
+
+    def keyUp(self):
+        if self["list"].instance is not None:
+            self.moveItem(self["list"].instance.moveUp)
+
+    def keyDown(self):
+        if self["list"].instance is not None:
+            self.moveItem(self["list"].instance.moveDown)
+
+    def keyLeft(self):
+        if self["list"].instance is not None:
+            self.moveItem(self["list"].instance.pageUp)
+
+    def keyRight(self):
+        if self["list"].instance is not None:
+            self.moveItem(self["list"].instance.pageDown)
+
+    def keyDrop(self):
+        pass
+
+    def getSelectedItem(self):
+        sel = None
+        try:
+            sel = self["list"].l.getCurrentSelection()[0]
+        except Exception:
+            pass
+        return sel
+
+    def makeNumberJump(self, digit):
+        return lambda: self.keyNumberJump(digit)
+
+    def keyNumberJump(self, digit):
+        if self.reorderingMode:
+            return
+        if not config.plugins.iptvplayer.enableT9MainList.value:
+            return
+
+        letter = self.t9Input.getKey(int(digit))
+        if not letter:
+            return
+
+        try:
+            currentIdx = self["list"].getCurrentIndex()
+            if ":groups:" == self.menu:
+                groups = self.favourites.getGroups()
+                total = len(groups)
+
+                def getTitle(i):
+                    return groups[i].get('title', '')
+            else:
+                if not self.loadGroupItems(self.menu):
+                    return
+                sts, items = self.favourites.getGroupItems(self.menu)
+                if not sts:
+                    return
+                total = len(items)
+
+                def getTitle(i):
+                    return getattr(items[i], 'name', '')
+
+            idx = findT9JumpIndex(total, currentIdx, letter, getTitle)
+            if idx >= 0:
+                self["list"].moveToIndex(idx)
+        except Exception:
+            printExc()

--- a/components/iptvplayerwidget.py
+++ b/components/iptvplayerwidget.py
@@ -1,0 +1,2727 @@
+# -*- coding: utf-8 -*-
+# Last Modified: 2026-07-26 - Updated blue_pressed() and blue_pressed_next(), added YouTube user links actions in the blue menu, and fixed deleteFavouriteItem(); fixed missing key_green label display by correcting the Halidri1080p1 playlist.xml key_green binding and set default green button text to "Download".
+# IplaPlayer based on SHOUTcast
+#
+#  $Id$
+#
+#
+
+from os import path as os_path
+from urllib.parse import quote as urllib_quote
+from random import shuffle as random_shuffle
+import traceback
+
+####################################################
+#                   E2 components
+####################################################
+from skin import parseColor
+from Screens.Screen import Screen
+from Screens.MessageBox import MessageBox
+from Screens.ChoiceBox import ChoiceBox
+from Components.ActionMap import ActionMap
+from Components.Label import Label
+from Components.Pixmap import Pixmap
+from Components.config import config
+from Components.Sources.StaticText import StaticText
+from Tools.BoundFunction import boundFunction
+from Tools.LoadPixmap import LoadPixmap
+from Tools.Directories import fileExists
+from Tools.NumericalTextInput import NumericalTextInput
+from enigma import getDesktop, eTimer
+
+####################################################
+#                   IPTV components
+####################################################
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import ConfigMenu, GetMoviePlayer, GetAvailableMoviePlayers, GetMoviePlayerName, GetListOfHostsNames
+from Plugins.Extensions.IPTVPlayer.components.confighost import ConfigHostMenu, ConfigHostsMenu
+from Plugins.Extensions.IPTVPlayer.components.configgroups import ConfigGroupsMenu
+
+from Plugins.Extensions.IPTVPlayer.components.iptvfavouriteswidgets import IPTVFavouritesAddItemWidget, IPTVFavouritesMainWidget
+
+from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdownloadercreator import IsUrlDownloadable
+from Plugins.Extensions.IPTVPlayer.libs.pCommon import CParsingHelper
+from Plugins.Extensions.IPTVPlayer.libs.urlparser import urlparser
+from Plugins.Extensions.IPTVPlayer.tools.iptvfavourites import IPTVFavourites
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import FreeSpace as iptvtools_FreeSpace, \
+                                                          mkdirs as iptvtools_mkdirs, GetIPTVPlayerVersion, \
+                                                          printDBG, printExc, iptv_system, GetHostsList, IsHostEnabled, \
+                                                          eConnectCallback, GetSkinsDir, GetIconDir, GetPluginDir, \
+                                                          SortHostsList, GetHostsOrderList, CSearchHistoryHelper, \
+                                                          CMoviePlayerPerHost, GetFavouritesDir, CFakeMoviePlayerOption, GetAvailableIconSize, \
+                                                          GetE2VideoMode, SetE2VideoMode, TestTmpCookieDir, TestTmpJSCacheDir, \
+                                                          ClearTmpCookieDir, ClearTmpJSCacheDir, SetTmpCookieDir, SetTmpJSCacheDir, \
+                                                          GetEnabledHostsList, SaveHostsOrderList, formatBytes, getExcMSG, \
+                                                          findT9JumpIndex
+from Plugins.Extensions.IPTVPlayer.tools.iptvhostgroups import IPTVHostsGroups
+from Plugins.Extensions.IPTVPlayer.iptvdm.iptvbuffui import E2iPlayerBufferingWidget
+from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdmapi import IPTVDMApi, DMItem
+
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, GetIPTVPlayerLastHostError, GetIPTVNotify, GetIPTVSleep
+
+from Plugins.Extensions.IPTVPlayer.components.iptvplayer import IPTVStandardMoviePlayer, IPTVMiniMoviePlayer
+from Plugins.Extensions.IPTVPlayer.components.iptvextmovieplayer import IPTVExtMoviePlayer
+from Plugins.Extensions.IPTVPlayer.components.iptvpictureplayer import IPTVPicturePlayerWidget
+from Plugins.Extensions.IPTVPlayer.components.iptvlist import IPTVMainNavigatorList, IPTVLinkChoiceBoxList
+from Plugins.Extensions.IPTVPlayer.components.iptvarticleview import IPTVArticleView
+from Plugins.Extensions.IPTVPlayer.components.ihost import IHost, CDisplayListItem, RetHost, CUrlItem, ArticleContent, CFavItem
+from Plugins.Extensions.IPTVPlayer.components.searchhistoryeditor import SearchHistoryEditor
+from Plugins.Extensions.IPTVPlayer.components.iconmenager import IconMenager
+from Plugins.Extensions.IPTVPlayer.components.cover import Cover, Cover3
+from Plugins.Extensions.IPTVPlayer.components.iptvchoicebox import IPTVChoiceBoxWidget, IPTVChoiceBoxItem
+import Plugins.Extensions.IPTVPlayer.components.asynccall as asynccall
+from Plugins.Extensions.IPTVPlayer.components.playerselector import PlayerSelectorWidget
+from Plugins.Extensions.IPTVPlayer.components.e2ivkselector import GetVirtualKeyboard
+from Plugins.Extensions.IPTVPlayer.__init__ import GRIDSUPPORT
+######################################################
+gDownloadManager = None
+
+
+class E2iPlayerWidget(Screen):
+    IPTV_VERSION = GetIPTVPlayerVersion()
+    skin = """
+        <screen position="center,center" size="1280,720" resolution="1280,720" title="E2iPlayer" backgroundColor="#34111112" flags="wfNoBorder">
+                <ePixmap position="22,687" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/info.png" transparent="1" alphatest="blend" />
+                <ePixmap position="80,687" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/ok.png" transparent="1" alphatest="blend" />
+                <ePixmap position="138,687" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/key_prevnext.png" transparent="1" alphatest="blend" />
+                <ePixmap position="196,687" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/key_updown.png" transparent="1" alphatest="blend" />
+                <ePixmap position="254,687" size="40,26" zPosition="10" pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/exit.png" transparent="1" alphatest="blend" />
+                <widget source="Title" render="Label" position="160,10" size="785,40" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" transparent="1" zPosition="1" font="Regular;24" valign="center" />
+                <widget name="headertext" position="320,70" zPosition="1" size="940,40" font="Regular; 20" transparent="1" halign="left" valign="center" backgroundColor="black" foregroundColor="#178ef5" borderWidth="1" borderColor="black" shadowColor="black" shadowOffset="-2,-2" />
+                <widget name="statustext" position="410,230" zPosition="1" size="685,90" font="Regular;30" halign="left" valign="top" transparent="1" backgroundColor="black" foregroundColor="white" />
+                <widget name="list" position="320,110" zPosition="2" size="940,384" itemHeight="32" font="Regular;20" scrollbarMode="showOnDemand" scrollbarSliderBorderWidth="1" scrollbarForegroundColor="#1b5a91" scrollbarBorderColor="#00b6b6b6" enableWrapAround="1" transparent="1" foregroundColor="white" backgroundColor="black" foregroundColorSelected="white" backgroundColorSelected="#1b5a91" borderWidth="1" borderColor="black" />
+                <widget name="console" position="20,500" zPosition="1" size="1240,170" font="Regular;18" transparent="1" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" shadowColor="black" shadowOffset="-2,-2" halign="left" valign="center" />
+                <widget name="sequencer" position="0,0" zPosition="6" size="1280,720" font="Regular;160" halign="center" valign="center" transparent="1" backgroundColor="#00000000" />
+                <widget name="cover" position="20,70" size="288,420" zPosition="3" alphatest="blend" />
+                <widget name="playerlogo"  zPosition="4" position="20,10" size="120,40" alphatest="blend" transparent="1" backgroundColor="black" />
+                <widget name="spinner"   zPosition="2" position="463,200" size="16,16" transparent="1" alphatest="blend" />
+                <widget name="spinner_1" zPosition="1" position="463,200" size="16,16" transparent="1" alphatest="blend" />
+                <widget name="spinner_2" zPosition="1" position="479,200" size="16,16" transparent="1" alphatest="blend" />
+                <widget name="spinner_3" zPosition="1" position="495,200" size="16,16" transparent="1" alphatest="blend" />
+                <widget name="spinner_4" zPosition="1" position="511,200" size="16,16" transparent="1" alphatest="blend" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/red.png" position="340,690" size="20,20" alphatest="blend" transparent="1" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/green.png" position="570,690" size="20,20" alphatest="blend" transparent="1" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/yellow.png" position="800,690" size="20,20" alphatest="blend" transparent="1" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/blue.png" position="1030,690" size="20,20" alphatest="blend" transparent="1" />
+                <widget source="key_red" render="Label" position="374,686" size="200,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+                <widget source="key_green" render="Label" position="604,686" size="200,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+                <widget source="key_yellow" render="Label" position="834,686" size="200,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+                <widget source="key_blue" render="Label" position="1064,686" size="200,28" zPosition="1" font="Regular;20" backgroundColor="black" foregroundColor="white" halign="left" transparent="1" valign="center" noWrap="1" />
+                <eLabel name="BG_Title" position="0,0" size="1280,60" backgroundColor="#100d0f16" zPosition="-1" />
+                <eLabel name="BG_Buttons" position="0,675" size="1280,48" backgroundColor="#100d0f16" zPosition="-1" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/smallshadowline.png" position="0,60" size="1280,2" zPosition="2" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/smallshadowline.png" position="20,494" size="1240,2" zPosition="2" />
+                <ePixmap pixmap="/usr/lib/enigma2/python/Plugins/Extensions/IPTVPlayer/icons/HD/smallshadowline.png" position="0,675" size="1280,2" zPosition="2" />
+                <widget source="global.CurrentTime" render="Label" position="1100,10" size="150,40" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="right">
+                    <convert type="ClockToText">Format:%H:%M</convert>
+                </widget>
+                <widget source="global.CurrentTime" render="Label" position="860,20" size="300,24" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" transparent="1" zPosition="1" font="Regular;16" valign="center" halign="right">
+                    <convert type="ClockToText">Date</convert>
+                </widget>
+        </screen>
+    """
+    fullHD = getDesktop(0).size().width() == 1920
+    if fullHD:
+        skin = skin.replace("/HD/", "/FHD/")
+
+    def __init__(self, session):
+        printDBG("E2iPlayerWidget.__init__ desktop IPTV_VERSION[%s]\n" % (E2iPlayerWidget.IPTV_VERSION))
+        self.session = session
+        self.skinResolutionType = 'sd'
+        screenwidth = getDesktop(0).size().width()
+        if screenwidth:
+            if screenwidth > 1900:
+                self.skinResolutionType = 'hd'
+            elif screenwidth > 1200:
+                self.skinResolutionType = 'hd_ready'
+
+        selSkin = config.plugins.iptvplayer.skin.value
+        if selSkin:
+            path = GetSkinsDir(selSkin) + "/playlist.xml"
+            printDBG("Playlist skin path [%s]" % path)
+            if fileExists(path):
+                try:
+                    with open(path, "r") as f:
+                        self.skin = f.read()
+                except Exception:
+                    printExc("Skin read error: " + path)
+
+        Screen.__init__(self, session)
+        self.skinName = ["E2iPlayerWidgetScreen", "E2iPlayerWidget"]
+        if config.plugins.iptvplayer.skinforceinternal.value:
+            self.skinName = "_E2iPlayerWidgetScreen"
+
+        self.recorderMode = False  # j00zek
+        self.hostLogoPath = None
+
+        self.currentService = self.session.nav.getCurrentlyPlayingServiceReference()
+        if config.plugins.iptvplayer.disable_live.value:
+            self.session.nav.stopService()
+
+        self["key_red"] = StaticText(_("Close"))
+        self["key_green"] = StaticText(_("Download"))
+
+        self["key_yellow"] = StaticText(_("Refresh"))
+        self["key_blue"] = StaticText(_("More"))
+
+        self["list"] = IPTVMainNavigatorList()
+        self["list"].connectSelChanged(self.onSelectionChanged)
+        self["statustext"] = Label("Loading...")
+
+        self["actions"] = ActionMap(["IPTVPlayerListActions", "ColorActions", "NumberActions"],
+        {
+            "red": self.red_pressed,
+            "green": self.green_pressed,
+            "yellow": self.yellow_pressed,
+            "blue": self.blue_pressed,
+            "ok": self.ok_pressed,
+            "back": self.back_pressed,
+            "info": self.info_pressed,
+            "0": self.ok_pressed0,
+            "1": self.keyT9_1,
+            "2": self.keyT9_2,
+            "3": self.keyT9_3,
+            "4": self.keyT9_4,
+            "5": self.keyT9_5,
+            "6": self.keyT9_6,
+            "7": self.keyT9_7,
+            "8": self.keyT9_8,
+            "9": self.keyT9_9,
+            "play": self.startAutoPlaySequencer,
+            "menu": self.menu_pressed,
+            "tools": self.blue_pressed,
+            "record": self.green_pressed,
+            "pageUp": self.pageup_pressed,
+            "pageDown": self.pagedown_pressed
+        }, -1)
+
+        self["headertext"] = Label()
+        self["console"] = Label()
+        self["sequencer"] = Label()
+
+        self["cover"] = Cover()
+        self["cover"].hide()
+        self["playerlogo"] = Cover()
+
+        try:
+            for idx in range(5):
+                spinnerName = "spinner"
+                if idx:
+                    spinnerName += '_%d' % idx
+                self[spinnerName] = Cover3()
+        except Exception:
+            printExc()
+
+        # Check for plugin update
+        self.lastPluginVersion = ''
+        self.checkUpdateConsole = None
+
+        self.spinnerPixmap = [LoadPixmap(GetIconDir('radio_button_on.png')), LoadPixmap(GetIconDir('radio_button_off.png'))]
+        self.useAlternativePlayer = False
+
+        self.showMessageNoFreeSpaceForIcon = False
+        self.iconMenager = None
+        if config.plugins.iptvplayer.showcover.value:
+            if not os_path.exists(config.plugins.iptvplayer.SciezkaCache.value):
+                iptvtools_mkdirs(config.plugins.iptvplayer.SciezkaCache.value)
+
+            if iptvtools_FreeSpace(config.plugins.iptvplayer.SciezkaCache.value, 10):
+                self.iconMenager = IconMenager(True)
+            else:
+                self.showMessageNoFreeSpaceForIcon = True
+                self.iconMenager = IconMenager(False)
+            self.iconMenager.setUpdateCallBack(self.checkIconCallBack)
+        self.showHostsErrorMessage = True
+
+        self.onClose.append(self.__onClose)
+        # self.onLayoutFinish.append(self.onStart)
+        self.onShow.append(self.onStart)
+
+        # Defs
+        self.searchPattern = CSearchHistoryHelper.loadLastPattern()[1]
+        self.searchType = None
+        self.workThread = None
+        self.group = None
+        self.groupDisplayName = None
+        self.groupObj = None
+        self.host = None
+        self.hostName = ''
+        self.hostTitle = ''
+        self.hostFavTypes = []
+
+        self.nextSelIndex = 0
+        self.currSelIndex = 0
+
+        self.prevSelList = []
+        self.categoryList = []
+
+        self.currList = []
+        self.currItem = CDisplayListItem()
+        self.favouritesCurrentGroupId = ''
+
+        # global (not per-host) memory of the last selected search-history entry,
+        # see _rememberHistorySelection()/_restoreHistorySelection()
+        self._lastHistorySelection = None
+        self._isLoadingList = False
+
+        self.visible = True
+        self.bufferSize = config.plugins.iptvplayer.requestedBuffSize.value * 1024 * 1024
+
+        #################################################################
+        #                      Inits for Proxy Queue
+        #################################################################
+
+        # register function in main Queue
+        if None is asynccall.gMainFunctionsQueueTab[0]:
+            asynccall.gMainFunctionsQueueTab[0] = asynccall.CFunctionProxyQueue(self.session)
+        asynccall.gMainFunctionsQueueTab[0].clearQueue()
+        asynccall.gMainFunctionsQueueTab[0].setProcFun(self.doProcessProxyQueueItem)
+
+        # main Queue
+        self.mainTimer = eTimer()
+        self.mainTimer_conn = eConnectCallback(self.mainTimer.timeout, self.processProxyQueue)
+        # every 100ms Proxy Queue will be checked
+        self.mainTimer_interval = 100
+        self.mainTimer.start(self.mainTimer_interval, True)
+
+        # delayed decode cover timer
+        self.decodeCoverTimer = eTimer()
+        self.decodeCoverTimer_conn = eConnectCallback(self.decodeCoverTimer.timeout, self.doStartCoverDecode)
+        self.decodeCoverTimer_interval = 100
+
+        # spinner timer
+        self.spinnerTimer = eTimer()
+        self.spinnerTimer_conn = eConnectCallback(self.spinnerTimer.timeout, self.updateSpinner)
+        self.spinnerTimer_interval = 200
+        self.spinnerEnabled = False
+
+        #################################################################
+
+        #################################################################
+        #                      Inits for IPTV Download Manager
+        #################################################################
+        global gDownloadManager
+        if None is gDownloadManager:
+            from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdmui import GetIPTVDMNotification
+            GetIPTVDMNotification().dialogInit(session)
+            printDBG('============Initialize Download Menager============')
+            gDownloadManager = IPTVDMApi(2, int(config.plugins.iptvplayer.IPTVDMMaxDownloadItem.value), GetIPTVDMNotification)
+            if config.plugins.iptvplayer.IPTVDMRunAtStart.value:
+                gDownloadManager.runWorkThread()
+        # transient state for the "Select link" screen: the full list of mirrors
+        # currently shown (so a resolve failure can reopen it with the failed one
+        # marked) and the mirror currently being resolved. Both reset naturally
+        # whenever a fresh mirror list is fetched from the host.
+        self._currentLinkOptions = None
+        self._resolvingLinkItem = None
+        # Auto playing sequencer
+        self.autoPlaySeqStarted = False
+        self.autoPlaySeqTimer = eTimer()
+        self.autoPlaySeqTimer_conn = eConnectCallback(self.autoPlaySeqTimer.timeout, self.autoPlaySeqTimerCallBack)
+        self.autoPlaySeqTimerValue = 0
+
+        self.activePlayer = None
+        self.canRandomizeList = False
+
+        self.prevVideoMode = None
+        # no handleTimeout: we act on every press immediately (list jump,
+        # not text composition), so the commit-after-timeout callback and
+        # its eTimer aren't needed - only the digit-cycling in getKey() is.
+        # Separate instances per list context: NumericalTextInput only resets
+        # its letter-cycle position when a DIFFERENT digit is pressed, so
+        # sharing one instance between the search-history and main-list T9
+        # jump would leak cycle state across an unrelated list switch (e.g.
+        # pressing '2' in the history list, then '2' again in the main list,
+        # would resume the cycle at 'b' instead of restarting at 'a').
+        self.t9HistoryInput = NumericalTextInput(handleTimeout=False)
+        self.t9MainListInput = NumericalTextInput(handleTimeout=False)
+
+        # test if path for js and cookies temporary files
+        # is writable, without this plugin can not works
+        try:
+            TestTmpCookieDir()
+            TestTmpJSCacheDir()
+            ClearTmpCookieDir()
+            ClearTmpJSCacheDir()
+        except Exception as e:
+            SetTmpCookieDir()
+            SetTmpJSCacheDir()
+            msg1 = _("Critical Error - cookie can't be saved!")
+            msg2 = _("Last error:\n%s") % str(e)
+            msg3 = _("Please make sure that the folder for cache data (set in the configuration) is writable.")
+            GetIPTVNotify().push('%s\n\n%s\n\n%s' % (msg1, msg2, msg3), 'error', 20)
+
+        self.statusTextValue = ""
+        self.enabledHostsListOld = []
+        asynccall.SetMainThreadId()
+
+        self.downloadable = False
+        self.colorEnabled = parseColor("#FFFFFF")
+        self.colorDisabled = parseColor("#808080")
+
+    # end def __init__(self, session):
+
+    def updateDownloadButton(self):
+        self.downloadable = False
+        try:
+            if self["list"].visible:
+                item = self.getSelItem()
+                self.downloadable = self.isDownloadableType(item.type)
+                if self.downloadable and item and item.urlItems and item.urlItems[0].url.startswith('file://'):  # workaround for LocalMedia
+                    self.downloadable = False
+        except Exception:
+            printExc()
+
+        self["key_green"].setText(_("Download") if self.downloadable else "")
+
+    def getSkinResolutionType(self):
+        return self.skinResolutionType
+
+    def setStatusTex(self, msg):
+        self.statusTextValue = msg
+        self["statustext"].setText(msg)
+
+    def __del__(self):
+        printDBG("E2iPlayerWidget.__del__")
+
+    def __onClose(self):
+        self.session.nav.playService(self.currentService)
+        self["list"].disconnectSelChanged(self.onSelectionChanged)
+        if None is not self.checkUpdateConsole:
+            self.checkUpdateConsole.terminate()
+        if None is not self.iconMenager:
+            self.iconMenager.setUpdateCallBack(None)
+            self.iconMenager.clearDQueue()
+            self.iconMenager = None
+        self.mainTimer_conn = None
+        self.mainTimer = None
+        self.decodeCoverTimer_conn = None
+        self.decodeCoverTimer = None
+        self.spinnerTimer_conn = None
+        self.spinnerTimer = None
+
+        try:
+            self.stopAutoPlaySequencer()
+            self.autoPlaySeqTimer_conn = None
+            self.autoPlaySeqTimer = None
+        except Exception:
+            printExc()
+
+        try:
+            asynccall.gMainFunctionsQueueTab[0].setProcFun(None)
+            asynccall.gMainFunctionsQueueTab[0].clearQueue()
+            with open("/proc/sys/vm/drop_caches", "w") as f:
+                f.write("1")
+        except Exception:
+            printExc()
+        self.activePlayer = None
+
+    def isPlayableType(self, type):
+        if type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO, CDisplayListItem.TYPE_ARTICLE, CDisplayListItem.TYPE_PICTURE]:
+            return True
+        else:
+            return False
+
+    def isDownloadableType(self, type):
+        if type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO, CDisplayListItem.TYPE_DATA]:
+            return True
+        else:
+            return False
+
+    def loadSpinner(self):
+        try:
+            if "spinner" in self:
+                self["spinner"].setPixmap(self.spinnerPixmap[0])
+                for idx in range(4):
+                    spinnerName = 'spinner_%d' % (idx + 1)
+                    self[spinnerName].setPixmap(self.spinnerPixmap[1])
+        except Exception:
+            printExc()
+
+    def showSpinner(self):
+        if None is not self.spinnerTimer:
+            self._setSpinnerVisibility(True)
+            self.spinnerTimer.start(self.spinnerTimer_interval, True)
+
+    def hideSpinner(self):
+        self._setSpinnerVisibility(False)
+
+    def _setSpinnerVisibility(self, visible=True):
+        self.spinnerEnabled = visible
+        try:
+            if "spinner" in self:
+                for idx in range(5):
+                    spinnerName = "spinner"
+                    if idx:
+                        spinnerName += '_%d' % idx
+                    self[spinnerName].visible = visible
+        except Exception:
+            printExc()
+
+    def updateSpinner(self):
+        try:
+            if self.spinnerEnabled and None is not self.workThread:
+                if self.workThread.isAlive():
+                    timeout = GetIPTVSleep().getTimeout()
+                    if timeout > 0:
+                        if timeout > 1:
+                            msg = _("wait %s seconds") % timeout
+                        else:
+                            msg = _("wait %s second") % timeout
+                        msg = '%s (%s)' % (self.statusTextValue, msg)
+                        self["statustext"].setText(msg)
+                    else:
+                        self["statustext"].setText(self.statusTextValue)
+
+                    if "spinner" in self:
+                        x, y = self["spinner"].getPosition()
+                        x += self["spinner"].getWidth()
+                        if x > self["spinner_4"].getPosition()[0]:
+                            x = self["spinner_1"].getPosition()[0]
+                        self["spinner"].setPosition(x, y)
+                    if None is not self.spinnerTimer:
+                        self.spinnerTimer.start(self.spinnerTimer_interval, True)
+                        return
+                elif not self.workThread.isFinished():
+                    if self.hostName not in GetHostsList(fromList=True, fromHostFolder=False):
+                        message = _('It seems that the host "%s" has crashed.') % self.hostName
+                        message += _('\nThis host is not integral part of the E2iPlayer plugin.\nIt is not supported by E2iPlayer team.')
+                        self.session.open(MessageBox, message, type=MessageBox.TYPE_ERROR)
+                    else:
+                        message = _('It seems that the host "%s" has crashed. Do you want to report this problem?') % self.hostName
+                        message += "\n"
+                        message += _('\nMake sure you are using the latest version of the plugin.')
+                        message += _('\nYou can also report problem here: \nhttps://github.com/oe-mirrors/e2iplayer/issues')
+                        self.session.openWithCallback(self.reportHostCrash, MessageBox, text=message, type=MessageBox.TYPE_YESNO)
+            self.hideSpinner()
+        except Exception:
+            printExc()
+
+    def reportHostCrash(self, ret):
+        try:
+            if False:
+                try:
+                    exceptStack = self.workThread.getExceptStack()
+                    reporter = GetPluginDir('iptvdm/reporthostcrash.py')
+                    msg = urllib_quote('%s|%s|%s|%s' % ('HOST_CRASH', E2iPlayerWidget.IPTV_VERSION, self.hostName, self.getCategoryPath()))
+                    self.crashConsole = iptv_system('python "%s" "http://iptvplayer.vline.pl/reporthostcrash.php?msg=%s" "%s" 2&>1 > /dev/null' % (reporter, msg, exceptStack))
+                    printDBG(msg)
+                except Exception:
+                    printExc()
+            self.workThread = None
+            self.prevSelList = []
+            self.back_pressed()
+        except Exception:
+            printExc()
+
+    def processIPTVNotify(self, callbackArg1=None, callbackArg2=None):
+        try:
+            notifyObj = GetIPTVNotify()
+            if not notifyObj.isEmpty():
+                notification = notifyObj.pop()
+                if notification:
+                    typeMap = {
+                        'info': MessageBox.TYPE_INFO,
+                        'error': MessageBox.TYPE_ERROR,
+                        'warning': MessageBox.TYPE_WARNING,
+                    }
+                    self.session.openWithCallback(self.processIPTVNotify, MessageBox, notification.message, type=typeMap.get(notification.type, MessageBox.TYPE_INFO), timeout=notification.timeout)
+                    return
+        except Exception:
+            printExc()
+        self.processProxyQueue()
+
+    def processProxyQueue(self):
+        if None is not self.mainTimer:
+            funName = asynccall.gMainFunctionsQueueTab[0].peekClientFunName()
+            notifyObj = GetIPTVNotify()
+            if funName is not None and notifyObj is not None and not notifyObj.isEmpty() and funName in ['showArticleContent', 'selectMainVideoLinks', 'selectResolvedVideoLinks', 'reloadList']:
+                self.processIPTVNotify()
+            else:
+                asynccall.gMainFunctionsQueueTab[0].processQueue()
+                self.mainTimer.start(self.mainTimer_interval, True)
+        return
+
+    def doProcessProxyQueueItem(self, item):
+        try:
+            if None is item.retValue[0] or self.workThread == item.retValue[0]:
+                if isinstance(item.retValue[1], asynccall.CPQParamsWrapper):
+                    getattr(self, item.clientFunName)(*item.retValue[1])
+                else:
+                    getattr(self, item.clientFunName)(item.retValue[1])
+            else:
+                printDBG('doProcessProxyQueueItem callback from old workThread[%r][%s]' % (self.workThread, item.retValue))
+        except Exception:
+            printExc()
+
+    def getArticleContentCallback(self, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("showArticleContent", [thread, ret])
+
+    def selectHostVideoLinksCallback(self, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("selectMainVideoLinks", [thread, ret])
+
+    def getResolvedURLCallback(self, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("selectResolvedVideoLinks", [thread, ret])
+
+    def callbackGetList(self, addParam, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("reloadList", [thread, {'add_param': addParam, 'ret': ret}])
+
+    # method called from IconMenager when a new icon has been dowlnoaded
+    def checkIconCallBack(self, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("displayIcon", [None, ret])
+
+    def isInWorkThread(self):
+        return None is not self.workThread and (not self.workThread.isFinished() or self.workThread.isAlive())
+
+    def red_pressed(self):
+        self.stopAutoPlaySequencer()
+        self.selectHost()
+        return
+
+    def green_pressed(self):
+        self.stopAutoPlaySequencer()
+        self.updateDownloadButton()
+        self.recorderMode = self.downloadable
+        if self.downloadable:
+            self.ok_pressed('green')
+
+    def yellow_pressed(self):
+        self.stopAutoPlaySequencer()
+        self.getRefreshedCurrList()
+        return
+
+    def blue_pressed(self):
+        # For Keyboard test
+        # if False:
+        # from Plugins.Extensions.IPTVPlayer.components.e2ivksuggestion import AutocompleteSearch
+        # from Plugins.Extensions.IPTVPlayer.suggestions.google import SuggestionsProvider
+        # self.session.open(GetVirtualKeyboard(), additionalParams={'autocomplete':AutocompleteSearch(SuggestionsProvider(True))})
+        # return
+
+        # For subtitles test
+        if False:
+            from Plugins.Extensions.IPTVPlayer.components.iptvsubdownloader import IPTVSubDownloaderWidget
+            self.session.open(IPTVSubDownloaderWidget, params={'movie_title': 'elementary s02e03'})
+            return
+
+        self.stopAutoPlaySequencer()
+        options = []
+
+        canAddUserLink = False
+        try:
+            currSelIndex = self.getSelIndex()
+            if currSelIndex > -1 and hasattr(self.host, 'canAddToUserLinks') and self.host.canAddToUserLinks(currSelIndex):
+                canAddUserLink = True
+        except Exception:
+            printExc()
+
+        if canAddUserLink:
+            options.append((_("Add to User Links"), "ADD_USER_LINK"))
+            if hasattr(self.host, 'editUserLinks'):
+                options.append((_("Edit User Links"), "EDIT_USER_LINKS"))
+
+        if -1 < self.canByAddedToFavourites()[0]:
+            options.append((_("Add item to favorites"), "ADD_FAV"))
+            options.append((_("Edit favorites"), "EDIT_FAV"))
+        elif 'favourites' == self.hostName:
+            options.append((_("Edit favorites"), "EDIT_FAV"))
+            options.append((_("Remove from favorites"), "DELETE_FAV"))
+
+        if not canAddUserLink:
+            try:
+                if hasattr(self.host, 'editUserLinks'):
+                    options.append((_("Edit User Links"), "EDIT_USER_LINKS"))
+            except Exception:
+                printExc()
+
+        if None is not self.activePlayer.get('player', None):
+            title = _('Change active movie player')
+        else:
+            title = _('Set active movie player')
+        options.append((title, "SetActiveMoviePlayer"))
+
+        if self.canRandomizeList and self.visible and len(self.currList) and not self.isInWorkThread():
+            options.append((_('Randomize a playlist'), "RandomizePlayableItems"))
+            options.append((_('Reverse a playlist'), "ReversePlayableItems"))
+
+        self._hostActions = []
+        try:
+            host = __import__('Plugins.Extensions.IPTVPlayer.hosts.host' + self.hostName, globals(), locals(), ['GetConfigList'], 0)
+            if (len(host.GetConfigList()) > 0):
+                options.append((_("Configure host"), "HostConfig"))
+            if hasattr(host, 'GetHostActions'):
+                self._hostActions = host.GetHostActions()
+                for i, action in enumerate(self._hostActions):
+                    options.append((action[0], f"HostAction:{i}"))
+        except Exception:
+            printExc()
+        if hasattr(self.host.host, 'history'):
+            options.append((_("Edit search history"), "EditSearchHistory"))
+        options.append((_("Download manager"), "IPTVDM"))
+        options.append((_("Exit"), "CLOSE"))
+        self.session.openWithCallback(self.blue_pressed_next, ChoiceBox, title=_("Select option"), list=options)
+
+    def pause_pressed(self):
+        printDBG('pause_pressed')
+        self.stopAutoPlaySequencer()
+
+    def startAutoPlaySequencer(self):
+        if not self.autoPlaySeqStarted:
+            self.autoPlaySeqStarted = True
+            self.autoPlaySequencerNext(False)
+
+    def stopAutoPlaySequencer(self):
+        if self.autoPlaySeqStarted:
+            if not config.plugins.iptvplayer.disable_live.value:
+                self.session.nav.playService(self.currentService)
+
+            if config.plugins.iptvplayer.autoplay_start_delay.value == 0:
+                self.showWindow()
+
+            self.autoPlaySeqTimer.stop()
+            self["sequencer"].setText("")
+            self.autoPlaySeqStarted = False
+            return True
+        return False
+
+    def autoPlaySequencerNext(self, goToNext=True):
+        if not self.autoPlaySeqStarted:
+            printDBG("ERROR in autoPlaySequencerNext - sequencer stopped")
+            return
+
+        idx = self.getSelIndex()
+        if -1 != idx:
+            # find next playable item
+            if goToNext:
+                idx += 1
+                if config.plugins.iptvplayer.autoplay_start_delay.value == 0:
+                    self.hideWindow()
+
+            while idx < len(self.currList):
+                if self.currList[idx].type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO, CDisplayListItem.TYPE_PICTURE, CDisplayListItem.TYPE_MORE]:
+                    break
+                else:
+                    idx += 1
+            if idx < len(self.currList):
+                self["list"].moveToIndex(idx)
+                self.sequencerPressOK()
+                return
+        self.stopAutoPlaySequencer()
+
+    def sequencerPressOK(self):
+        self.autoPlaySeqTimerValue = config.plugins.iptvplayer.autoplay_start_delay.value
+
+        if self.autoPlaySeqTimerValue == 0:
+            self.ok_pressed('sequencer')
+        else:
+            self["sequencer"].setText(str(self.autoPlaySeqTimerValue))
+            self.autoPlaySeqTimer.start(1000)
+
+    def autoPlaySeqTimerCallBack(self):
+        self.autoPlaySeqTimerValue -= 1
+        if self.autoPlaySeqTimerValue > 0:
+            self["sequencer"].setText(str(self.autoPlaySeqTimerValue))
+        else:
+            self["sequencer"].setText("")
+            self.autoPlaySeqTimer.stop()
+            self.ok_pressed('sequencer')
+
+    def checkAutoPlaySequencer(self):
+        if self.autoPlaySeqStarted:
+            self.autoPlaySequencerNext()
+            return True
+        return False
+
+    def blue_pressed_next(self, ret):
+        if ret:
+            if ret[1] == "IPTVDM":
+                self.runIPTVDM()
+            elif ret[1] == "CLOSE":
+                self.close()
+            elif ret[1] == "HostConfig":
+                self.runConfigHostIfAllowed()
+            elif ret[1] == "SetActiveMoviePlayer":
+                options = []
+                options.append(IPTVChoiceBoxItem(_("Auto selection based on the settings"), "", {}))
+                if config.plugins.iptvplayer.moviePlayerPickerMode.value == 'extended':
+                    # every actually available player directly, not just
+                    # whatever the two configured "default"/"alternative"
+                    # slots resolve to - those often both land on the two
+                    # external players (auto always prefers them when
+                    # present), so mini/standard were never reachable here
+                    # without changing Settings first
+                    for buffering in (True, False):
+                        for playerKey in GetAvailableMoviePlayers():
+                            player = CFakeMoviePlayerOption(playerKey, GetMoviePlayerName(playerKey))
+                            # keep the original combined msgid ("[%s] with/
+                            # without buffering"), not a split "with
+                            # buffering" + "[%s] %s" - 14 locales already
+                            # have real translations for this exact string,
+                            # splitting it would silently orphan every one
+                            label = _("[%s] with buffering") % player.getText() if buffering else _("[%s] without buffering") % player.getText()
+                            options.append(IPTVChoiceBoxItem(label, "", {'buffering': buffering, 'player': player}))
+                else:
+                    # "standard": only the 4 configured default/alternative
+                    # slots, same as before the "extended" mode existed
+                    for buffering, useAlternativePlayer in ((True, False), (True, True), (False, False), (False, True)):
+                        player = self.getMoviePlayer(buffering, useAlternativePlayer)
+                        label = _("[%s] with buffering") % player.getText() if buffering else _("[%s] without buffering") % player.getText()
+                        options.append(IPTVChoiceBoxItem(label, "", {'buffering': buffering, 'player': player}))
+
+                currIdx = -1
+                for idx in range(len(options)):
+                    try:
+                        if options[idx].privateData.get('buffering', None) == self.activePlayer.activePlayer.get('buffering', None) and options[idx].privateData.get('player', CFakeMoviePlayerOption('', '')).value == self.activePlayer.activePlayer.get('player', CFakeMoviePlayerOption('', '')).value:
+                            currIdx = idx
+                    except Exception:
+                        printExc()
+                    if idx == currIdx:
+                        options[idx].type = IPTVChoiceBoxItem.TYPE_ON
+                    else:
+                        options[idx].type = IPTVChoiceBoxItem.TYPE_OFF
+
+                height = self._getMoviePlayerPickerHeight(len(options))
+                # 120: same derivation as the keyboard's language picker -
+                # the list starts at y=66 in the chrome skin's reference
+                # space, and "e-N" sizes against the full container height,
+                # not reduced by that 66 first, so footerMargin needs to be
+                # >= 66 + 48 (footer height) = 114 just to end flush with
+                # the footer; the chrome default of 150 leaves a visible
+                # ~36px reference-space gap above it
+                self.session.openWithCallback(self.setActiveMoviePlayer, IPTVChoiceBoxWidget, {'width': self.MOVIE_PLAYER_PICKER_WIDTH, 'height': height, 'current_idx': currIdx, 'title': _("Select movie player"), 'options': options, 'chrome': True, 'footerMargin': 120})
+            elif ret[1] == 'ADD_FAV':
+                currSelIndex = self.canByAddedToFavourites()[0]
+                self.requestListFromHost('ForFavItem', currSelIndex, '')
+            elif ret[1] == 'EDIT_FAV':
+                self.session.openWithCallback(self.editFavouritesCallback, IPTVFavouritesMainWidget)
+            elif ret[1] == 'DELETE_FAV':
+                self.session.openWithCallback(self.deleteFavouriteItem, MessageBox, _('Definitely remove from favorites?'), type=MessageBox.TYPE_YESNO, timeout=10)
+            elif ret[1] == 'ADD_USER_LINK':
+                try:
+                    currSelIndex = self.getSelIndex()
+                    if currSelIndex > -1 and hasattr(self.host, 'addToUserLinks'):
+                        self.host.addToUserLinks(self.session, currSelIndex)
+                except Exception:
+                    printExc()
+            elif ret[1] == 'EDIT_USER_LINKS':
+                try:
+                    if hasattr(self.host, 'editUserLinks'):
+                        self.host.editUserLinks(self.session)
+                except Exception:
+                    printExc()
+            elif ret[1] == 'RandomizePlayableItems':
+                self.randomizePlayableItems()
+            elif ret[1] == 'ReversePlayableItems':
+                self.reversePlayableItems()
+            elif ret[1] == 'EditSearchHistory':
+                try:
+                    historyFile = self.host.host.history.PATH_FILE
+                except Exception:
+                    printExc()
+                    historyFile = ''
+                if historyFile:
+                    self.session.open(SearchHistoryEditor, historyFile=historyFile, reverseForDisplay=True, reverseForWrite=True)
+                else:
+                    self.session.open(MessageBox, _('Search history is not available for this host.'), type=MessageBox.TYPE_ERROR, timeout=5)
+            elif ret[1].startswith("HostAction:"):
+                try:
+                    idx = int(ret[1].split(":")[1])
+                    if hasattr(self, '_hostActions') and idx < len(self._hostActions):
+                        self._hostActions[idx][1](self.session)
+                except Exception:
+                    printExc()
+
+    def deleteFavouriteItem(self, confirmed=False):
+        printDBG("E2iPlayerWidget.deleteFavouriteItem")
+        if confirmed is False:
+            return
+
+        if self.visible and not self.isInWorkThread() and 'favourites' == self.hostName:
+            currSelIndex = self.getSelIndex()
+            if currSelIndex < 0:
+                return
+
+            groupId = self.favouritesCurrentGroupId
+            printDBG("deleteFavouriteItem groupId[%s] currSelIndex[%d]" % (groupId, currSelIndex))
+
+            try:
+                helper = IPTVFavourites(GetFavouritesDir())
+                if not helper.load():
+                    self.session.open(MessageBox, _('Error loading favorites.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                groups = helper.getGroups()
+
+                def _norm(txt):
+                    try:
+                        txt = str(txt).strip().lower()
+                    except Exception:
+                        return ''
+                    txt = txt.replace('_', ' ')
+                    txt = ' '.join(txt.split())
+                    return txt
+
+                if not groupId:
+                    selItem = self.getSelItem()
+                    selTitle = ''
+                    try:
+                        selTitle = selItem.name
+                    except Exception:
+                        printExc()
+
+                    groupIdx = -1
+                    for idx in range(len(groups)):
+                        group = groups[idx]
+                        if not isinstance(group, dict):
+                            continue
+                        if group.get('title', '') == selTitle or _norm(group.get('title', '')) == _norm(selTitle):
+                            groupId = group.get('group_id', '')
+                            groupIdx = idx
+                            break
+
+                    if not groupId or groupIdx < 0:
+                        self.session.open(MessageBox, _('Favorite group not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                        return
+
+                    if not helper.delGroup(groupId):
+                        self.session.open(MessageBox, helper.getLastError(), type=MessageBox.TYPE_ERROR, timeout=5)
+                        return
+
+                    if not helper.save():
+                        self.session.open(MessageBox, _('Error saving favorites.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                        return
+
+                    # the active host object (Favourites in hostfavourites.py) keeps its own
+                    # helper instance loaded once at entry - reload it too, otherwise it still
+                    # shows the old state after leaving/re-entering the screen (getPrevList()
+                    # only pops a cached list, it never re-reads from disk)
+                    try:
+                        if hasattr(self.host, 'host') and hasattr(self.host.host, 'helper'):
+                            self.host.host.helper.load()
+                    except Exception:
+                        printExc()
+
+                    del self.currList[currSelIndex]
+                    self["list"].setList([(x,) for x in self.currList])
+
+                    if len(self.currList) <= currSelIndex:
+                        currSelIndex = len(self.currList) - 1
+                    if currSelIndex >= 0:
+                        self["list"].moveToIndex(currSelIndex)
+
+                    self.changeBottomPanel()
+                    self.updateDownloadButton()
+                    return
+
+                realGroupId = ''
+                for group in groups:
+                    if not isinstance(group, dict):
+                        continue
+
+                    tmpGroupId = group.get('group_id', '')
+                    tmpTitle = group.get('title', '')
+
+                    if tmpGroupId == groupId:
+                        realGroupId = tmpGroupId
+                        break
+                    if tmpTitle == groupId:
+                        realGroupId = tmpGroupId
+                        break
+                    if _norm(tmpTitle) == _norm(groupId):
+                        realGroupId = tmpGroupId
+                        break
+                    if _norm(tmpGroupId) == _norm(groupId):
+                        realGroupId = tmpGroupId
+                        break
+
+                if not realGroupId:
+                    self.session.open(MessageBox, _('Favorite group not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                sts, groupItems = helper.getGroupItems(realGroupId)
+                if not sts:
+                    self.session.open(MessageBox, _('Favorite group not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                if currSelIndex >= len(groupItems):
+                    self.session.open(MessageBox, _('Favorite item not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                helper.delGroupItem(currSelIndex, realGroupId)
+
+                if not helper.save():
+                    self.session.open(MessageBox, _('Error saving favorites.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                # see comment above - keep the host's helper state in sync with the file
+                try:
+                    if hasattr(self.host, 'host') and hasattr(self.host.host, 'helper'):
+                        self.host.host.helper.load()
+                except Exception:
+                    printExc()
+
+                del self.currList[currSelIndex]
+                self["list"].setList([(x,) for x in self.currList])
+
+                if len(self.currList) <= currSelIndex:
+                    currSelIndex = len(self.currList) - 1
+                if currSelIndex >= 0:
+                    self["list"].moveToIndex(currSelIndex)
+
+                self.changeBottomPanel()
+                self.updateDownloadButton()
+            except Exception:
+                printExc()
+                self.session.open(MessageBox, _('Error deleting favorite item.'), type=MessageBox.TYPE_ERROR, timeout=5)
+
+    def editFavouritesCallback(self, ret=False):
+        if ret and 'favourites' == self.hostName:  # we must reload host
+            self.loadHost()
+
+    def setActiveMoviePlayer(self, ret):
+        if not isinstance(ret, IPTVChoiceBoxItem):
+            return
+        self.activePlayer.set(ret.privateData)
+
+    def runIPTVDM(self, callback=None):
+        global gDownloadManager
+        if None is not gDownloadManager:
+            from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdmui import IPTVDMWidget
+            if None is callback:
+                self.session.open(IPTVDMWidget, gDownloadManager)
+            else:
+                self.session.openWithCallback(callback, IPTVDMWidget, gDownloadManager)
+        elif None is not callback:
+            callback()
+        return
+
+    def displayIcon(self, ret=None, doDecodeCover=False):
+        # check if displays icon is enabled in options
+        if not config.plugins.iptvplayer.showcover.value or None is self.iconMenager:
+            return
+
+        selItem = self.getSelItem()
+        # when ret is != None the method is called from IconMenager
+        # and in this variable the url for icon which was downloaded
+        # is returned
+        # if icon for other than selected item has been downloaded
+        # the displayed icon will not be changed
+        if ret is not None and selItem is not None and ret != selItem.iconimage:
+            return
+
+        # Display icon
+        if selItem and '' != selItem.iconimage:
+            self.iconMenager.addToDQueue([selItem.iconimage])
+            # check if we have this icon and get the path to this icon on disk
+            iconPath = self.iconMenager.getIconPathFromAAueue(selItem.iconimage)
+            printDBG('displayIcon -> getIconPathFromAAueue: %s' % selItem.iconimage)
+            if '' != iconPath and not self["cover"].checkDecodeNeeded(iconPath):
+                self["cover"].show()
+                return
+            else:
+                if doDecodeCover:
+                    self["cover"].decodeCover(iconPath, self.updateCover, "cover")
+                else:
+                    self.decodeCoverTimer.start(self.decodeCoverTimer_interval, True)
+        self["cover"].hide()
+
+    def doStartCoverDecode(self):
+        if self.decodeCoverTimer:
+            self.displayIcon(None, doDecodeCover=True)
+
+    def updateCover(self, retDict):
+        # retDict - return dictionary  {Ident, Pixmap, FileName, Changed}
+        printDBG('updateCover')
+        if retDict:
+            printDBG("updateCover retDict for Ident: %s " % retDict["Ident"])
+            updateIcon = False
+            if 'cover' == retDict["Ident"]:
+                # check if we have icon for right item on list
+                selItem = self.getSelItem()
+                if selItem and '' != selItem.iconimage:
+                    # check if we have this icon and get the path to this icon on disk
+                    iconPath = self.iconMenager.getIconPathFromAAueue(selItem.iconimage)
+
+                    if iconPath == retDict["FileName"]:
+                        # now we are sure that we have right icon
+                        updateIcon = True
+                        self.decodeCoverTimer_interval = 100
+                    else:
+                        self.decodeCoverTimer_interval = 1000
+            else:
+                updateIcon = True
+            if updateIcon:
+                if None is not retDict["Pixmap"]:
+                    self[retDict["Ident"]].updatePixmap(retDict["Pixmap"], retDict["FileName"])
+                    self[retDict["Ident"]].show()
+                else:
+                    self[retDict["Ident"]].hide()
+        else:
+            printDBG("updateCover retDict empty")
+    # end updateCover(self, retDict):
+
+    def changeBottomPanel(self):
+        self.displayIcon()
+        selItem = self.getSelItem()
+        if selItem and selItem.description != '':
+            data = selItem.description
+            sData = data.replace('\n', '')
+            sData = data.replace('[/br]', '\n')
+            self["console"].setText(sData)
+        else:
+            self["console"].setText('')
+
+    def onSelectionChanged(self):
+        self.updateDownloadButton()
+        self.changeBottomPanel()
+        self._rememberHistorySelection()
+
+    def back_pressed(self):
+        if self.stopAutoPlaySequencer() and self.autoPlaySeqTimerValue:
+            return
+        try:
+            if self.isInWorkThread():
+                if self.workThread.kill():
+                    self.workThread = None
+                    self.setStatusTex(_("Operation aborted!"))
+                return
+        except Exception:
+            return
+        if self.visible:
+            if len(self.prevSelList) > 0:
+                self.nextSelIndex = self.prevSelList.pop()
+                self.categoryList.pop()
+                if 'favourites' == self.hostName and len(self.categoryList) == 0:
+                    self.favouritesCurrentGroupId = ''
+                printDBG("back_pressed prev sel index %s" % self.nextSelIndex)
+                self.requestListFromHost('Previous')
+            else:
+                # There is no prev categories, so exit
+                # self.close()
+                if self.group is None:
+                    self.selectHost()
+                else:
+                    self.selectHostFromGroup()
+        else:
+            self.showWindow()
+    # end back_pressed(self):
+
+    def info_pressed(self):
+        printDBG('info_pressed')
+        if self.visible and not self.isInWorkThread():
+            try:
+                item = self.getSelItem()
+            except Exception:
+                printExc()
+                item = None
+            if None is not item:
+                self.stopAutoPlaySequencer()
+                self.currSelIndex = currSelIndex = self["list"].getCurrentIndex()
+                self.requestListFromHost('ForArticleContent', currSelIndex)
+    # end info_pressed(self):
+
+    def isSearchHistoryList(self):
+        """True only for the actual list of past search entries, not the
+        Search category menu (which also contains one TYPE_SEARCH_HISTORY
+        item - the link that navigates into that list)."""
+        try:
+            if not self.currList:
+                return False
+
+            hasHistoryEntry = False
+            for item in self.currList:
+                itemType = getattr(item, 'type', None)
+                if itemType == CDisplayListItem.TYPE_SEARCH:
+                    # the Search category menu always has exactly one such
+                    # item; the actual history-entries list never does
+                    return False
+                if itemType == CDisplayListItem.TYPE_SEARCH_HISTORY:
+                    hasHistoryEntry = True
+            return hasHistoryEntry
+        except Exception:
+            printExc()
+
+        return False
+
+    def _rememberHistorySelection(self):
+        # global (not per-host) memory of the last selected search-history
+        # entry, restored by _restoreHistorySelection() in reloadList() so
+        # reopening the history list lands back on it instead of index 0.
+        # Skipped while a list is being (re)loaded, since moveToIndex() below
+        # fires this same callback and would otherwise overwrite the value
+        # we are about to restore with whatever index/name it lands on first.
+        try:
+            if not config.plugins.iptvplayer.rememberHistorySelection.value:
+                return
+            if self._isLoadingList or not self.isSearchHistoryList():
+                return
+            item = self.getSelItem()
+            name = getattr(item, 'name', None) if item is not None else None
+            if name:
+                self._lastHistorySelection = name
+        except Exception:
+            printExc()
+
+    def _restoreHistorySelection(self):
+        # name-based, not index-based: new searches insert at the front of
+        # the history list and shift every existing entry's index
+        try:
+            if not config.plugins.iptvplayer.rememberHistorySelection.value:
+                return
+            if not self.isSearchHistoryList():
+                return
+            wanted = self._lastHistorySelection
+            if not wanted:
+                return
+            for idx, it in enumerate(self.currList):
+                if getattr(it, 'name', None) == wanted:
+                    self["list"].moveToIndex(idx)
+                    break
+        except Exception:
+            printExc()
+
+    def keyT9Jump(self, digit):
+        # single global switch for the whole T9 letter-jump feature (this
+        # method's search-history AND main-list branch alike, plus the
+        # independent keyNumberJump() copies in iptvfavouriteswidgets.py and
+        # searchhistoryeditor.py) - off restores plain keyT9_1/4/8 fallback
+        # behaviour (ok_pressed1/4, startAutoPlaySequencer) everywhere
+        if not config.plugins.iptvplayer.enableT9MainList.value:
+            return False
+
+        # search-history list: every digit press is consumed by the T9 jump
+        # (always returns True), digits have no other meaning in this list
+        if self.isSearchHistoryList():
+            letter = self.t9HistoryInput.getKey(int(digit))
+            if not letter:
+                return True
+
+            try:
+                currentIdx = self['list'].getCurrentIndex()
+                idx = findT9JumpIndex(len(self.currList), currentIdx, letter, lambda i: getattr(self.currList[i], 'name', ''))
+                if idx >= 0:
+                    self['list'].moveToIndex(idx)
+                    printDBG('T9 history jump key[%s] letter[%s] index[%d]' % (digit, letter, idx))
+                else:
+                    printDBG('T9 history jump key[%s] letter[%s] no match' % (digit, letter))
+            except Exception:
+                printExc()
+
+            return True
+
+        # any other list (main menu, categories, series, favourites, ...):
+        # only intercept the digit when it actually produced a jump, so
+        # keyT9_1/4/8's secondary binding (ok_pressed1/4, startAutoPlaySequencer)
+        # still fires normally when there is no match
+        if not self.currList:
+            return False
+
+        try:
+            letter = self.t9MainListInput.getKey(int(digit))
+            if not letter:
+                return True
+
+            currentIdx = self['list'].getCurrentIndex()
+            idx = findT9JumpIndex(len(self.currList), currentIdx, letter, lambda i: getattr(self.currList[i], 'name', ''))
+            if idx >= 0:
+                self['list'].moveToIndex(idx)
+                printDBG('T9 main list jump key[%s] letter[%s] index[%d]' % (digit, letter, idx))
+                return True
+            printDBG('T9 main list jump key[%s] letter[%s] no match' % (digit, letter))
+            return False
+        except Exception:
+            printExc()
+            return False
+
+    def keyT9_1(self):
+        if not self.keyT9Jump('1'):
+            self.ok_pressed1()
+
+    def keyT9_2(self):
+        if not self.keyT9Jump('2'):
+            self.ok_pressed2()
+
+    def keyT9_3(self):
+        if not self.keyT9Jump('3'):
+            self.ok_pressed3()
+
+    def keyT9_4(self):
+        if not self.keyT9Jump('4'):
+            self.ok_pressed4()
+
+    def keyT9_5(self):
+        self.keyT9Jump('5')
+
+    def keyT9_6(self):
+        self.keyT9Jump('6')
+
+    def keyT9_7(self):
+        self.keyT9Jump('7')
+
+    def keyT9_8(self):
+        if not self.keyT9Jump('8'):
+            self.startAutoPlaySequencer()
+
+    def keyT9_9(self):
+        self.keyT9Jump('9')
+
+    def ok_pressed0(self):
+        self.activePlayer.set({})
+        self.ok_pressed(useAlternativePlayer=False)
+
+    def ok_pressed1(self):
+        player = self.getMoviePlayer(True, False)
+        self.activePlayer.set({'buffering': True, 'player': player})
+        self.ok_pressed(useAlternativePlayer=True)
+
+    def ok_pressed2(self):
+        player = self.getMoviePlayer(True, True)
+        self.activePlayer.set({'buffering': True, 'player': player})
+        self.ok_pressed(useAlternativePlayer=True)
+
+    def ok_pressed3(self):
+        player = self.getMoviePlayer(False, False)
+        self.activePlayer.set({'buffering': False, 'player': player})
+        self.ok_pressed(useAlternativePlayer=False)
+
+    def ok_pressed4(self):
+        player = self.getMoviePlayer(False, True)
+        self.activePlayer.set({'buffering': False, 'player': player})
+        self.ok_pressed(useAlternativePlayer=True)
+
+    def ok_pressed(self, eventFrom='remote', useAlternativePlayer=False):
+        self.useAlternativePlayer = useAlternativePlayer
+        if eventFrom != 'green':
+            self.recorderMode = False
+
+        if 'sequencer' != eventFrom:
+            self.stopAutoPlaySequencer()
+
+        if self.visible or 'sequencer' == eventFrom:
+            sel = None
+            try:
+                if len(self.currList) > 0 and (not self["list"].getVisible() and 'sequencer' != eventFrom):
+                    printDBG("ok_pressed -> ignored /\\")
+                    return
+            except Exception:
+                printExc()
+
+            try:
+                sel = self["list"].l.getCurrentSelection()[0]
+            except Exception:
+                printExc()
+                self.getRefreshedCurrList()
+                return
+            if sel is None:
+                printDBG("ok_pressed sel is None")
+                self.stopAutoPlaySequencer()
+                self.getInitialList()
+                return
+            elif len(self.currList) <= 0:
+                printDBG("ok_pressed list is empty")
+                self.stopAutoPlaySequencer()
+                self.getRefreshedCurrList()
+                return
+            else:
+                printDBG("ok_pressed selected item: %s" % (sel.name))
+
+                item = self.getSelItem()
+                self.currItem = item
+
+                # Get current selection
+                currSelIndex = self["list"].getCurrentIndex()
+                # remember only prev categories
+                if item.type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO, CDisplayListItem.TYPE_PICTURE, CDisplayListItem.TYPE_DATA]:
+                    if CDisplayListItem.TYPE_AUDIO == item.type:
+                        self.bufferSize = config.plugins.iptvplayer.requestedAudioBuffSize.value * 1024
+                    else:
+                        self.bufferSize = config.plugins.iptvplayer.requestedBuffSize.value * 1024 * 1024
+                    # check if separete host request is needed to get links to VIDEO
+                    if item.urlSeparateRequest == 1:
+                        printDBG("ok_pressed selected TYPE_VIDEO.urlSeparateRequest")
+                        self.requestListFromHost('ForVideoLinks', currSelIndex)
+                    else:
+                        printDBG("ok_pressed selected TYPE_VIDEO.selectLinkForCurrVideo")
+                        self.selectLinkForCurrVideo()
+                elif item.type == CDisplayListItem.TYPE_SEARCH_HISTORY_DELETE:
+                    printDBG("ok_pressed selected TYPE_SEARCH_HISTORY_DELETE")
+                    self.host.host.delHistory(self.session)
+                elif item.type in [CDisplayListItem.TYPE_CATEGORY, CDisplayListItem.TYPE_SEARCH_HISTORY, CDisplayListItem.TYPE_SEARCH_HISTORY_EDITOR, CDisplayListItem.TYPE_NEXT, CDisplayListItem.TYPE_JUMP, CDisplayListItem.TYPE_FIRST, CDisplayListItem.TYPE_PREVIOUS, CDisplayListItem.TYPE_LAST]:
+                    printDBG("ok_pressed selected TYPE_CATEGORY")
+                    self.stopAutoPlaySequencer()
+                    self.currSelIndex = currSelIndex
+                    if 'favourites' == self.hostName and len(self.categoryList) == 0:
+                        try:
+                            self.favouritesCurrentGroupId = ''
+                            try:
+                                groupTitle = item.name
+                            except Exception:
+                                groupTitle = ''
+
+                            if groupTitle:
+                                self.favouritesCurrentGroupId = groupTitle.strip().lower()
+
+                            printDBG("ok_pressed favouritesCurrentGroupId[%s]" % self.favouritesCurrentGroupId)
+                        except Exception:
+                            printExc()
+
+                    if item.pinLocked:
+                        from Plugins.Extensions.IPTVPlayer.components.iptvpin import IPTVPinWidget
+                        self.session.openWithCallback(boundFunction(self.checkDirPin, self.requestListFromHost, 'ForItem', currSelIndex, '', item.pinCode), IPTVPinWidget, title=_("Enter pin"))
+                    else:
+                        self.requestListFromHost('ForItem', currSelIndex, '')
+                elif item.type == CDisplayListItem.TYPE_MORE:
+                    printDBG("ok_pressed selected TYPE_MORE")
+                    self.currSelIndex = currSelIndex
+                    self.requestListFromHost('ForMore', currSelIndex, '')
+                elif item.type == CDisplayListItem.TYPE_ARTICLE:
+                    printDBG("ok_pressed selected TYPE_ARTICLE")
+                    self.info_pressed()
+                elif item.type == CDisplayListItem.TYPE_SEARCH:
+                    printDBG("ok_pressed selected TYPE_SEARCH")
+                    self.stopAutoPlaySequencer()
+                    self.currSelIndex = currSelIndex
+                    self.startSearchProcedure(item.possibleTypesOfSearch)
+        else:
+            self.showWindow()
+    # end ok_pressed(self):
+
+    def pageup_pressed(self):
+        self.stopAutoPlaySequencer()
+        if self.visible and self.prevSelList and self.prevSelList[-1]:
+            self.nextSelIndex = self.prevSelList.pop() - len(self.currList)
+            self.categoryList.pop()
+            printDBG(f"back_pressed prev sel index {self.nextSelIndex}")
+            self.requestListFromHost('Previous')
+
+    def pagedown_pressed(self):
+        self.stopAutoPlaySequencer()
+        if self.visible:
+            try:
+                if len(self.currList) > 0 and (not self["list"].getVisible()):
+                    printDBG("pagedown_pressed -> ignored /\\")
+                    return
+            except Exception:
+                printExc()
+
+            if self.currList:
+                lastItem = self.currList[-1]
+                if lastItem.type == CDisplayListItem.TYPE_NEXT:
+                    self.currSelIndex = len(self.currList) - 1
+                    self.requestListFromHost('ForItem', self.currSelIndex, '')
+
+    def checkDirPin(self, callbackFun, arg1, arg2, arg3, pinCode, pin=None):
+        if pin is not None:
+            if 4 != len(pinCode):
+                pinCode = config.plugins.iptvplayer.pin.value  # use default pin code if custom has wrong length
+            if pin == pinCode:
+                callbackFun(arg1, arg2, arg3)
+            else:
+                self.session.open(MessageBox, _("Pin incorrect!"), type=MessageBox.TYPE_INFO, timeout=5)
+
+    def leaveArticleView(self):
+        printDBG("leaveArticleView")
+        pass
+
+    def showArticleContent(self, ret):
+        printDBG("showArticleContent")
+        self.setStatusTex("")
+        self["list"].show()
+
+        artItem = None
+        if ret.status != RetHost.OK or 0 == len(ret.value):
+            item = self.currList[self.currSelIndex]
+            if len(item.description):
+                artItem = ArticleContent(title=item.name, text=item.description, images=[{'title': 'Fot.', 'url': item.iconimage}])  # richDescParams={"alternate_title":"***alternate_title", "year":"year", "rating":"rating",  "duration":"duration",  "genre":"genre",  "director":"director",  "actors":"actors",  "awards":"awards"}
+        else:
+            artItem = ret.value[0]
+        if None is not artItem:
+            self.session.openWithCallback(self.leaveArticleView, IPTVArticleView, artItem, {'buffering_path': config.plugins.iptvplayer.bufferingPath.value, 'host_name': self.hostName, 'logo_path': self.hostLogoPath, 'download_dir': self.iconMenager.currDownloadDir})
+
+    def selectMainVideoLinks(self, ret):
+        printDBG("selectMainVideoLinks")
+        self.setStatusTex("")
+        self["list"].show()
+
+        # ToDo: check ret.status if not OK do something :P
+        if ret.status != RetHost.OK:
+            printDBG("++++++++++++++++++++++ selectHostVideoLinksCallback ret.status = %s" % ret.status)
+        else:
+            # update links in List
+            currSelIndex = self.getSelIndex()
+            if -1 == currSelIndex:
+                return
+            self.currList[currSelIndex].urlItems = ret.value
+        self.selectLinkForCurrVideo()
+    # end selectMainVideoLinks(self, ret):
+
+    def selectResolvedVideoLinks(self, ret):
+        printDBG("selectResolvedVideoLinks")
+        self.setStatusTex("")
+        self["list"].show()
+        linkList = []
+        if ret.status == RetHost.OK and isinstance(ret.value, list):
+            for item in ret.value:
+                if isinstance(item, CUrlItem):
+                    item.urlNeedsResolve = 0  # protection from recursion
+                    linkList.append(item)
+                elif isinstance(item, str):
+                    linkList.append(CUrlItem(item, item, 0))
+                else:
+                    printExc("selectResolvedVideoLinks: wrong resolved url type!")
+        else:
+            printExc()
+
+        resolvingLink = self._resolvingLinkItem
+        self._resolvingLinkItem = None
+        # only reopen the picker on failure when there was genuinely a choice of
+        # several mirrors to begin with - for a single mirror (or the non-interactive
+        # autoplay sequencer, which always auto-picks the first one) reopening would
+        # just re-select and re-resolve the very same failing link again
+        if (0 == len(linkList) and resolvingLink is not None and self._currentLinkOptions is not None and
+                len(self._currentLinkOptions) > 1 and not self.autoPlaySeqStarted):
+            # resolving this particular mirror failed - mark it, tell the user, then
+            # reopen the full mirror list (instead of dead-ending on "no valid links")
+            # so they can see it highlighted and try another one
+            resolvingLink.failed = True
+            message = _("No valid links available.")
+            lastErrorMsg = GetIPTVPlayerLastHostError()
+            if '' != lastErrorMsg:
+                message += "\n" + _('Last error: "%s"') % lastErrorMsg
+            self.session.openWithCallback(self._reopenLinkPickerAfterFailure, MessageBox, message, type=MessageBox.TYPE_INFO, timeout=10)
+            return
+        self.selectLinkForCurrVideo(linkList)
+
+    def _reopenLinkPickerAfterFailure(self, ret=None):
+        self.selectLinkForCurrVideo(self._currentLinkOptions)
+
+    def getSelIndex(self):
+        currSelIndex = self["list"].getCurrentIndex()
+        if len(self.currList) > currSelIndex:
+            return currSelIndex
+        return -1
+
+    def getSelItem(self):
+        currSelIndex = self["list"].getCurrentIndex()
+        if len(self.currList) <= currSelIndex:
+            printDBG("ERROR: getSelItem there is no item with index: %d, listOfItems.len: %d" % (currSelIndex, len(self.currList)))
+            return None
+        return self.currList[currSelIndex]
+
+    def getSelectedItem(self):
+        sel = None
+        try:
+            sel = self["list"].l.getCurrentSelection()[0]
+        except Exception:
+            return None
+        return sel
+
+    def onStart(self):
+        self.onShow.remove(self.onStart)
+        # self.onLayoutFinish.remove(self.onStart)
+        self.setTitle('E2iPlayer ' + GetIPTVPlayerVersion())
+        self.loadSpinner()
+        self.hideSpinner()
+        self.selectHost()
+
+    def selectHost(self, arg1=None):
+        printDBG(">> selectHost")
+        # self.groupObj = None
+        self.groupDisplayName = None
+        self.group = None
+        self.host = None
+        self.hostName = ''
+        self.nextSelIndex = 0
+        self.prevSelList = []
+        self.categoryList = []
+        self.currList = []
+        self.currItem = CDisplayListItem()
+
+        if (config.plugins.iptvplayer.group_hosts.value is False or 0 == GetAvailableIconSize()):
+            self.selectHostFromSingleList()
+        else:
+            self.selectGroup()
+
+    def selectGroup(self):
+        printDBG(">> selectGroup")
+        self.groupObj = IPTVHostsGroups()
+        self.displayGroupsList = []
+        groupsList = self.groupObj.getGroupsList()
+        for item in groupsList:
+            self.displayGroupsList.append((item.title, item.name))
+        if not GRIDSUPPORT:
+            self.displayGroupsList.append((_('All'), 'all'))
+            self.displayGroupsList.append((_("Configuration"), "config"))
+
+        self.newDisplayGroupsList = []
+        self.session.openWithCallback(self.selectGroupCallback, PlayerSelectorWidget, inList=self.displayGroupsList, outList=self.newDisplayGroupsList, numOfLockedItems=self.getNumOfSpecialItems(self.displayGroupsList), groupName='selectgroup')
+
+    def selectGroupCallback(self, ret):
+        printDBG(">> selectGroupCallback")
+        # save groups order if user change it at player selection
+        if self.newDisplayGroupsList != self.displayGroupsList:
+            numOfSpecialItems = self.getNumOfSpecialItems(self.newDisplayGroupsList)
+            groupList = []
+            for idx in range(len(self.newDisplayGroupsList) - numOfSpecialItems):
+                groupList.append(self.newDisplayGroupsList[idx][1])
+            self.groupObj.setGroupList(groupList)
+
+        self.selectItemCallback(ret, 'selectgroup')
+
+    def selectHostFromGroup(self):
+        printDBG(">> selectHostFromGroup")
+        self.host = None
+        self.hostName = ''
+        self.nextSelIndex = 0
+        self.prevSelList = []
+        self.categoryList = []
+        self.currList = []
+        self.currItem = CDisplayListItem()
+
+        self.displayHostsList = []
+        if self.group != 'all':
+            hostsList = self.groupObj.getHostsList(self.group)
+        else:
+            hostsList = []
+            sortedList = SortHostsList(GetHostsList(fromList=False, fromHostFolder=True))
+            for hostName in sortedList:
+                if IsHostEnabled(hostName):
+                    hostsList.append(hostName)
+
+        brokenHostList = []
+        for hostName in hostsList:
+            if hostName == "localmedia":
+                title = _("LocalMedia")
+            elif hostName == "favourites":
+                title = _("Favorites")
+            else:
+                try:
+                    _temp = __import__('Plugins.Extensions.IPTVPlayer.hosts.host' + hostName, globals(), locals(), ['gettytul'], 0)
+                    title = _temp.gettytul()
+                except Exception:
+                    printExc('get host name exception for host "%s"' % hostName)
+                    brokenHostList.append('host' + hostName)
+                    continue
+            self.displayHostsList.append((title, hostName))
+
+        # if there is no order hosts list use old behavior for all group
+        if self.group == 'all' and 0 == len(GetHostsOrderList()):
+            try:
+                self.displayHostsList.sort(key=lambda t: tuple(str(t[1]).lower()))
+            except Exception:
+                self.displayHostsList.sort()
+
+        # prepare info message when some host or update cannot be used
+        errorMessage = ""
+        if len(brokenHostList) > 0:
+            errorMessage = _("Following host are broken or additional python modules are needed.") + '\n' + '\n'.join(brokenHostList)
+
+        if "" != errorMessage and True is self.showHostsErrorMessage:
+            self.showHostsErrorMessage = False
+            self.session.openWithCallback(self.displayListOfHostsFromGroup, MessageBox, errorMessage, type=MessageBox.TYPE_INFO, timeout=10)
+        else:
+            self.displayListOfHostsFromGroup()
+        return
+
+    def displayListOfHostsFromGroup(self, arg=None):
+        printDBG(">> displayListOfHostsFromGroup")
+        self.newDisplayHostsList = []
+        if len(self.displayHostsList):
+            self.session.openWithCallback(self.selectHostFromGroupCallback, PlayerSelectorWidget, inList=self.displayHostsList, outList=self.newDisplayHostsList, numOfLockedItems=0, groupName=self.group, groupObj=self.groupObj, groupDisplayName=self.groupDisplayName)
+        else:
+            msg = _('There is no hosts in this group.')
+            self.session.openWithCallback(self.selectHost, MessageBox, msg, type=MessageBox.TYPE_INFO, timeout=10)
+
+    def selectHostFromGroupCallback(self, ret):
+        printDBG(">> selectHostFromGroupCallback")
+
+        # save hosts order if user change it at player selection
+        if self.newDisplayHostsList != self.displayHostsList:
+            hostsList = []
+            for idx in range(len(self.newDisplayHostsList)):
+                hostsList.append(self.newDisplayHostsList[idx][1])
+            if self.group != 'all':
+                self.groupObj.setHostsList(self.group, hostsList)
+            else:
+                SaveHostsOrderList(hostsList)
+        self.groupObj.flushAddedHosts()
+        self.selectItemCallback(ret, 'selecthostfromgroup')
+
+    def selectHostFromSingleList(self):
+        self.displayHostsList = []
+        sortedList = SortHostsList(GetHostsList(fromList=False, fromHostFolder=True))
+        brokenHostList = []
+        for hostName in sortedList:
+            if IsHostEnabled(hostName):
+                try:
+                    _temp = __import__('Plugins.Extensions.IPTVPlayer.hosts.host' + hostName, globals(), locals(), ['gettytul'], 0)
+                    title = _temp.gettytul()
+                except Exception:
+                    printExc('get host name exception for host "%s"' % hostName)
+                    brokenHostList.append('host' + hostName)
+                    continue
+
+                # The 'http...' in host titles is annoying on regular choiceBox and impacts sorting.
+                # To simplify choiceBox usage and clearly show service is a webpage, list is build using the "<service name> (<service URL>)" schema.
+                """
+                if (config.plugins.iptvplayer.ListaGraficzna.value is False or 0 == GetAvailableIconSize()) and title[:4] == 'http':
+                    try:
+                        title = ('%s   (%s)') % ('.'.join(title.replace('://', '.').replace('www.', '').split('.')[1:-1]), title)
+                    except Exception:
+                        pass
+                """
+                self.displayHostsList.append((title, hostName))
+        # if there is no order hosts list use old behavior
+        if 0 == len(GetHostsOrderList()):
+            try:
+                self.displayHostsList.sort(key=lambda t: tuple(str(t[0]).lower()))
+            except Exception:
+                self.displayHostsList.sort()
+        if not GRIDSUPPORT:
+            self.displayHostsList.append((_("Configuration"), "config"))
+
+        # prepare info message when some host or update cannot be used
+        errorMessage = ""
+        if len(brokenHostList) > 0:
+            errorMessage = _("Following host are broken or additional python modules are needed.") + '\n' + '\n'.join(brokenHostList)
+
+        if "" != errorMessage and True is self.showHostsErrorMessage:
+            self.showHostsErrorMessage = False
+            self.session.openWithCallback(self.displayListOfHosts, MessageBox, errorMessage, type=MessageBox.TYPE_INFO, timeout=10)
+        else:
+            self.displayListOfHosts()
+        return
+
+    def displayListOfHosts(self, arg=None):
+        """
+        if config.plugins.iptvplayer.ListaGraficzna.value is False or 0 == GetAvailableIconSize():
+            self.newDisplayHostsList = None
+            self.session.openWithCallback(self.selectHostCallback, ChoiceBox, title=_("Select service"), list=self.displayHostsList)
+        else:
+        """
+        self.newDisplayHostsList = []
+        self.session.openWithCallback(self.selectHostCallback, PlayerSelectorWidget, inList=self.displayHostsList, outList=self.newDisplayHostsList, numOfLockedItems=self.getNumOfSpecialItems(self.displayHostsList), groupName='selecthost')
+
+    def getNumOfSpecialItems(self, inList, filters=['config', 'all']):
+        if GRIDSUPPORT:
+            return 0
+        numOfSpecialItems = 0
+        for item in inList:
+            if item[1] in filters:
+                numOfSpecialItems += 1
+        return numOfSpecialItems
+
+    def selectHostCallback(self, ret):
+        printDBG(">> selectHostCallback")
+        # save hosts order if user change it at player selection
+        if self.newDisplayHostsList is not None and self.newDisplayHostsList != self.displayHostsList:
+            numOfSpecialItems = self.getNumOfSpecialItems(self.newDisplayHostsList)
+            hostsList = []
+            for idx in range(len(self.newDisplayHostsList) - numOfSpecialItems):
+                hostsList.append(self.newDisplayHostsList[idx][1])
+            SaveHostsOrderList(hostsList)
+
+        self.selectHostCallback2(ret)
+
+    def selectHostCallback2(self, ret):
+        printDBG(">> selectHostCallback2")
+        self.selectItemCallback(ret, 'selecthost')
+
+    def selectItemCallback(self, ret, type):
+        printDBG(">> selectItemCallback ret[%s] type[%s]" % (ret, type))
+        hasIcon = False
+        nextFunction = None
+        prevFunction = None
+        protectedByPin = False
+        if ret:
+            if ret[1] == "config":
+                nextFunction = self.runConfig
+                prevFunction = self.selectHost
+                protectedByPin = config.plugins.iptvplayer.configProtectedByPin.value
+            elif ret[1] == "reset_group":
+                self.groupObj.resetHostList(ret[2])
+                self.selectHost()
+            elif ret[1] == "config_hosts":
+                nextFunction = self.runConfigHosts
+                if type == 'selecthost':
+                    prevFunction = self.selectHost
+                else:
+                    prevFunction = self.selectHostFromGroup
+                protectedByPin = config.plugins.iptvplayer.configProtectedByPin.value
+            elif ret[1] == "config_groups":
+                nextFunction = self.runConfigGroupsMenu
+                prevFunction = self.selectHost
+                protectedByPin = config.plugins.iptvplayer.configProtectedByPin.value
+            elif ret[1] == "IPTVDM":
+                if type in ['selecthost', 'selectgroup']:
+                    self.runIPTVDM(self.selectHost)
+                elif type == 'selecthostfromgroup':
+                    self.runIPTVDM(self.selectHostFromGroup)
+                return
+            elif type in ['selecthost', 'selecthostfromgroup']:
+                self.hostTitle = ret[0]
+                self.hostName = ret[1]
+                self.loadHost()
+            elif type == 'selectgroup':
+                self.group = ret[1]
+                self.groupDisplayName = ret[0]
+                self.selectHostFromGroup()
+                return
+
+            if self.showMessageNoFreeSpaceForIcon and hasIcon:
+                self.showMessageNoFreeSpaceForIcon = False
+                self.session.open(MessageBox, (_("There is no free space on the drive [%s].") % config.plugins.iptvplayer.SciezkaCache.value) + "\n" + _("New icons will not be available."), type=MessageBox.TYPE_INFO, timeout=10)
+        elif type in ['selecthost', 'selectgroup']:
+            self.close()
+            return
+        else:
+            self.selectHost()
+            return
+
+        if nextFunction and prevFunction:
+            if True is protectedByPin:
+                from .iptvpin import IPTVPinWidget
+                self.session.openWithCallback(boundFunction(self.checkPin, nextFunction, prevFunction), IPTVPinWidget, title=_("Enter pin"))
+            else:
+                nextFunction()
+
+    def runConfigHosts(self):
+        self.enabledHostsListOld = GetEnabledHostsList()
+        self.session.openWithCallback(self.configHostsCallback, ConfigHostsMenu, GetListOfHostsNames())
+
+    def configHostsCallback(self, arg1=None):
+        if self.group is not None:
+            self.selectHostFromGroup()
+        else:
+            self.selectHost()
+
+    def runConfigGroupsMenu(self):
+        self.session.openWithCallback(self.selectHost, ConfigGroupsMenu)
+
+    def runConfig(self):
+        self.session.openWithCallback(self.configCallback, ConfigMenu)
+
+    def runConfigHostIfAllowed(self):
+        if config.plugins.iptvplayer.configProtectedByPin.value:
+            from .iptvpin import IPTVPinWidget
+            self.session.openWithCallback(boundFunction(self.checkPin, self.runConfigHost, None), IPTVPinWidget, title=_("Enter pin"))
+        else:
+            self.runConfigHost()
+
+    def runConfigHost(self):
+        self.session.openWithCallback(self.runConfigHostCallBack, ConfigHostMenu, hostName=self.hostName)
+
+    def runConfigHostCallBack(self, confgiChanged=False):
+        if confgiChanged:
+            self.loadHost()
+
+    def checkPin(self, callbackFun, failCallBackFun, pin=None):
+        if pin is not None:
+            if pin == config.plugins.iptvplayer.pin.value:
+                callbackFun()
+            else:
+                self.session.openWithCallback(self.close, MessageBox, _("Pin incorrect!"), type=MessageBox.TYPE_INFO, timeout=5)
+        else:
+            if failCallBackFun:
+                failCallBackFun()
+
+    def loadHost(self, ret=None):
+        self.hostFavTypes = []
+        try:
+            _temp = __import__('Plugins.Extensions.IPTVPlayer.hosts.host' + self.hostName, globals(), locals(), ['IPTVHost'], 0)
+            self.host = _temp.IPTVHost()
+            if not isinstance(self.host, IHost):
+                printDBG("Host [%r] does not inherit from IHost" % self.hostName)
+                self.close()
+                return
+        except Exception as e:
+            printExc('Cannot import class IPTVHost for host [%r]' % self.hostName)
+            errorMessage = [_('Loading %s failed due to following error:') % self.hostName]
+            elines = traceback.format_exc().splitlines()
+            errorMessage.append("%s" % '\n'.join(elines[-3:]))
+            self.session.open(MessageBox, '\n'.join(errorMessage), type=MessageBox.TYPE_ERROR, timeout=10)
+            self.setStatusTex(_("Failed: %s") % e)
+            return
+
+        try:
+            protectedByPin = self.host.isProtectedByPinCode()
+        except Exception:
+            protected = False  # should never happen
+
+        if protectedByPin:
+            from .iptvpin import IPTVPinWidget
+            self.session.openWithCallback(boundFunction(self.checkPin, self.loadHostData, self.selectHost), IPTVPinWidget, title=_("Enter pin"))
+        else:
+            self.loadHostData()
+
+    def loadHostData(self):
+        self.session.summary.setText(self.hostName)
+        self.activePlayer = CMoviePlayerPerHost(self.hostName)
+
+        # change logo for player
+        self["playerlogo"].hide()
+        self.session.summary.LCD_hide('LCDlogo')
+        self.hostLogoPath = None
+        try:
+            hRet = self.host.getLogoPath()
+            if hRet.status == RetHost.OK and len(hRet.value):
+                logoPath = hRet.value[0]
+                if logoPath != '':
+                    printDBG('Logo Path: ' + logoPath)
+                    self.hostLogoPath = logoPath
+                    if not self["playerlogo"].checkDecodeNeeded(logoPath):
+                        self["playerlogo"].show()
+                    else:
+                        self["playerlogo"].decodeCover(logoPath, self.updateCover, "playerlogo")
+                    self.session.summary.LCD_showPic('LCDlogo', logoPath)
+        except Exception:
+            printExc()
+
+        # get types of items which can be added as favourites
+        self.hostFavTypes = []
+        try:
+            hRet = self.host.getSupportedFavoritesTypes()
+            if hRet.status == RetHost.OK:
+                self.hostFavTypes = hRet.value
+        except Exception:
+            printExc('The current host crashed')
+
+        # request initial list from host
+        self.getInitialList()
+    # end selectHostCallback(self, ret):
+
+    def selectLinkForCurrVideo(self, customUrlItems=None):
+        if not self.visible and not (self.autoPlaySeqStarted and
+           config.plugins.iptvplayer.autoplay_start_delay.value == 0):
+            self.setStatusTex("")
+            self.showWindow()
+
+        item = self.getSelItem()
+        if item.type not in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO,
+                             CDisplayListItem.TYPE_PICTURE, CDisplayListItem.TYPE_DATA]:
+            printDBG("Incorrect item type[%s]" % item.type)
+            return
+
+        if None is customUrlItems:
+            links = item.urlItems
+        else:
+            links = customUrlItems
+
+        # There is no free links for current video
+        numOfLinks = len(links)
+        if 0 == numOfLinks:
+            self._currentLinkOptions = None
+            if not self.checkAutoPlaySequencer():
+                message = _("No valid links available.")
+                lastErrorMsg = GetIPTVPlayerLastHostError()
+                if '' != lastErrorMsg:
+                    message += "\n" + _('Last error: "%s"') % lastErrorMsg
+                lastExcMSG = getExcMSG(True)
+                if lastExcMSG != '':
+                    message += "\n" + _("Last Exception error: '%s'") % lastExcMSG
+                self.session.open(MessageBox, message, type=MessageBox.TYPE_INFO, timeout=10)
+            return
+        elif 1 == numOfLinks or self.autoPlaySeqStarted:
+            # call manualy selectLinksCallback - start VIDEO without links selection
+            self._currentLinkOptions = links
+            self.selectLinksCallback(IPTVChoiceBoxItem(" ", "", links[0]))  # name of item - not displayed so empty
+            return
+
+        self._currentLinkOptions = links
+        options = []
+        for link in links:
+            printDBG("selectLinkForCurrVideo: |%s| |%s|" % (link.name, link.url))
+            options.append(IPTVChoiceBoxItem(link.name, "", link, failed=link.failed))
+
+        self.session.openWithCallback(self.selectLinksCallback, IPTVChoiceBoxWidget, {'width': 600, 'height': self._getLinkPickerHeight(), 'current_idx': 0, 'title': _("Select link"), 'options': options, 'list_class': IPTVLinkChoiceBoxList})
+
+    # IPTVChoiceBoxWidget's screen declares resolution="1280,720", so the
+    # skin engine already scales width/size per axis to the real screen
+    # (1x HD, 1.5x FHD, 2x WQHD) - this has to be a single reference-space
+    # constant, not stepped up per tier like the old code did, or it gets
+    # scaled twice (which is exactly why WQHD ended up nearly full-screen)
+    MOVIE_PLAYER_PICKER_WIDTH = 550
+
+    def _getMoviePlayerPickerHeight(self, numItems):
+        # same reference-space-vs-real-pixels reasoning as _getLinkPickerHeight,
+        # but using IPTVRadioButtonList's (IPTVMainNavigatorList's) own real
+        # per-tier item heights (35/40/55) instead of guessed constants.
+        # +130 = the footerMargin passed below (120, itself derived from the
+        # list's fixed y=66 + the 48px footer bar) plus a small 10px
+        # breathing buffer - not the keyboard's own +160, which assumes the
+        # chrome default footerMargin (150) instead of this screen's 120
+        screenwidth = getDesktop(0).size().width()
+        if screenwidth >= 2560:
+            itemH, scale = 55, 2.0
+        elif screenwidth >= 1920:
+            itemH, scale = 40, 1.5
+        else:
+            itemH, scale = 35, 1.0
+        return int(numItems * itemH / scale) + 130
+
+    def _getLinkPickerHeight(self):
+        # IPTVChoiceBoxWidget's skin is defined in a fixed 1280x720 reference space
+        # and scaled per-axis to the real screen resolution by the skin engine, so
+        # these are reference-space pixel heights, not real ones. Tuned so HD and
+        # FullHD both show 12 rows before the list starts scrolling (up from ~6/~9
+        # at the previous default of 300), and SD gets a few more rows too.
+        resType = self.getSkinResolutionType()
+        if resType == 'sd':
+            return 370
+        elif resType == 'hd':
+            return 380
+        elif resType == 'hd_ready':
+            return 480
+        return 300
+
+    def selectLinksCallback(self, retArg):
+        if retArg is None:
+            # user cancelled the picker without trying any link - there's nothing
+            # wrong, so don't show a "No valid links" error for it
+            return
+        if isinstance(retArg, IPTVChoiceBoxItem) and isinstance(retArg.privateData, CUrlItem):
+            link = retArg.privateData
+            videoUrl = link.url
+            if isinstance(videoUrl, str) and len(videoUrl) > 3:
+                # check if we need to resolve this URL (strict '1' check, same as the
+                # original ChoiceBox-based code - some hosts store this as a string,
+                # and a plain truthiness check would wrongly treat "0" as needing resolve)
+                if str(link.urlNeedsResolve) == '1':
+                    # call resolve link from host
+                    self._resolvingLinkItem = link
+                    self.requestListFromHost('ResolveURL', -1, videoUrl)
+                else:
+                    list = []
+                    list.append(videoUrl)
+                    self.playVideo(RetHost(status=RetHost.OK, value=list))
+                return
+        self.playVideo(RetHost(status=RetHost.ERROR, value=[]))
+    # end selectLinksCallback(self, retArg):
+
+    def checkBuffering(self, url):
+        # check flag forcing of the using/not using buffering
+        if 'iptv_buffering' in url.meta:
+            if "required" == url.meta['iptv_buffering']:
+                # iptv_buffering was set as required, this is done probably due to
+                # extra http headers needs, at now extgstplayer and exteplayer can handle this headers,
+                # so we skip forcing buffering for such links. at now this is temporary
+                # solution we need to add separate filed iptv_extraheaders_need!
+                if url.startswith("http") and self.getMoviePlayer(False, False).value in ['extgstplayer', 'exteplayer']:
+                    pass  # skip forcing buffering
+                else:
+                    return True
+            elif "forbidden" == url.meta['iptv_buffering']:
+                return False
+        if "|" in url:
+            return True
+
+        # check based on protocol
+        protocol = url.meta.get('iptv_proto', '')
+        protocol = url.meta.get('iptv_proto', '')
+        if protocol in ['f4m', 'uds']:
+            return True  # supported only in buffering mode
+        elif protocol in ['http', 'https']:
+            return config.plugins.iptvplayer.buforowanie.value
+        elif 'rtmp' == protocol:
+            return config.plugins.iptvplayer.buforowanie_rtmp.value
+        elif protocol in ['m3u8', 'em3u8']:
+            return config.plugins.iptvplayer.buforowanie_m3u8.value
+
+    def isUrlBlocked(self, url, type):
+        protocol = url.meta.get('iptv_proto', '')
+        if ".wmv" == self.getFileExt(url, type) and config.plugins.iptvplayer.ZablokujWMV.value:
+            return True, _("Format 'wmv' blocked in configuration.")
+        elif '' == protocol:
+            return True, _("Unknown protocol [%s]") % url
+        return False, ''
+
+    def getFileExt(self, url, type):
+        format = url.meta.get('iptv_format', '')
+        if '' != format:
+            return '.' + format
+        protocol = url.meta.get('iptv_proto', '')
+
+        fileExtension = ''
+        tmp = url.lower().split('?', 1)[0]
+        for item in ['avi', 'flv', 'mp4', 'ts', 'mov', 'wmv', 'mpeg', 'mpg', 'mkv', 'vob', 'divx', 'm2ts', 'mp3', 'm4a', 'ogg', 'wma', 'fla', 'wav', 'flac']:
+            if tmp.endswith('.' + item):
+                fileExtension = '.' + item
+                break
+
+        if '' == fileExtension:
+            if protocol in ['mms', 'mmsh', 'rtsp']:
+                fileExtension = '.wmv'
+            elif protocol in ['f4m', 'uds', 'rtmp']:
+                fileExtension = '.flv'
+            else:
+                if type == CDisplayListItem.TYPE_VIDEO:
+                    fileExtension = '.mp4'  # default video extension
+                else:
+                    fileExtension = '.mp3'  # default audio extension
+        return fileExtension
+
+    def getMoviePlayer(self, buffering=False, useAlternativePlayer=False):
+        printDBG("getMoviePlayer")
+        return GetMoviePlayer(buffering, useAlternativePlayer)
+
+    def writeCurrentTitleToFile(self, title):
+        titleFilePath = config.plugins.iptvplayer.curr_title_file.value
+        if "" != titleFilePath:
+            try:
+                with open(titleFilePath, 'w') as titleFile:
+                    titleFile.write(title)
+            except Exception:
+                printExc()
+        """
+        if config.plugins.iptvplayer.set_curr_title.value:
+            try:
+                from enigma import evfd
+                title = CParsingHelper.getNormalizeStr(title)
+                evfd.getInstance().vfd_write_string(title[0:17])
+            except Exception:
+                printExc()
+        """
+
+    def playVideo(self, ret):
+        printDBG("playVideo")
+        url = ''
+        if RetHost.OK == ret.status:
+            if len(ret.value) > 0:
+                url = ret.value[0]
+
+        self.setStatusTex("")
+        self["list"].show()
+
+        if url != '' and CDisplayListItem.TYPE_PICTURE == self.currItem.type:
+            self.session.openWithCallback(self.leavePicturePlayer, IPTVPicturePlayerWidget, url, config.plugins.iptvplayer.bufferingPath.value, self.currItem.name, {'seq_mode': self.autoPlaySeqStarted})
+        elif url != '' and self.isDownloadableType(self.currItem.type):
+            printDBG("playVideo url[%s]" % url)
+            if self.currItem.type == CDisplayListItem.TYPE_DATA:
+                recorderMode = True
+            else:
+                recorderMode = self.recorderMode
+            url = urlparser.decorateUrl(url)
+            titleOfMovie = self.currItem.name.replace('/', '-').replace(':', '-').replace('*', '-').replace('?', '-').replace('"', '-').replace('<', '-').replace('>', '-').replace('|', '-')
+            fileExtension = self.getFileExt(url, self.currItem.type)
+
+            blocked, reaseon = self.isUrlBlocked(url, self.currItem.type)
+            if blocked:
+                self.session.open(MessageBox, reaseon, type=MessageBox.TYPE_INFO, timeout=10)
+                return
+
+            isBufferingMode = False if url.startswith('file://') else self.activePlayer.get('buffering', self.checkBuffering(url))
+            bufferingPath = config.plugins.iptvplayer.bufferingPath.value
+            downloadingPath = config.plugins.iptvplayer.NaszaSciezka.value
+            destinationPath = downloadingPath if recorderMode else bufferingPath
+
+            if recorderMode or isBufferingMode:
+                errorTab = []
+                if not os_path.exists(destinationPath):
+                    iptvtools_mkdirs(destinationPath)
+
+                if not os_path.isdir(destinationPath):
+                    errorTab.append(_("Directory \"%s\" does not exists.") % destinationPath)
+                    errorTab.append(_("Please set valid %s in the %s configuration.") % (_("downloads location") if recorderMode else _("buffering location"), 'E2iPlayer'))
+                else:
+                    requiredSpace = 3 * 512 * 1024 * 1024  # 1,5 GB
+                    availableSpace = iptvtools_FreeSpace(destinationPath, requiredSpace=None, unitDiv=1)
+                    if requiredSpace > availableSpace:
+                        errorTab.append(_("There is no enough free space in the folder \"%s\".") % destinationPath)
+                        errorTab.append(_("\tDisk space required: %s") % formatBytes(requiredSpace))
+                        errorTab.append(_("\tDisk space available: %s") % formatBytes(availableSpace))
+
+                if errorTab:
+                    errorTab.append("\n")
+                    errorTab.append(_("Tip! You can connect USB flash drive to fix this problem."))
+                    self.stopAutoPlaySequencer()
+                    self.session.open(MessageBox, '\n'.join(errorTab), type=MessageBox.TYPE_INFO, timeout=10)
+                    return
+
+            global gDownloadManager
+            if recorderMode:
+                if None is not gDownloadManager:
+                    if IsUrlDownloadable(url):
+                        fullFilePath = downloadingPath + '/' + titleOfMovie + fileExtension
+                        ret = gDownloadManager.addToDQueue(DMItem(url, fullFilePath))
+                    else:
+                        ret = False
+                        self.session.open(MessageBox, _("File can not be downloaded. Protocol [%s] is unsupported") % url.meta.get('iptv_proto', ''), type=MessageBox.TYPE_INFO, timeout=10)
+                    if ret:
+                        if not self.checkAutoPlaySequencer():
+                            if config.plugins.iptvplayer.IPTVDMShowAfterAdd.value:
+                                self.runIPTVDM()
+                            else:
+                                self.session.open(MessageBox, _("File [%s] was added to downloading queue.") % titleOfMovie, type=MessageBox.TYPE_INFO, timeout=10)
+                    else:
+                        self.stopAutoPlaySequencer()
+                else:
+                    self.stopAutoPlaySequencer()
+            else:
+                # genuinely about to stream (not download) and every earlier check
+                # (blocked url, missing directory, low disk space) already passed -
+                # this is the only place that marks the item "started"
+                try:
+                    if hasattr(self.host, 'markItemAsStarted'):
+                        self.host.markItemAsStarted(self["list"].getCurrentIndex())
+                except Exception:
+                    printExc()
+
+                self.prevVideoMode = GetE2VideoMode()
+                printDBG("Current video mode [%s]" % self.prevVideoMode)
+                gstAdditionalParams = {'defaul_videomode': self.prevVideoMode, 'host_name': self.hostName, 'external_sub_tracks': url.meta.get('external_sub_tracks', []), 'iptv_refresh_cmd': url.meta.get('iptv_refresh_cmd', '')}  # default_player_videooptions
+                if self.currItem.type == CDisplayListItem.TYPE_AUDIO:
+                    gstAdditionalParams['show_iframe'] = config.plugins.iptvplayer.show_iframe.value
+                    gstAdditionalParams['iframe_file_start'] = config.plugins.iptvplayer.iframe_file.value
+                    gstAdditionalParams['iframe_file_end'] = config.plugins.iptvplayer.clear_iframe_file.value
+                    gstAdditionalParams['iframe_continue'] = False
+
+                self.writeCurrentTitleToFile(titleOfMovie)
+                if isBufferingMode:
+                    self.session.nav.stopService()
+                    player = self.activePlayer.get('player', self.getMoviePlayer(True, self.useAlternativePlayer))
+                    self.session.openWithCallback(self.leaveMoviePlayer, E2iPlayerBufferingWidget, url, bufferingPath, downloadingPath, titleOfMovie, player.value, self.bufferSize, gstAdditionalParams, gDownloadManager, fileExtension)
+                else:
+                    self.session.nav.stopService()
+                    player = self.activePlayer.get('player', self.getMoviePlayer(False, self.useAlternativePlayer))
+                    if "mini" == player.value:
+                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVMiniMoviePlayer, url, titleOfMovie)
+                    elif "standard" == player.value:
+                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVStandardMoviePlayer, url, titleOfMovie)
+                    else:
+                        if "extgstplayer" == player.value:
+                            playerVal = 'gstplayer'
+                            gstAdditionalParams['download-buffer-path'] = ''
+                            gstAdditionalParams['ring-buffer-max-size'] = 0
+                            gstAdditionalParams['buffer-duration'] = 18000  # 300min
+                            gstAdditionalParams['buffer-size'] = 10240  # 10MB
+                        else:
+                            assert ("exteplayer" == player.value)
+                            playerVal = 'eplayer'
+                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVExtMoviePlayer, url, titleOfMovie, None, playerVal, gstAdditionalParams)
+        else:
+            # There was problem in resolving direct link for video
+            if not self.checkAutoPlaySequencer():
+                self.session.open(MessageBox, _("No valid links available."), type=MessageBox.TYPE_INFO, timeout=10)
+    # end playVideo(self, ret):
+
+    def leaveMoviePlayer(self, answer=None, lastPosition=None, clipLength=None, *args, **kwargs):
+        self.writeCurrentTitleToFile("")
+        videoMode = GetE2VideoMode()
+        printDBG("Current video mode [%s], previus video mode [%s]" % (videoMode, self.prevVideoMode))
+        if None not in [self.prevVideoMode, videoMode] and self.prevVideoMode != videoMode:
+            printDBG("Restore previus video mode")
+            SetE2VideoMode(self.prevVideoMode)
+
+        try:
+            if answer is not None:
+                self.stopAutoPlaySequencer()
+        except Exception:
+            printExc()
+
+        if not config.plugins.iptvplayer.disable_live.value and not self.autoPlaySeqStarted:
+            self.session.nav.playService(self.currentService)
+
+        if lastPosition is not None and clipLength is not None and clipLength > 0:
+            try:
+                if config.plugins.iptvplayer.favourites_use_watched_flag.value and (lastPosition * 100 / clipLength) > 95 and hasattr(self.host, 'markItemAsViewed'):
+                    currSelIndex = self["list"].getCurrentIndex()
+                    self.requestListFromHost('MarkItemAsViewed', currSelIndex)
+                    return
+            except Exception:
+                printExc()
+
+        self.checkAutoPlaySequencer()
+
+    def leavePicturePlayer(self, answer=None, lastPosition=None, *args, **kwargs):
+        self.checkAutoPlaySequencer()
+
+    def requestListFromHost(self, type, currSelIndex=-1, privateData=''):
+
+        if not self.isInWorkThread():
+            self["list"].hide()
+            GetIPTVSleep().Reset()
+
+            if type not in ['ForVideoLinks', 'ResolveURL', 'ForArticleContent', 'ForFavItem', 'PerformCustomAction']:
+                # hide bottom panel
+                self["cover"].hide()
+                self["console"].setText('')
+
+            if (type == 'ForItem' or type == 'ForSearch') and getattr(self.currItem, 'type', None) not in CDisplayListItem.NON_NAVIGATING_TYPES:
+                self.prevSelList.append(self.currSelIndex)
+                if type == 'ForSearch':
+                    self.categoryList.append(_("Search results"))
+                else:
+                    self.categoryList.append(self.currItem.name)
+                # new list, so select first index
+                self.nextSelIndex = 0
+
+            selItem = None
+            if currSelIndex > -1 and len(self.currList) > currSelIndex:
+                selItem = self.currList[currSelIndex]
+                if self.isPlayableType(selItem.type) and selItem.itemIdx > -1 and len(self.currList) > selItem.itemIdx:
+                    currSelIndex = selItem.itemIdx
+
+            dots = ""  # _("...............")
+            IDS_DOWNLOADING = _("Downloading") + dots
+            IDS_LOADING = _("Loading") + dots
+            IDS_REFRESHING = _("Refreshing") + dots
+            try:
+                if type == 'Refresh':
+                    self.setStatusTex(IDS_REFRESHING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getCurrentList, boundFunction(self.callbackGetList, {'refresh': 1, 'selIndex': currSelIndex}), True)(1)
+                elif type == 'ForMore':
+                    self.setStatusTex(IDS_DOWNLOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getMoreForItem, boundFunction(self.callbackGetList, {'refresh': 2, 'selIndex': currSelIndex}), True)(currSelIndex)
+                elif type == 'Initial':
+                    self.setStatusTex(IDS_DOWNLOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getInitList, boundFunction(self.callbackGetList, {}), True)()
+                elif type == 'Previous':
+                    self.setStatusTex(IDS_DOWNLOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getPrevList, boundFunction(self.callbackGetList, {}), True)()
+                elif type == 'ForItem':
+                    self.setStatusTex(IDS_DOWNLOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getListForItem, boundFunction(self.callbackGetList, {}), True)(currSelIndex, 0, selItem)
+                elif type == 'ForVideoLinks':
+                    self.setStatusTex(IDS_LOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getLinksForVideo, self.selectHostVideoLinksCallback, True)(currSelIndex, selItem)
+                elif type == 'ResolveURL':
+                    self.setStatusTex(IDS_LOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getResolvedURL, self.getResolvedURLCallback, True)(privateData)
+                elif type == 'ForSearch':
+                    self.setStatusTex(IDS_LOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getSearchResults, boundFunction(self.callbackGetList, {}), True)(self.searchPattern, self.searchType)
+                elif type == 'ForArticleContent':
+                    self.setStatusTex(IDS_DOWNLOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getArticleContent, self.getArticleContentCallback, True)(currSelIndex)
+                elif type == 'ForFavItem':
+                    self.setStatusTex(IDS_LOADING)
+                    self.workThread = asynccall.AsyncMethod(self.host.getFavouriteItem, self.getFavouriteItemCallback, True)(currSelIndex)
+                elif type == 'PerformCustomAction':
+                    self.workThread = asynccall.AsyncMethod(self.host.performCustomAction, self.performCustomActionCallback, True)(privateData)
+                elif type == 'MarkItemAsViewed':
+                    self.workThread = asynccall.AsyncMethod(self.host.markItemAsViewed, self.markItemAsViewedCallback, True)(currSelIndex)
+                else:
+                    printDBG('requestListFromHost unknown list type: ' + type)
+                self.showSpinner()
+            except Exception:
+                printExc('The current host crashed')
+    # end requestListFromHost(self, type, currSelIndex = -1, privateData = ''):
+
+    def startSearchProcedure(self, searchTypes):
+        if config.plugins.iptvplayer.osk_remember_last_search.value:
+            sts, prevPattern = CSearchHistoryHelper.loadLastPattern()
+            if sts:
+                self.searchPattern = prevPattern
+        else:
+            self.searchPattern = ''
+        if searchTypes:
+            self.session.openWithCallback(self.selectSearchTypeCallback, ChoiceBox, title=_("Search type"), list=searchTypes)
+        else:
+            self.searchType = None
+            self.doSearchWithVirtualKeyboard()
+
+    def selectSearchTypeCallback(self, ret=None):
+        if ret:
+            self.searchType = ret[1]
+            self.doSearchWithVirtualKeyboard()
+        else:
+            pass
+
+    def _resolveSuggestionsProvider(self):
+        # !!! NON BLOCKING !!! host suggestions call method directly on the
+        # host, so it must never block. Used both for the keyboard's initial
+        # provider and, via additionalParams['resolve_suggestions_provider'],
+        # to re-resolve live when "Default suggestions provider" / "Allow
+        # host to override suggestions provider" change while the keyboard
+        # is already open (e2ivk.py calls it again from its Settings-closed
+        # callback).
+        suggestionsProvider = None
+        try:
+            if config.plugins.iptvplayer.osk_allow_host_suggestions.value and self.visible and not self.isInWorkThread():
+                currSelIndex = self.getSelItem().itemIdx
+                hRet = self.host.getSuggestionsProvider(currSelIndex)
+                if hRet.status == RetHost.OK and hRet.value and hRet.value[0]:
+                    suggestionsProvider = hRet.value[0] if hRet.value[0] is not None else False
+        except Exception:
+            printExc()
+
+        if suggestionsProvider is None:
+            providerAlias = config.plugins.iptvplayer.osk_default_suggestions.value
+            if not providerAlias:
+                if not self.groupObj:
+                    self.groupObj = IPTVHostsGroups()
+                if self.hostName in self.groupObj.PREDEFINED_HOSTS['moviesandseries']:
+                    if self.hostName in self.groupObj.PREDEFINED_HOSTS['polish']:
+                        providerAlias = 'filmweb'
+                    else:
+                        providerAlias = 'imdb'
+                else:
+                    providerAlias = 'google'
+
+            if providerAlias == 'filmweb':
+                from Plugins.Extensions.IPTVPlayer.suggestions.filmweb import SuggestionsProvider as filmweb_Provider
+                suggestionsProvider = filmweb_Provider()
+            elif providerAlias == 'imdb':
+                from Plugins.Extensions.IPTVPlayer.suggestions.imdb import SuggestionsProvider as imdb_Provider
+                suggestionsProvider = imdb_Provider()
+            elif providerAlias == 'google':
+                from Plugins.Extensions.IPTVPlayer.suggestions.google import SuggestionsProvider as google_Provider
+                suggestionsProvider = google_Provider()
+            elif providerAlias == 'bing':
+                from Plugins.Extensions.IPTVPlayer.suggestions.bing import SuggestionsProvider as bing_Provider
+                suggestionsProvider = bing_Provider()
+            elif providerAlias == 'duckduckgo':
+                from Plugins.Extensions.IPTVPlayer.suggestions.duckduckgo import SuggestionsProvider as duckduckgo_Provider
+                suggestionsProvider = duckduckgo_Provider()
+        return suggestionsProvider
+
+    def doSearchWithVirtualKeyboard(self):
+        printDBG("doSearchWithVirtualKeyboard")
+        caps = {}
+        virtualKeyboard = GetVirtualKeyboard(caps)
+
+        if caps.get('has_additional_params'):
+            try:
+                additionalParams = {}
+                if caps.get('has_suggestions') and config.plugins.iptvplayer.osk_allow_suggestions.value:
+                    suggestionsProvider = self._resolveSuggestionsProvider()
+                    if suggestionsProvider:
+                        from Plugins.Extensions.IPTVPlayer.components.e2ivksuggestion import AutocompleteSearch
+                        additionalParams['autocomplete'] = AutocompleteSearch(suggestionsProvider)
+                        # only offered when the suggestions panel exists from
+                        # the start - e2ivk.py's skin decides whether to lay
+                        # out right_list/right_header once, at open time,
+                        # based on additionalParams['autocomplete'] being set
+                        additionalParams['resolve_suggestions_provider'] = self._resolveSuggestionsProvider
+
+                self.session.openWithCallback(self.enterPatternCallBack, virtualKeyboard, title=(_("Your search entry")), text=self.searchPattern, additionalParams=additionalParams)
+                return
+            except Exception:
+                printExc()
+        self.session.openWithCallback(self.enterPatternCallBack, virtualKeyboard, title=(_("Your search entry")), text=self.searchPattern)
+
+    def enterPatternCallBack(self, callback=None):
+        if callback is not None and len(callback):
+            self.searchPattern = callback
+            if config.plugins.iptvplayer.osk_remember_last_search.value:
+                CSearchHistoryHelper.saveLastPattern(self.searchPattern)
+            self.requestListFromHost('ForSearch')
+
+    def configCallback(self):
+        self.selectHost()
+
+    def randomizePlayableItems(self, randomize=True):
+        printDBG("randomizePlayableItems")
+        self.stopAutoPlaySequencer()
+        if self.visible and len(self.currList) > 1 and not self.isInWorkThread():
+            randList = []
+            for item in self.currList:
+                if isinstance(item, CDisplayListItem) and self.isPlayableType(item.type):
+                    randList.append(item)
+            if randomize:
+                random_shuffle(randList)
+            reloadList = False
+            if len(self.currList) == len(randList):
+                randList.reverse()
+                self.currList = randList
+                reloadList = True
+            elif len(randList) > 1:
+                newList = []
+                for item in self.currList:
+                    if isinstance(item, CDisplayListItem) and self.isPlayableType(item.type):
+                        newList.append(randList.pop())
+                    else:
+                        newList.append(item)
+                reloadList = True
+                self.currList = newList
+            if reloadList:
+                self["list"].setList([(x,) for x in self.currList])
+
+    def reversePlayableItems(self):
+        printDBG("reversePlayableItems")
+        self.randomizePlayableItems(False)
+
+    def reloadList(self, params):
+        printDBG("reloadList")
+        # suppresses _rememberHistorySelection() while the list below is being
+        # (re)built and its selection moved around programmatically
+        self._isLoadingList = True
+        refresh = params['add_param'].get('refresh', 0)
+        selIndex = params['add_param'].get('selIndex', -1)
+        ret = params['ret']
+        printDBG("> E2iPlayerWidget.reloadList refresh[%s], selIndex[%s]" % (refresh, selIndex))
+        if 0 < refresh and -1 < selIndex:
+            self.nextSelIndex = selIndex
+        # ToDo: check ret.status if not OK do something :P
+        if ret.status != RetHost.OK:
+            printDBG("+ reloadList ret.status = %s" % ret.status)
+            self.stopAutoPlaySequencer()
+
+        self.canRandomizeList = False
+        numPlayableItems = 0
+        for idx in range(len(ret.value)):
+            if isinstance(ret.value[idx], CDisplayListItem):
+                ret.value[idx].itemIdx = idx
+                if self.isPlayableType(ret.value[idx].type):
+                    numPlayableItems += 1
+
+        if numPlayableItems > 1:
+            self.canRandomizeList = True
+
+        self.currList = ret.value
+        self["list"].setList([(x,) for x in self.currList])
+
+        self["headertext"].setText(self.getCategoryPath())
+        if len(self.currList) <= 0:
+            disMessage = _("No item to display. \nPress OK to refresh.\n")
+            if ret.message and ret.message != '':
+                disMessage += ret.message
+            lastErrorMsg = GetIPTVPlayerLastHostError()
+            if lastErrorMsg != '':
+                disMessage += "\n" + _('Last error: "%s"') % lastErrorMsg
+            lastExcMSG = getExcMSG(True)
+            if lastExcMSG != '':
+                disMessage += "\n" + _('Last Exception error: "%s"') % lastExcMSG
+
+            self.setStatusTex(disMessage)
+            self["list"].hide()
+        else:
+            # restor previus selection
+            if len(self.currList) > self.nextSelIndex:
+                self["list"].moveToIndex(self.nextSelIndex)
+            # else:
+            # selection will not be change so manualy call
+            self.changeBottomPanel()
+
+            self.setStatusTex("")
+            self["list"].show()
+        self._isLoadingList = False
+        self._restoreHistorySelection()
+        self.updateDownloadButton()
+        if 2 == refresh:
+            self.autoPlaySequencerNext(False)
+        elif 1 == refresh:
+            self.autoPlaySequencerNext()
+    # end reloadList(self, ret):
+
+    def getCategoryPath(self):
+        def _getCat(cat, num):
+            if '' == cat:
+                return ''
+            cat = ' > ' + cat
+            if 1 < num:
+                cat += (' (x%d)' % num)
+            return cat
+
+        # str = self.hostName
+        str = self.hostTitle
+        prevCat = ''
+        prevNum = 0
+        for cat in self.categoryList:
+            if prevCat != cat:
+                str += _getCat(prevCat, prevNum)
+                prevCat = cat
+                prevNum = 1
+            else:
+                prevNum += 1
+        str += _getCat(prevCat, prevNum)
+        return str
+
+    def getRefreshedCurrList(self):
+        currSelIndex = self["list"].getCurrentIndex()
+        self.requestListFromHost('Refresh', currSelIndex)
+
+    def getInitialList(self):
+        self.nexSelIndex = 0
+        self.prevSelList = []
+        self.categoryList = []
+        self.currList = []
+        self.currItem = CDisplayListItem()
+        self.favouritesCurrentGroupId = ''
+        self["headertext"].setText(self.getCategoryPath())
+        self.requestListFromHost('Initial')
+
+    def hideWindow(self):
+        self.visible = False
+        self.hide()
+
+    def showWindow(self):
+        self.visible = True
+        self.show()
+
+    def createSummary(self):
+        return IPTVPlayerLCDScreen
+
+    def canByAddedToFavourites(self):
+        try:
+            favouritesHostActive = config.plugins.iptvplayer.hostfavourites.value
+        except Exception:
+            favouritesHostActive = False
+        cItem = None
+        index = -1
+        # we need to check if fav is available
+        if not self.isInWorkThread() and favouritesHostActive and self.visible:
+            cItem = self.getSelItem()
+            if None is not cItem and (cItem.isGoodForFavourites or cItem.type in self.hostFavTypes):
+                index = self.getSelIndex()
+            else:
+                cItem = None
+        return index, cItem
+
+    def getFavouriteItemCallback(self, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("handleFavouriteItemCallback", [thread, ret])
+
+    def handleFavouriteItemCallback(self, ret):
+        printDBG("E2iPlayerWidget.handleFavouriteItemCallback")
+        self.setStatusTex("")
+        self["list"].show()
+        if ret.status == RetHost.OK and isinstance(ret.value, list) and 1 == len(ret.value) and isinstance(ret.value[0], CFavItem):
+            favItem = ret.value[0]
+            if CFavItem.RESOLVER_SELF == favItem.resolver:
+                favItem.resolver = self.hostName
+            if '' == favItem.hostName:
+                favItem.hostName = self.hostName
+            self.session.open(IPTVFavouritesAddItemWidget, favItem)
+        else:
+            self.session.open(MessageBox, _("No valid links available."), type=MessageBox.TYPE_INFO, timeout=10)
+
+    def menu_pressed(self):
+        printDBG("E2iPlayerWidget.menu_pressed")
+        # we have to be careful here as we will call method
+        # directly from host
+        options = []
+        try:
+            if self.visible and not self.isInWorkThread():
+                try:
+                    item = self.getSelItem()
+                except Exception:
+                    printExc()
+                    item = None
+                if None is not item:
+                    currSelIndex = item.itemIdx  # self["list"].getCurrentIndex()
+                else:
+                    currSelIndex = -1
+                hRet = self.host.getCustomActions(currSelIndex)
+                if hRet.status == RetHost.OK and len(hRet.value):
+                    for item in hRet.value:
+                        if isinstance(item, IPTVChoiceBoxItem):
+                            options.append(item)
+
+                try:
+                    if -1 < self.canByAddedToFavourites()[0]:
+                        options.append(IPTVChoiceBoxItem(_("Add item to favorites"), "", {'e2i_menu_action': 'ADD_FAV'}))
+                    elif 'favourites' == self.hostName:
+                        options.append(IPTVChoiceBoxItem(_("Remove from favorites"), "", {'e2i_menu_action': 'DELETE_FAV'}))
+                except Exception:
+                    printExc()
+            if len(options):
+                self.stopAutoPlaySequencer()
+                self.session.openWithCallback(self.requestCustomActionFromHost, IPTVChoiceBoxWidget, {'width': 600, 'current_idx': 0, 'title': _("Select action"), 'options': options})
+        except Exception:
+            printExc()
+
+    def requestCustomActionFromHost(self, ret):
+        printDBG("E2iPlayerWidget.requestCustomActionFromHost ret[%r]" % [ret])
+        if isinstance(ret, IPTVChoiceBoxItem):
+            menuAction = ret.privateData.get('e2i_menu_action') if isinstance(ret.privateData, dict) else None
+            if menuAction == 'ADD_FAV':
+                currSelIndex = self.canByAddedToFavourites()[0]
+                self.requestListFromHost('ForFavItem', currSelIndex, '')
+                return
+            elif menuAction == 'DELETE_FAV':
+                self.session.openWithCallback(self.deleteFavouriteItem, MessageBox, _('Definitely remove from favorites?'), type=MessageBox.TYPE_YESNO, timeout=10)
+                return
+            self.requestListFromHost('PerformCustomAction', -1, ret.privateData)
+
+    def performCustomActionCallback(self, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("handlePerformCustomActionCallback", [thread, ret])
+
+    def handlePerformCustomActionCallback(self, ret):
+        printDBG("E2iPlayerWidget.handlePerformCustomActionCallback")
+        self.setStatusTex("")
+        self["list"].show()
+        if ret.status == RetHost.OK and isinstance(ret.value, list) and 1 == len(ret.value):
+           self.yellow_pressed()
+        elif ret.status == RetHost.ERROR and isinstance(ret.value, list) and 1 == len(ret.value) and isinstance(ret.value[0], str):
+           self.session.open(MessageBox, ret.value[0], type=MessageBox.TYPE_ERROR)
+
+    def markItemAsViewedCallback(self, thread, ret):
+        asynccall.gMainFunctionsQueueTab[0].addToQueue("handleMarkItemAsViewedCallback", [thread, ret])
+
+    def handleMarkItemAsViewedCallback(self, ret):
+        printDBG("E2iPlayerWidget.handleMarkItemAsViewedCallback")
+        self.setStatusTex("")
+        self["list"].show()
+        if ret.status == RetHost.OK and isinstance(ret.value, list) and 1 == len(ret.value) and 'refresh' in ret.value:
+           self.getRefreshedCurrList()
+        elif ret.status == RetHost.ERROR and isinstance(ret.value, list) and 1 == len(ret.value) and isinstance(ret.value[0], str):
+           self.session.open(MessageBox, ret.value[0], type=MessageBox.TYPE_ERROR)
+        else:
+            self.checkAutoPlaySequencer()
+
+# class E2iPlayerWidget
+
+
+class IPTVPlayerLCDScreen(Screen):
+    try:
+        summary_screenwidth = getDesktop(1).size().width()
+        summary_screenheight = getDesktop(1).size().height()
+    except Exception:
+        summary_screenwidth = 132
+        summary_screenheight = 64
+    if summary_screenwidth >= 800 and summary_screenheight >= 480:
+        skin = """
+    <screen position="0,0" size="800,480" title="E2iPlayer">
+        <widget name="text1" position="10,0"  size="800,70" font="Regular;50" halign="center" valign="center" foregroundColor="#05F7F3"/>
+        <widget name="text2" position="10,80" size="800,70" font="Regular;40" halign="center" valign="center" foregroundColor="#FFFF00"/>
+        <widget name="LCDlogo" position="0,210" zPosition="4" size="800,267" alphatest="blend" />
+    </screen>"""
+    elif summary_screenwidth >= 480 and summary_screenheight >= 320:
+        skin = """
+    <screen position="0,0" size="480,320" title="E2iPlayer">
+        <widget name="text1" position="10,0" size="460,70" font="Regular;50" halign="center" valign="center" foregroundColor="#05F7F3"/>
+        <widget name="text2" position="10,80" size="460,70" font="Regular;40" halign="center" valign="center" foregroundColor="#FFFF00"/>
+        <widget name="LCDlogo" position="0,160" zPosition="4" size="480,160" alphatest="blend" />
+    </screen>"""
+    elif summary_screenwidth >= 220 and summary_screenheight >= 176:
+        skin = """
+    <screen position="0,0" size="220,176" title="E2iPlayer">
+        <widget name="text1" position="5,0" size="210,26" font="Regular;24" halign="center" valign="center" foregroundColor="#05F7F3"/>
+        <widget name="text2" position="5,30" size="210,65" font="Regular;22" halign="center" valign="center" foregroundColor="#FFFF00"/>
+        <widget name="LCDlogo" position="5,106" size="210,70" zPosition="4" alphatest="blend" />
+    </screen>"""
+    else:
+        skin = """
+    <screen position="0,0" size="132,64" title="E2iPlayer">
+        <widget name="text1" position="4,0" size="132,14" font="Regular;12" halign="center" valign="center"/>
+        <widget name="text2" position="4,14" size="132,49" font="Regular;10" halign="center" valign="center"/>
+        <widget name="LCDlogo" zPosition="4" position="4,70" size="240,80" alphatest="blend" />
+    </screen>"""
+
+    def __init__(self, session, parent):
+        Screen.__init__(self, session)
+        try:
+            self["text1"] = Label("E2iPlayer")
+            self["text2"] = Label("")
+            self["LCDlogo"] = Pixmap()
+        except Exception:
+            pass
+
+    def setText(self, text):
+        try:
+            self["text2"].setText(text[0:39])
+        except Exception:
+            pass
+
+    def LCD_showPic(self, widgetName, picPath):
+        try:
+            self[widgetName].instance.setScale(1)
+            self[widgetName].instance.setPixmap(LoadPixmap(picPath))
+            self[widgetName].show()
+        except Exception:
+            pass
+
+    def LCD_hide(self, widgetName):
+        try:
+            self[widgetName].hide()
+        except Exception:
+            pass

--- a/components/searchhistoryeditor.py
+++ b/components/searchhistoryeditor.py
@@ -1,0 +1,718 @@
+# -*- coding: utf-8 -*-
+# added: 18.08.2026 - Kamikaze24
+
+import os
+import codecs
+
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, getReorderOnReuseEnabled, setReorderOnReuseEnabled, findT9JumpIndex
+from Plugins.Extensions.IPTVPlayer.p2p3.manipulateStrings import ensure_str
+
+from enigma import gRGB
+
+from Screens.Screen import Screen
+from Screens.MessageBox import MessageBox
+from Screens.ChoiceBox import ChoiceBox
+from Components.config import config
+from Components.ActionMap import ActionMap
+from Components.Label import Label
+from Components.MenuList import MenuList
+
+from Plugins.Extensions.IPTVPlayer.components.e2ivkselector import GetVirtualKeyboard
+from Tools.NumericalTextInput import NumericalTextInput
+
+try:
+    text_type = unicode
+    binary_type = str
+    PY2 = True
+except NameError:
+    text_type = str
+    binary_type = bytes
+    PY2 = False
+
+TYPE_SEP = u'|--TYPE--|'
+
+
+def toUnicode(value):
+    try:
+        if value is None:
+            return u''
+        if isinstance(value, text_type):
+            return value
+        if isinstance(value, binary_type):
+            return value.decode('utf-8', 'ignore')
+        return text_type(value)
+    except Exception:
+        try:
+            if PY2:
+                return text_type(str(value), 'utf-8', 'ignore')
+            return text_type(value)
+        except Exception:
+            printExc()
+            return u''
+
+
+def guiSafeStr(value):
+    try:
+        if value is None:
+            return ''
+        return ensure_str(toUnicode(value))
+    except Exception:
+        try:
+            if PY2 and isinstance(value, text_type):
+                return value.encode('utf-8')
+            return str(value)
+        except Exception:
+            printExc()
+            return ''
+
+
+class HistoryEntry(object):
+    __slots__ = ('title', 'searchtype')
+
+    def __init__(self, title, searchtype=None):
+        self.title = toUnicode(title).strip()
+        self.searchtype = toUnicode(searchtype).strip() if searchtype else None
+
+    def toLine(self):
+        if self.searchtype:
+            return self.title + TYPE_SEP + self.searchtype
+        return self.title
+
+    def displayText(self):
+        return self.title
+
+
+def parseHistoryFile(path, reverseForDisplay=False):
+    entries = []
+    try:
+        if not os.path.isfile(path):
+            return entries
+
+        with codecs.open(path, 'r', 'utf-8', 'ignore') as f:
+            raw = f.read()
+
+        raw = toUnicode(raw)
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if TYPE_SEP in line:
+                title, searchtype = line.split(TYPE_SEP, 1)
+                entries.append(HistoryEntry(title, searchtype))
+            else:
+                entries.append(HistoryEntry(line))
+
+        if reverseForDisplay:
+            entries.reverse()
+    except Exception:
+        printExc()
+
+    return entries
+
+
+def writeHistoryFile(path, entries, reverseForWrite=False):
+    try:
+        dirName = os.path.dirname(path)
+        if dirName and not os.path.isdir(dirName):
+            os.makedirs(dirName)
+
+        entriesToWrite = list(entries)
+        if reverseForWrite:
+            entriesToWrite.reverse()
+
+        tmpPath = path + '.tmp'
+        with codecs.open(tmpPath, 'w', 'utf-8', 'replace') as f:
+            for entry in entriesToWrite:
+                f.write(entry.toLine() + u'\n')
+
+        try:
+            os.rename(tmpPath, path)
+        except OSError:
+            if os.path.isfile(path):
+                os.remove(path)
+            os.rename(tmpPath, path)
+
+        return True
+    except Exception:
+        printExc()
+        return False
+
+
+class SearchHistoryEditor(Screen):
+
+    skin = """
+    <screen name="SearchHistoryEditor" position="center,center" size="1200,700" title="Search History">
+        <widget name="status" position="20,18" size="1160,30" font="Regular;24" halign="left" valign="center" transparent="1" />
+        <widget name="list" position="20,58" size="1160,587" font="Regular;32" itemHeight="44" scrollbarMode="showOnDemand" transparent="1" />
+
+        <eLabel position="20,662" size="18,18" backgroundColor="#00f23d21" />
+        <widget name="key_red" position="45,655" size="210,30" font="Regular;24" halign="left" valign="center" transparent="1" />
+
+        <eLabel position="252,662" size="18,18" backgroundColor="#0031a500" />
+        <widget name="key_green" position="277,655" size="210,30" font="Regular;24" halign="left" valign="center" transparent="1" />
+
+        <eLabel position="484,662" size="18,18" backgroundColor="#00e5b243" />
+        <widget name="key_yellow" position="509,655" size="210,30" font="Regular;24" halign="left" valign="center" transparent="1" />
+
+        <eLabel position="716,662" size="18,18" backgroundColor="#000064c7" />
+        <widget name="key_blue" position="741,655" size="210,30" font="Regular;24" halign="left" valign="center" transparent="1" />
+
+        <widget name="key_menu" position="948,655" size="235,30" font="Regular;24" halign="left" valign="center" transparent="1" />
+    </screen>
+    """
+
+    def __init__(self, session, historyFile, reverseForDisplay=True, reverseForWrite=True):
+        Screen.__init__(self, session)
+
+        self.historyFile = toUnicode(historyFile)
+        self.reverseForDisplay = bool(reverseForDisplay)
+        self.reverseForWrite = bool(reverseForWrite)
+
+        self.entries = []
+        self.sortMode = 0
+        self.dirty = False
+        self.numberInput = NumericalTextInput(handleTimeout=False)
+        self.reorderOnReuse = getReorderOnReuseEnabled(self.historyFile)
+        self.manualReorderMode = False
+        self.manualReorderItemPicked = False
+
+        # reuse the exact strings from iptvfavouriteswidgets.py's reordering
+        # toggle so translators don't need new entries for this screen
+        self.IDS_ENABLE_REORDERING = _(u'Enable reordering')
+        self.IDS_DISABLE_REORDERING = _(u'Disable reordering')
+        self.IDS_MENU_OPTIONS = _(u'MENU=Options')
+
+        printDBG('SearchHistoryEditor init file=%s' % self.historyFile)
+
+        self['status'] = Label('')
+        self['key_red'] = Label('')
+        self['key_green'] = Label('')
+        self['key_yellow'] = Label('')
+        self['key_blue'] = Label('')
+        self['key_menu'] = Label('')
+        self['list'] = MenuList([], enableWrapAround=True)
+
+        self.setTitle(guiSafeStr(_(u'Edit search history')))
+        self.safeSetText(self['key_red'], _(u'Delete'))
+        self.safeSetText(self['key_green'], _(u'Sort'))
+        self.safeSetText(self['key_yellow'], _(u'Save'))
+        self.safeSetText(self['key_blue'], _(u'Rename'))
+        self.safeSetText(self['key_menu'], self.IDS_MENU_OPTIONS)
+
+        actionsDict = {
+            'ok': self.keyRename,
+            'back': self.keyExit,
+            'cancel': self.keyExit,
+            'red': self.keyDelete,
+            'green': self.keyToggleSort,
+            'yellow': self.keySave,
+            'blue': self.keyRename,
+            'up': self.keyUp,
+            'down': self.keyDown,
+            # neutralize the ListboxActions page/home/end keys instead of
+            # leaving them unbound - matches iptvfavouriteswidgets.py's
+            # moveItem()/keyDrop() pattern, which is the one confirmed
+            # working for manual reordering on oATV8. Without an explicit
+            # (no-op) handler these fall through unhandled on some cores.
+            'moveUp': self.keyIgnoreListboxNav,
+            'moveDown': self.keyIgnoreListboxNav,
+            'moveTop': self.keyIgnoreListboxNav,
+            'moveEnd': self.keyIgnoreListboxNav,
+            'home': self.keyIgnoreListboxNav,
+            'end': self.keyIgnoreListboxNav,
+            'pageUp': self.keyIgnoreListboxNav,
+            'pageDown': self.keyIgnoreListboxNav,
+            'menu': self.keyMenu,
+        }
+        for digit in '123456789':
+            actionsDict[digit] = self.makeNumberJump(digit)
+
+        # priority 0, not -1: the underlying E2iPlayerWidget also binds
+        # 'menu' in the 'IPTVPlayerListActions' context at priority -1 (see
+        # iptvplayerwidget.py) - matching that priority here would make it
+        # ambiguous which of the two receives the key while this screen is
+        # open on top of it
+        self['actions'] = ActionMap(
+            ['OkCancelActions', 'WizardActions', 'DirectionActions', 'ColorActions', 'NumberActions', 'IPTVPlayerListActions', 'ListboxActions'],
+            actionsDict,
+            0
+        )
+        self.onLayoutFinish.append(self.onStart)
+
+    def makeNumberJump(self, digit):
+        return lambda: self.keyNumberJump(digit)
+
+    def safeSetText(self, widget, value):
+        try:
+            widget.setText(guiSafeStr(value))
+        except Exception:
+            printExc()
+
+    def buildDisplayList(self):
+        return [guiSafeStr(entry.displayText()) for entry in self.entries]
+
+    def setEntriesList(self, displayList, selectedIndex=None):
+        self['list'].setList(displayList)
+        if selectedIndex is not None and displayList:
+            selectedIndex = max(0, min(selectedIndex, len(displayList) - 1))
+            self['list'].moveToIndex(selectedIndex)
+
+    def loadEntriesFromFile(self):
+        return parseHistoryFile(self.historyFile, self.reverseForDisplay)
+
+    def removeDuplicates(self):
+        cleanEntries = []
+        knownEntries = set()
+        removed = 0
+
+        for entry in self.entries:
+            entry.title = toUnicode(entry.title).strip()
+
+            if not entry.title:
+                removed += 1
+                continue
+
+            compareKey = (entry.title.lower(), (entry.searchtype or u'').lower())
+            if compareKey in knownEntries:
+                removed += 1
+                continue
+
+            knownEntries.add(compareKey)
+            cleanEntries.append(entry)
+
+        if removed:
+            self.entries = cleanEntries
+            self.dirty = True
+            printDBG('SearchHistoryEditor removed duplicate/empty entries: %d' % removed)
+
+        return removed
+
+    def onStart(self):
+        self.reloadList()
+
+    def reloadList(self):
+        try:
+            self.entries = self.loadEntriesFromFile()
+            self.setEntriesList(self.buildDisplayList())
+            self.updateStatus()
+        except Exception:
+            printExc()
+            self.entries = []
+            self.setEntriesList([])
+            self.safeSetText(self['status'], _(u'Loading failed.'))
+
+    def updateStatus(self):
+        modes = {0: u'unsorted', 1: u'A-Z', 2: u'Z-A', 3: u'manual'}
+        state = _(u'changed') if self.dirty else _(u'saved')
+        reuseMode = _(u'to top') if self.reorderOnReuse else _(u'fixed')
+        text = _(u'Entries: %d | Sort: %s | Status: %s | Jump target: %s') % (
+            len(self.entries), modes.get(self.sortMode, u'?'), state, reuseMode
+        )
+        self.safeSetText(self['status'], text)
+
+    def getCurrentIndex(self):
+        try:
+            idx = self['list'].getSelectedIndex()
+            if idx is None:
+                return None
+            idx = int(idx)
+            if idx < 0 or idx >= len(self.entries):
+                return None
+            return idx
+        except Exception:
+            printExc()
+            return None
+
+    def keyIgnoreListboxNav(self):
+        pass
+
+    def keyUp(self):
+        try:
+            if not self.entries:
+                return
+            instance = self['list'].instance
+            if instance is None:
+                return
+            self.moveCursor(instance.moveUp)
+        except Exception:
+            printExc()
+
+    def keyDown(self):
+        try:
+            if not self.entries:
+                return
+            instance = self['list'].instance
+            if instance is None:
+                return
+            self.moveCursor(instance.moveDown)
+        except Exception:
+            printExc()
+
+    def moveCursor(self, key):
+        # matches iptvfavouriteswidgets.py's moveItem(): always drive
+        # navigation through the native eListbox moveSelection() (not
+        # MenuList.up()/down()) - proven working for manual reordering on
+        # oATV8. Outside of carrying an item this just moves the cursor;
+        # while carrying, entries are swapped based on where the native
+        # cursor actually ends up (handles wraparound correctly).
+        instance = self['list'].instance
+        if instance is None:
+            return
+
+        if self.manualReorderMode and self.manualReorderItemPicked:
+            idx = self.getCurrentIndex()
+            instance.moveSelection(key)
+            newIdx = self.getCurrentIndex()
+            printDBG('SearchHistoryEditor.moveCursor carrying idx=%s newIdx=%s' % (idx, newIdx))
+            if idx is None or newIdx is None or idx == newIdx:
+                return
+            self.entries[idx], self.entries[newIdx] = self.entries[newIdx], self.entries[idx]
+            self.dirty = True
+            self['list'].setList(self.buildDisplayList())
+            self.showCarryingStatus(newIdx)
+        else:
+            instance.moveSelection(key)
+
+    def setCarryColor(self, active):
+        try:
+            instance = self['list'].instance
+            if instance is None:
+                return
+            instance.setForegroundColorSelected(gRGB(0xFF0505) if active else gRGB(0xFFFFFF))
+            # setForegroundColorSelected() alone doesn't force a repaint - the
+            # new color only becomes visible on the next content rebuild, so
+            # force one here rather than relying on the next unrelated list
+            # rebuild (matches iptvfavouriteswidgets.py's _changeMode(),
+            # which always calls displayList() right after the color change)
+            self['list'].setList(self.buildDisplayList())
+        except Exception:
+            printExc()
+
+    def showCarryingStatus(self, idx):
+        text = _(u'Carrying: %s | UP/DOWN=Move, OK=Drop') % self.entries[idx].title
+        self.safeSetText(self['status'], text)
+
+    def keyNumberJump(self, digit):
+        if self.manualReorderMode:
+            return
+        if not self.entries:
+            return
+        if not config.plugins.iptvplayer.enableT9MainList.value:
+            return
+
+        letter = self.numberInput.getKey(int(digit))
+        if not letter:
+            return
+
+        currentIdx = self.getCurrentIndex()
+
+        try:
+            idx = findT9JumpIndex(len(self.entries), currentIdx, letter, lambda i: toUnicode(self.entries[i].title))
+            if idx >= 0:
+                self['list'].moveToIndex(idx)
+        except Exception:
+            printExc()
+
+    def keyToggleSort(self):
+        if self.manualReorderMode:
+            return
+        nextMode = {0: 1, 1: 2, 2: 0, 3: 1}.get(self.sortMode, 1)
+        if nextMode == 0 and self.dirty:
+            self.session.openWithCallback(
+                self.keyToggleSortConfirmed,
+                MessageBox,
+                guiSafeStr(_(u'Reverting to unsorted order will discard unsaved changes. Continue?')),
+                type=MessageBox.TYPE_YESNO,
+                default=False
+            )
+            return
+        self.applySortMode(nextMode)
+
+    def keyToggleSortConfirmed(self, confirmed):
+        if confirmed:
+            self.applySortMode(0)
+
+    def applySortMode(self, mode):
+        try:
+            currentIdx = self.getCurrentIndex()
+            if currentIdx is None:
+                currentIdx = 0
+
+            removed = self.removeDuplicates()
+            fixedJumpTarget = False
+
+            if mode == 1:
+                self.entries.sort(key=lambda entry: toUnicode(entry.title).lower())
+                fixedJumpTarget = self.fixJumpTargetAfterSort()
+            elif mode == 2:
+                self.entries.sort(key=lambda entry: toUnicode(entry.title).lower(), reverse=True)
+                fixedJumpTarget = self.fixJumpTargetAfterSort()
+            else:
+                mode = 0
+                self.entries = self.loadEntriesFromFile()
+                removed = self.removeDuplicates()
+
+            self.sortMode = mode
+            self.dirty = (mode != 0) or bool(removed)
+            self.setEntriesList(self.buildDisplayList(), currentIdx)
+            self.updateStatus()
+
+            self.notifyAfterSort(removed, fixedJumpTarget)
+        except Exception:
+            printExc()
+
+    def fixJumpTargetAfterSort(self):
+        # sorting is a deliberate, explicit ordering - don't let a later
+        # casual reuse (MRU bump-to-top) undo it silently
+        if self.reorderOnReuse:
+            self.reorderOnReuse = False
+            setReorderOnReuseEnabled(self.historyFile, False)
+            return True
+        return False
+
+    def notifyAfterSort(self, removed, fixedJumpTarget):
+        parts = []
+        if removed:
+            parts.append(_(u'%d duplicate entries removed.') % removed)
+        if fixedJumpTarget:
+            parts.append(_(u'Jump target was fixed so the sort order is preserved.'))
+        if parts:
+            self.openInfoMessage(u' '.join(parts))
+
+    def keyStartManualSort(self):
+        printDBG('SearchHistoryEditor.keyStartManualSort ENTER')
+        try:
+            removed = self.removeDuplicates()
+            fixedJumpTarget = self.fixJumpTargetAfterSort()
+            self.manualReorderMode = True
+            self.manualReorderItemPicked = False
+            self.sortMode = 3
+            self.setEntriesList(self.buildDisplayList(), self.getCurrentIndex())
+            self.safeSetText(self['key_menu'], self.IDS_DISABLE_REORDERING)
+            self.updateStatus()
+
+            self.notifyAfterSort(removed, fixedJumpTarget)
+            printDBG('SearchHistoryEditor.keyStartManualSort OK manualReorderMode=%s' % self.manualReorderMode)
+        except Exception:
+            printExc()
+
+    def keyStopManualSort(self):
+        printDBG('SearchHistoryEditor.keyStopManualSort')
+        self.manualReorderMode = False
+        self.manualReorderItemPicked = False
+        self.setCarryColor(False)
+        self.safeSetText(self['key_menu'], self.IDS_MENU_OPTIONS)
+        self.updateStatus()
+
+    def keyManualPickOrDrop(self):
+        idx = self.getCurrentIndex()
+        printDBG('SearchHistoryEditor.keyManualPickOrDrop idx=%s pickedBefore=%s' % (idx, self.manualReorderItemPicked))
+        if idx is None:
+            return
+        self.manualReorderItemPicked = not self.manualReorderItemPicked
+        self.setCarryColor(self.manualReorderItemPicked)
+        if self.manualReorderItemPicked:
+            self.showCarryingStatus(idx)
+        else:
+            self.dirty = True
+            self.updateStatus()
+        printDBG('SearchHistoryEditor.keyManualPickOrDrop pickedAfter=%s' % self.manualReorderItemPicked)
+
+    def keyMenu(self):
+        printDBG('SearchHistoryEditor.keyMenu manualReorderMode=%s' % self.manualReorderMode)
+        try:
+            if self.manualReorderMode:
+                self.keyStopManualSort()
+                return
+
+            options = [
+                (guiSafeStr(_(u'Add new entry')), 'ADD_NEW'),
+                (guiSafeStr(_(u'Sort A-Z')), 'SORT_AZ'),
+                (guiSafeStr(_(u'Sort Z-A')), 'SORT_ZA'),
+                (guiSafeStr(self.IDS_ENABLE_REORDERING), 'SORT_MANUAL'),
+            ]
+            if self.reorderOnReuse:
+                options.append((guiSafeStr(_(u'Fix jump target')), 'TOGGLE_REORDER'))
+            else:
+                options.append((guiSafeStr(_(u'Unfix jump target')), 'TOGGLE_REORDER'))
+
+            self.session.openWithCallback(self.menuCallback, ChoiceBox, title=guiSafeStr(_(u'Search history - options')), list=options)
+        except Exception:
+            printExc()
+
+    def menuCallback(self, ret):
+        printDBG('SearchHistoryEditor.menuCallback ret=%r' % (ret,))
+        if not ret:
+            return
+        action = ret[1]
+        if action == 'ADD_NEW':
+            self.keyAddNew()
+        elif action == 'SORT_AZ':
+            self.applySortMode(1)
+        elif action == 'SORT_ZA':
+            self.applySortMode(2)
+        elif action == 'SORT_MANUAL':
+            self.keyStartManualSort()
+        elif action == 'TOGGLE_REORDER':
+            self.keyToggleReorderOnReuse()
+
+    def keyAddNew(self):
+        virtualKeyboard = GetVirtualKeyboard()
+        self.session.openWithCallback(
+            self.addNewCallback,
+            virtualKeyboard,
+            title=guiSafeStr(_(u'New entry')),
+            text=''
+        )
+
+    def addNewCallback(self, newTitle=None):
+        if newTitle is None:
+            return
+
+        newTitle = toUnicode(newTitle).strip()
+
+        if not newTitle:
+            self.openInfoMessage(_(u'Empty title is not allowed.'), MessageBox.TYPE_ERROR)
+            return
+
+        self.entries.insert(0, HistoryEntry(newTitle))
+        removed = self.removeDuplicates()
+        self.dirty = True
+        self.setEntriesList(self.buildDisplayList(), 0)
+        self.updateStatus()
+
+        if removed:
+            self.openInfoMessage(_(u'%d duplicate entry removed.') % removed)
+
+    def keyToggleReorderOnReuse(self):
+        try:
+            self.reorderOnReuse = not self.reorderOnReuse
+            setReorderOnReuseEnabled(self.historyFile, self.reorderOnReuse)
+            self.updateStatus()
+
+            if self.reorderOnReuse:
+                msg = _(u'Reused entries move back to the top again.')
+            else:
+                msg = _(u'Order stays fixed - useful for T9 browsing.')
+            self.openInfoMessage(msg)
+        except Exception:
+            printExc()
+
+    def keyRename(self):
+        printDBG('SearchHistoryEditor.keyRename manualReorderMode=%s' % self.manualReorderMode)
+        if self.manualReorderMode:
+            self.keyManualPickOrDrop()
+            return
+
+        idx = self.getCurrentIndex()
+        if idx is None:
+            self.openInfoMessage(_(u'Please select an entry.'))
+            return
+
+        entry = self.entries[idx]
+        virtualKeyboard = GetVirtualKeyboard()
+        self.session.openWithCallback(
+            lambda newTitle=None: self.renameCallback(idx, newTitle),
+            virtualKeyboard,
+            title=guiSafeStr(_(u'Edit title')),
+            text=guiSafeStr(entry.title)
+        )
+
+    def renameCallback(self, idx, newTitle):
+        if newTitle is None:
+            return
+
+        newTitle = toUnicode(newTitle).strip()
+
+        if not newTitle:
+            self.openInfoMessage(_(u'Empty title is not allowed.'), MessageBox.TYPE_ERROR)
+            return
+
+        if 0 <= idx < len(self.entries):
+            self.entries[idx].title = newTitle
+
+            removed = self.removeDuplicates()
+            self.dirty = True
+            self.setEntriesList(self.buildDisplayList(), min(idx, max(0, len(self.entries) - 1)))
+            self.updateStatus()
+
+            if removed:
+                self.openInfoMessage(_(u'%d duplicate entry removed.') % removed)
+
+    def keyDelete(self):
+        if self.manualReorderMode:
+            return
+
+        idx = self.getCurrentIndex()
+        if idx is None:
+            self.openInfoMessage(_(u'Please select an entry.'))
+            return
+
+        entry = self.entries[idx]
+        message = toUnicode(_(u'Delete entry')) + u'\n' + toUnicode(entry.title)
+
+        self.session.openWithCallback(
+            lambda ret=None: self.deleteCallback(ret, idx),
+            MessageBox,
+            guiSafeStr(message),
+            type=MessageBox.TYPE_YESNO
+        )
+
+    def deleteCallback(self, ret, idx):
+        if not ret:
+            return
+        if 0 <= idx < len(self.entries):
+            del self.entries[idx]
+            self.dirty = True
+            self.setEntriesList(self.buildDisplayList(), idx)
+            self.updateStatus()
+
+    def keySave(self):
+        if self.manualReorderMode:
+            return
+        try:
+            removed = self.removeDuplicates()
+            sts = writeHistoryFile(self.historyFile, self.entries, self.reverseForWrite)
+
+            if sts:
+                self.dirty = False
+                self.setEntriesList(self.buildDisplayList(), self.getCurrentIndex())
+                self.updateStatus()
+
+                if removed:
+                    self.openInfoMessage(
+                        _(u'Search history saved. %d duplicate entries removed.') % removed
+                    )
+                else:
+                    self.openInfoMessage(_(u'Search history saved.'))
+            else:
+                self.openInfoMessage(_(u'Error while saving.'), MessageBox.TYPE_ERROR)
+        except Exception:
+            printExc()
+            self.openInfoMessage(_(u'Error while saving.'), MessageBox.TYPE_ERROR)
+
+    def openInfoMessage(self, text, msgType=MessageBox.TYPE_INFO, timeout=4):
+        try:
+            self.session.open(MessageBox, guiSafeStr(text), type=msgType, timeout=timeout)
+        except Exception:
+            printExc()
+
+    def keyExit(self):
+        if self.manualReorderMode:
+            self.keyStopManualSort()
+            return
+        if self.dirty:
+            self.session.openWithCallback(
+                self.exitCallback,
+                MessageBox,
+                guiSafeStr(_(u'There are unsaved changes. Save now?')),
+                type=MessageBox.TYPE_YESNO
+            )
+        else:
+            self.close(None)
+
+    def exitCallback(self, ret):
+        if ret:
+            self.keySave()
+        self.close(None)

--- a/hosts/hostfilmpalast.py
+++ b/hosts/hostfilmpalast.py
@@ -1,0 +1,727 @@
+# -*- coding: utf-8 -*-
+# Last Modified: 23.08.2026 - getSuggestionsProvider() added (forces Google search suggestions) - Kamikaze24
+###################################################
+# LOCAL import
+###################################################
+from Components.config import config, ConfigYesNo, getConfigListEntry
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
+from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass, RetHost
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, rm
+from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
+from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
+from Plugins.Extensions.IPTVPlayer.libs import ph
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, sidecarFromUrlMeta, decorateUrl, decorateCachedLinkItems, decorateResolvedLinkItems
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhostmixin import WatchedFlagHostMixin
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
+
+###################################################
+from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote
+from Plugins.Extensions.IPTVPlayer.p2p3.UrlParse import urljoin
+
+###################################################
+# FOREIGN import
+###################################################
+###################################################
+
+config.plugins.iptvplayer.filmpalast_mkv = ConfigYesNo(default=True)
+
+
+def GetConfigList():
+    # "Allow watched flag to be set" / "The color of the viewed item" / "Create sidecar
+    # files" now live in the global E2iPlayer settings (components/iptvconfigmenu.py),
+    # not per-host
+    optionList = [
+        getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.filmpalast_mkv),
+    ]
+    return optionList
+
+
+def gettytul():
+    return "https://filmpalast.to/"
+
+
+class FilmPalastTo(CBaseHostClass):
+
+    def __init__(self):
+        CBaseHostClass.__init__(self, {"history": "filmpalast.to", "cookie": "filmpalast.to.cookie"})
+        self.USER_AGENT = "Mozilla/5.0"
+        self.HEADER = {"User-Agent": self.USER_AGENT, "Accept": "text/html"}
+        self.AJAX_HEADER = dict(self.HEADER)
+        self.AJAX_HEADER.update({"X-Requested-With": "XMLHttpRequest"})
+
+        self.defaultParams = {"header": self.HEADER, "use_cookie": True, "load_cookie": True, "save_cookie": True, "cookiefile": self.COOKIE_FILE}
+
+        self.DEFAULT_ICON_URL = "https://filmpalast.to/themes/downloadarchive/images/logo.png"
+        self.MAIN_URL = None
+        self.cacheSeries = {}
+        self.cacheSeasons = {}
+        self.cacheLinks = {}
+        self.watchedHelper = IPTVWatchedHelper('filmpalastto')
+
+    def selectDomain(self):
+        self.MAIN_URL = "https://filmpalast.to/"
+        self.MAIN_CAT_TAB = [
+            {"category": "list_items", "title": _("Main"), "url": self.getMainUrl()},
+            {"category": "movies", "title": _("Movies")},
+            {"category": "series", "title": _("Series")},
+        ] + self.searchItems()
+
+        self.MOVIES_CAT_TAB = [
+            {"category": "list_items", "title": _("New"), "url": self.getFullUrl("/movies/new")},
+            {"category": "list_items", "title": _("Top"), "url": self.getFullUrl("/movies/top")},
+            {"category": "movies_cats", "title": _("Categories"), "url": self.getFullUrl("/movies/new")},
+            {"category": "movies_abc", "title": _("Alphabetically"), "url": self.getFullUrl("/movies/new")},
+        ]
+
+        self.SERIES_CAT_TAB = [
+            {"category": "list_items", "title": _("--All Episodes--"), "url": self.getFullUrl("/serien/view")},
+            {"category": "series_abc", "title": _("Alphabetically"), "url": self.getFullUrl("/serien/view")},
+        ]
+
+    def getPage(self, baseUrl, addParams={}, post_data=None):
+        if addParams == {}:
+            addParams = dict(self.defaultParams)
+        addParams["cloudflare_params"] = {"cookie_file": self.COOKIE_FILE, "User-Agent": self.USER_AGENT}
+        return self.cm.getPageCFProtection(baseUrl, addParams, post_data)
+
+    def getFullIconUrl(self, url):
+        url = self.getFullUrl(url)
+        if url == "":
+            return ""
+        cookieHeader = self.cm.getCookieHeader(self.COOKIE_FILE)
+        return strwithmeta(url, {"Cookie": cookieHeader, "User-Agent": self.USER_AGENT})
+
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict):
+                return ""
+            itemType = cItem.get("type", "")
+            category = cItem.get("category", "")
+            if itemType in ["video", "audio"]:
+                url = str(cItem.get("url", "") or "").strip()
+                if url != "":
+                    return "url:%s" % url
+                return ""
+            if category == "explore_item":
+                url = str(cItem.get("url", "") or "").strip()
+                if url != "":
+                    return "url:%s" % url
+                return ""
+            if category == "list_episodes":
+                baseUrl = str(cItem.get("series_url", "") or "").strip() or str(cItem.get("url", "") or "").strip()
+                seasonId = str(cItem.get("season_num", "") or "").strip() or str(cItem.get("f_season", "") or "").strip()
+                if baseUrl != "" and seasonId != "":
+                    return "season:%s|%s" % (baseUrl, seasonId)
+                return ""
+            if category == "list_seasons":
+                url = str(cItem.get("url", "") or "").strip()
+                if url != "":
+                    return "series:%s" % url
+                return ""
+            return ""
+        except Exception:
+            printExc()
+        return ""
+
+    def _listLinks(self, cItem, m1, m2):
+        sts, data = self.getPage(cItem["url"])
+        if not sts:
+            return []
+
+        retTab = []
+        data = self.cm.ph.getDataBeetwenMarkers(data, m1, m2)[1]
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, "<a", "</a>")
+        for item in data:
+            url = self.getFullUrl(self.cm.ph.getSearchGroups(item, """href=['"]([^'^"]+?)['"]""")[0])
+            title = self.cleanHtmlStr(item)
+            retTab.append({"title": title, "url": url})
+        return retTab
+
+    def listSeriesABC(self, cItem, nextCategory):
+        printDBG("FilmPalastTo.listSeriesABC |%s|" % cItem)
+        self.cacheSeries = {"letters": []}
+        tab = self._listLinks(cItem, 'id="serien"', "</ul>")
+        for item in tab:
+            letter = item["title"][0]
+            if not letter.isalpha():
+                letter = "#"
+            if letter not in self.cacheSeries:
+                self.cacheSeries["letters"].append(letter)
+                self.cacheSeries[letter] = []
+                params = dict(cItem)
+                params.update({"category": nextCategory, "title": letter, "f_letter": letter})
+                self.addDir(params)
+            self.cacheSeries[letter].append(item)
+
+        params = dict(cItem)
+        params.update({"category": nextCategory, "title": _("--All--"), "f_letter": ""})
+        self.currList.insert(0, params)
+
+    def listSeriesByLetter(self, cItem, nextCategory):
+        printDBG("FilmPalastTo.listSeriesByLetter |%s|" % cItem)
+
+        if "" == cItem.get("f_letter", ""):
+            letters = self.cacheSeries["letters"]
+        else:
+            letters = [cItem["f_letter"]]
+
+        for letter in letters:
+            for item in self.cacheSeries[letter]:
+                params = dict(cItem)
+                params.update(item)
+                params["icon"] = self.getFullIconUrl("/files/movies/450/%s.jpg" % item["url"].split("/")[-1])
+                params["category"] = nextCategory
+                self.addDir(params)
+
+    def listCats(self, cItem, nextCategory, m1, m2):
+        printDBG("FilmPalastTo.listCats |%s|" % cItem)
+
+        tab = self._listLinks(cItem, m1, m2)
+        for item in tab:
+            params = dict(cItem)
+            params.update(item)
+            params["category"] = nextCategory
+            self.addDir(params)
+
+    def listItems(self, cItem, nextCategory):
+        printDBG("FilmPalastTo.listItems |%s|" % cItem)
+
+        url = cItem["url"]
+        page = cItem.get("page", 1)
+
+        if "?" not in url:
+            if page > 1:
+                if not url.endswith("/"):
+                    url += "/"
+                if "/search/" not in url:
+                    url += "page/"
+                url += str(page)
+
+        sts, data = self.getPage(url)
+        if not sts:
+            return
+
+        if "vorw&auml;rts&nbsp;+" in data:
+            nextPage = True
+        else:
+            nextPage = False
+
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, "<article", "</article>")
+        for item in data:
+            url = self.getFullUrl(self.cm.ph.getSearchGroups(item, """href=['"]([^'^"]+?)['"]""")[0])
+            icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(item, r"""src=['"]([^'^"]+?\.jpe?g)['"]""")[0])
+            title = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, """title=['"]([^'^"]+)['"]""")[0])
+
+            # get desc
+            sts, tmp = self.cm.ph.getDataBeetwenMarkers(item, '<ul class="clearfix">', "</ul>")
+            if not sts:
+                rating = item.count("/star_on.png")
+                desc = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(item, "<small", "</small>")[1])
+                desc = "%d/10 %s" % (rating, desc)
+            else:
+                desc = []
+                tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<li", "</li>")
+                for t in tmp:
+                    t = t.split("</span>")
+                    for t1 in t:
+                        t1 = self.cleanHtmlStr(t1)
+                        if t1 != "":
+                            desc.append(t1)
+                desc = "[/br]".join(desc)
+            # get desc end
+
+            params = dict(cItem)
+            params.update({"good_for_fav": True, "category": nextCategory, "title": title, "url": url, "icon": icon, "desc": desc})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addDir(params)
+
+        if nextPage:
+            params = dict(cItem)
+            params.update({"good_for_fav": False, "title": _("Next page"), "page": page + 1})
+            self.addDir(params)
+
+    def listEpisodes(self, cItem):
+        printDBG("FilmPalastTo.listEpisodes")
+        seasonId = cItem.get("f_season", "")
+        tab = self.cacheSeasons.get(seasonId, [])
+        for item in tab:
+            params = dict(cItem)
+            params.update(item)
+            params.pop("isWatched", None)
+            # cItem is the season item (category="list_episodes") - clear it here so this
+            # episode isn't mistaken for its own season/series container elsewhere
+            params.pop("category", None)
+            # params['icon'] = self.getFullIconUrl('/files/movies/450/%s.jpg' % item['url'].split('/')[-1])
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addVideo(params)
+
+    def _buildSeasonItem(self, seasonId):
+        return {"category": "list_episodes", "url": self.currItem.get("url", ""), "f_season": seasonId}
+
+    def _propagateEpisodeWatchedState(self, item):
+        # recomputes season+series state right when an episode's own watched/started
+        # state changes, instead of relying on exploreItem() being re-run later - the
+        # "refresh from cache" shortcut used after playback/marking often skips that
+        try:
+            if not isinstance(item, dict):
+                return
+            seasonId = str(item.get("season_num", "") or item.get("f_season", "") or "").strip()
+            if seasonId == "":
+                return
+            seriesUrl = str(item.get("series_url", "") or item.get("url", "") or self.currItem.get("url", "") or "").strip()
+            seasonParent = {"category": "list_episodes", "url": seriesUrl, "series_url": seriesUrl, "season_num": seasonId}
+            seasonEpisodes = self.cacheSeasons.get(seasonId, [])
+            if seasonEpisodes:
+                self.watchedHelper.updateParentWatchedState(seasonParent, seasonEpisodes, self._getWatchedKeyForItem)
+            if seriesUrl != "":
+                seriesParent = {"category": "list_seasons", "url": seriesUrl}
+                seasonChildren = [{"category": "list_episodes", "url": seriesUrl, "series_url": seriesUrl, "season_num": str(sid)} for sid in list(self.cacheSeasons.keys())]
+                self.watchedHelper.updateParentWatchedState(seriesParent, seasonChildren, self._getWatchedKeyForItem)
+        except Exception:
+            printExc()
+
+    def exploreItem(self, cItem, nextCategory):
+        printDBG("FilmPalastTo.exploreItem")
+        url = cItem["url"]
+        sts, data = self.getPage(url)
+        if not sts:
+            return
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, '<ul class="staffelNav', "</ul>")[1]
+        if 'data-id="staffId' not in data:
+            params = dict(cItem)
+            params.pop("isWatched", None)
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addVideo(params)
+            return
+        if "" != self.cm.ph.getSearchGroups(cItem["title"] + " ", r"""\s([Ss][0-9]+[Ee][0-9]+)\s""")[0]:
+            params = dict(cItem)
+            params.pop("isWatched", None)
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addVideo(params)
+        self.cacheSeasons = {}
+        seasonTitles = {}
+        seasonParams = {}
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, '<ul class="staffelNav', "</ul>")[1]
+        tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<li", "</li>")
+        for item in tmp:
+            seasonId = self.cm.ph.getSearchGroups(item, """data-id=['"]([^"^']+?)['"]""")[0]
+            title = self.cleanHtmlStr(item)
+            seasonTitles[seasonId] = title
+        sp = '<div class="staffelWrapperLoop'
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, sp, '<a name="comments_view">', False)[1]
+        tmp = tmp.split(sp)
+        for item in tmp:
+            seasonId = self.cm.ph.getSearchGroups(item, """id=['"]([^"^']+?)['"]""")[0]
+            item = self.cm.ph.getAllItemsBeetwenMarkers(item, "<a", "</a>")
+            for it in item:
+                url = self.getFullUrl(self.cm.ph.getSearchGroups(it, """href=['"]([^'^"]+?)['"]""")[0])
+                if not url:
+                    continue
+                title = self.cleanHtmlStr(it)
+                if seasonId not in self.cacheSeasons:
+                    self.cacheSeasons[seasonId] = []
+                    params = dict(cItem)
+                    params.pop("isWatched", None)
+                    params.update({"good_for_fav": False, "category": nextCategory, "title": seasonTitles.get(seasonId, seasonId), "f_season": seasonId})
+                    params["isWatched"] = False
+                    seasonParams[seasonId] = params
+                    self.addDir(params)
+                episodeParams = {"good_for_fav": True, "title": title, "url": url, "type": "video", "series_url": cItem.get("url", ""), "season_num": str(seasonId)}
+                self.cacheSeasons[seasonId].append(episodeParams)
+
+        for seasonId, seasonEpisodes in self.cacheSeasons.items():
+            if seasonId not in seasonParams:
+                continue
+            self.watchedHelper.updateParentWatchedState(seasonParams[seasonId], seasonEpisodes, self._getWatchedKeyForItem)
+
+        seriesItem = {"category": "list_seasons", "url": cItem.get("url", "")}
+        seriesKey = self._getWatchedKeyForItem(seriesItem)
+        if seriesKey != "":
+            self.watchedHelper.updateParentWatchedState(seriesItem, [seasonParams[seasonId] for seasonId in seasonParams], self._getWatchedKeyForItem)
+
+    def listSearchResult(self, cItem, searchPattern, searchType):
+        printDBG("FilmPalastTo.listSearchResult cItem[%s], searchPattern[%s] searchType[%s]" % (cItem, searchPattern, searchType))
+        cItem = dict(cItem)
+        cItem["url"] = self.getFullUrl("/search/title/%s" % urllib_quote(searchPattern))
+        self.listItems(cItem, "explore_item")
+
+    def getLinksForVideo(self, cItem):
+        printDBG("FilmPalastTo.getLinksForVideo [%s]" % cItem)
+        # NOTE: marking the item "started" happens later, in iptvplayerwidget.py's
+        # playVideo() - not here. This method resolves links for both actually
+        # streaming AND downloading, and can also fail/return nothing, so marking
+        # here would (and used to) tag failed attempts and downloads as "started" too.
+        linksTab = []
+        sidecarTxt = ""
+        sidecarImg = ""
+        sidecarEnabled = IsSidecarEnabled()
+        imdb_rating = cItem.get("imdb_rating", "")
+        sidecarYear = ""
+        sidecarDuration = ""
+        sidecarGenre = ""
+
+        if sidecarEnabled or config.plugins.iptvplayer.filmpalast_mkv.value:
+            try:
+                article = self.getArticleContent(cItem)
+                if article and isinstance(article, list):
+                    articleItem = article[0]
+                    sidecarTxt = articleItem.get("text", "")
+                    images = articleItem.get("images", [])
+                    if images and images[0].get("url"):
+                        sidecarImg = images[0].get("url")
+
+                    otherInfo = articleItem.get("other_info", {})
+                    if not imdb_rating or imdb_rating == "-":
+                        imdb_rating = otherInfo.get("imdb_rating", "")
+                    sidecarYear = otherInfo.get("year", "") or otherInfo.get("released", "")
+                    sidecarDuration = otherInfo.get("duration", "")
+                    sidecarGenre = otherInfo.get("genre", "")
+            except Exception:
+                printExc("getArticleContent for sidecar failed")
+
+        if not sidecarTxt:
+            sidecarTxt = cItem.get("desc", "")
+        if not sidecarImg:
+            sidecarImg = cItem.get("icon", "")
+
+        sidecarLines = []
+
+        if imdb_rating and imdb_rating != "-":
+            sidecarLines.append(u"IMDb: %s" % imdb_rating)
+
+        infoLine = []
+        if sidecarYear:
+            infoLine.append(u"Jahr: %s" % sidecarYear)
+        if sidecarDuration:
+            infoLine.append(u"Spielzeit: %s" % sidecarDuration)
+        if infoLine:
+            sidecarLines.append(u" / ".join(infoLine))
+
+        if sidecarGenre:
+            sidecarLines.append(sidecarGenre)
+
+        if sidecarLines:
+            prefix = u"\n".join(sidecarLines)
+            if sidecarTxt:
+                if not sidecarTxt.startswith("IMDb:"):
+                    sidecarTxt = prefix + u"\n\n" + sidecarTxt
+            else:
+                sidecarTxt = prefix
+
+        sidecar = buildSidecar(sidecarEnabled, sidecarTxt, sidecarImg)
+
+        linksTab = self.cacheLinks.get(cItem["url"], [])
+        if len(linksTab) > 0:
+            return decorateCachedLinkItems(linksTab, sidecar)
+
+        sts, data = self.getPage(cItem["url"], self.defaultParams)
+        if not sts:
+            return []
+
+        data = ph.findall(data, ("<ul", ">", "currentStreamLinks"), "</ul>", flags=0)
+        for item in data:
+            printDBG("FilmPalastTo.getLinksForVideo item [%s]" % item)
+            url = self.getFullUrl(self.cm.ph.getSearchGroups(item, """href=['"]([^"^']+?)['"]""")[0])
+            title = ph.clean_html(ph.find(item, ("<p", ">"), "</p>", flags=0)[1])
+            if title == "":
+                title = ph.clean_html(item)
+
+            url = decorateUrl(url, referer=cItem["url"], sidecar=sidecar)
+            linksTab.append({"name": title, "url": url, "need_resolve": 1})
+
+        if len(linksTab):
+            self.cacheLinks[cItem["url"]] = linksTab
+
+        return linksTab
+
+    def getVideoLinks(self, videoUrl):
+        printDBG("FilmPalastTo.getVideoLinks [%s]" % videoUrl)
+        linksTab = []
+
+        videoUrl = strwithmeta(videoUrl)
+
+        cfgSidecarEnabled = IsSidecarEnabled()
+        cfgMkvEnabled = config.plugins.iptvplayer.filmpalast_mkv.value
+        sidecar = sidecarFromUrlMeta(videoUrl, cfgSidecarEnabled)
+
+        def _addFinalMeta(videoLinks):
+            return decorateResolvedLinkItems(videoLinks, sidecar, cfgMkvEnabled)
+
+        key = videoUrl.meta.get("links_key", "")
+        if key != "":
+            if key in self.cacheLinks:
+                for idx in range(len(self.cacheLinks[key])):
+                    if self.cacheLinks[key][idx]["url"] == videoUrl and not self.cacheLinks[key][idx]["name"].startswith("*"):
+                        self.cacheLinks[key][idx]["name"] = "*" + self.cacheLinks[key][idx]["name"]
+
+        data_id = videoUrl.meta.get("data_id", "")
+        data_stamp = videoUrl.meta.get("data_stamp", "")
+
+        if data_id and data_stamp:
+            # sts, data = self.getPage(key, self.defaultParams)
+            # if not sts: return []
+
+            url = self.getFullUrl("/stream/%s/%s" % (data_id, data_stamp))
+            urlParams = dict(self.defaultParams)
+            urlParams["header"] = dict(self.AJAX_HEADER)
+            urlParams["header"]["Referer"] = key
+            sts, data = self.getPage(url, urlParams, {"streamID": data_id})
+            if not sts:
+                return []
+
+            try:
+                data = json_loads(data)
+                url = data.get("url", "")
+                if self.cm.isValidUrl(url):
+                    return _addFinalMeta(self.up.getVideoLinkExt(url))
+                SetIPTVPlayerLastHostError(data["msg"])
+            except Exception:
+                printExc()
+        else:
+            linksTab = _addFinalMeta(self.up.getVideoLinkExt(videoUrl))
+
+        return linksTab
+
+    def getArticleContent(self, cItem):
+        printDBG("FilmPalastTo.getArticleContent [%s]" % cItem)
+        retTab = []
+
+        otherInfo = {}
+
+        sts, data = self.getPage(cItem["url"])
+        if not sts:
+            return []
+
+        data = self.cm.ph.getDataBeetwenMarkers(data, '<div id="content" role="main">', "</ul>")[1]
+
+        title = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, "<h2", "</h2>")[1])
+        desc = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, '<span class="hidden', "</span>")[1])
+        icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(data, r"""src=['"]([^"^']+\.jpe?g)['"]""")[0])
+
+        tmpTab = []
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, "enre</p>", "</li>", False)[1]
+        tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<a", "</a>")
+        for t in tmp:
+            tmpTab.append(self.cleanHtmlStr(t))
+        if len(tmpTab):
+            otherInfo["genre"] = ", ".join(tmpTab)
+
+        tmpTab = []
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, "chauspieler</p>", "</li>", False)[1]
+        tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<a", "</a>")
+        for t in tmp:
+            tmpTab.append(self.cleanHtmlStr(t))
+        if len(tmpTab):
+            otherInfo["actors"] = ", ".join(tmpTab)
+
+        tmpTab = []
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, "chöpfer</p>", "</li>", False)[1]
+        tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<a", "</a>")
+        for t in tmp:
+            tmpTab.append(self.cleanHtmlStr(t))
+        if len(tmpTab):
+            otherInfo["creators"] = ", ".join(tmpTab)
+
+        tmpTab = []
+        tmp = self.cm.ph.getDataBeetwenMarkers(data, "egie</p>", "</li>", False)[1]
+        tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<a", "</a>")
+        for t in tmp:
+            tmpTab.append(self.cleanHtmlStr(t))
+        if len(tmpTab):
+            otherInfo["director"] = ", ".join(tmpTab)
+
+        tmp = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, "hortinfos</p>", "</strong>", False)[1])
+        if tmp != "":
+            otherInfo["views"] = tmp
+
+        tmp = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, "Ver&ouml;ffentlicht:", "<", False)[1])
+        if tmp != "":
+            otherInfo["released"] = tmp
+
+        tmp = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, "<em>", "</em>", False)[1])
+        if tmp != "":
+            otherInfo["duration"] = tmp
+
+        tmp = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, "Imdb:", "<", False)[1])
+        if tmp != "":
+            otherInfo["imdb_rating"] = tmp
+
+        tmp = self.cleanHtmlStr(self.cm.ph.getDataBeetwenMarkers(data, '<span class="average">', "<span", False)[1])
+        if tmp != "":
+            otherInfo["rating"] = tmp
+
+        if title == "":
+            title = cItem["title"]
+        if desc == "":
+            desc = cItem.get("desc", "")
+        if icon == "":
+            icon = cItem.get("icon", self.DEFAULT_ICON_URL)
+
+        return [{"title": self.cleanHtmlStr(title), "text": self.cleanHtmlStr(desc), "images": [{"title": "", "url": self.getFullUrl(icon)}], "other_info": otherInfo}]
+
+    def handleService(self, index, refresh=0, searchPattern="", searchType=""):
+        printDBG("handleService start")
+
+        CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
+        if self.MAIN_URL is None:
+            # rm(self.COOKIE_FILE)
+            self.selectDomain()
+
+        name = self.currItem.get("name", "")
+        category = self.currItem.get("category", "")
+        mode = self.currItem.get("mode", "")
+
+        printDBG("handleService: |||||||||||||||||||||||||||||||||||| name[%s], category[%s] " % (name, category))
+        self.currList = []
+
+        # MAIN MENU
+        if name is None:
+            self.listsTab(self.MAIN_CAT_TAB, {"name": "category"})
+        elif "movies" == category:
+            self.listsTab(self.MOVIES_CAT_TAB, self.currItem)
+        elif "movies_cats" == category:
+            self.listCats(self.currItem, "list_items", 'id="genre"', "</ul>")
+        elif "movies_abc" == category:
+            self.listCats(self.currItem, "list_items", 'id="movietitle"', "</ul>")
+
+        elif "series" == category:
+            self.listsTab(self.SERIES_CAT_TAB, self.currItem)
+        elif "series_abc" == category:
+            self.listSeriesABC(self.currItem, "series_by_letter")
+        elif "series_by_letter" == category:
+            self.listSeriesByLetter(self.currItem, "explore_item")
+
+        elif "list_items" == category:
+            self.listItems(self.currItem, "explore_item")
+        elif "explore_item" == category:
+            self.exploreItem(self.currItem, "list_episodes")
+        elif "list_episodes" == category:
+            self.listEpisodes(self.currItem)
+
+        # SEARCH
+        elif category in ["search", "search_next_page"]:
+            cItem = dict(self.currItem)
+            cItem.update({"search_item": False, "name": "category"})
+            self.listSearchResult(cItem, searchPattern, searchType)
+        # HISTORIA SEARCH
+        elif category == "search_history":
+            self.listsHistory({"name": "history", "category": "search"}, "desc")
+        else:
+            printExc()
+
+        CBaseHostClass.endHandleService(self, index, refresh)
+
+
+class IPTVHost(WatchedFlagHostMixin, CHostBase):
+
+    def __init__(self):
+        CHostBase.__init__(self, FilmPalastTo(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('filmpalastto')
+
+    def _setWatchedStateForSeasonItem(self, seasonItem, action):
+        try:
+            seasonId = str(seasonItem.get('season_num', '') or seasonItem.get('f_season', '') or '').strip()
+            seasonKey = self.host._getWatchedKeyForItem(seasonItem)
+            if seasonKey == '':
+                return False
+            changed = False
+            for episodeItem in self.host.cacheSeasons.get(seasonId, []):
+                episodeKey = self.host._getWatchedKeyForItem(episodeItem)
+                if episodeKey == '':
+                    continue
+                if action == 'set_watched_flag':
+                    changed = self.watchedHelper.markItemWatched(episodeItem, episodeKey) or changed
+                else:
+                    changed = self.watchedHelper.unmarkItemWatched(episodeItem, episodeKey) or changed
+            if action == 'set_watched_flag':
+                changed = self.watchedHelper.markItemWatched(seasonItem, seasonKey) or changed
+            else:
+                changed = self.watchedHelper.unmarkItemWatched(seasonItem, seasonKey) or changed
+            return changed
+        except Exception:
+            printExc()
+            return False
+
+    def _setWatchedStateForSeriesItem(self, seriesItem, action):
+        try:
+            seriesUrl = str(seriesItem.get('url', '') or '').strip()
+            if seriesUrl == '':
+                return False
+            changed = False
+            for seasonId in list(self.host.cacheSeasons.keys()):
+                seasonItem = {'category': 'list_episodes', 'url': seriesUrl, 'series_url': seriesUrl, 'season_num': str(seasonId)}
+                changed = self._setWatchedStateForSeasonItem(seasonItem, action) or changed
+            seriesKey = self.host._getWatchedKeyForItem(seriesItem)
+            if seriesKey == '':
+                return changed
+            if action == 'set_watched_flag':
+                changed = self.watchedHelper.markItemWatched(seriesItem, seriesKey) or changed
+            else:
+                changed = self.watchedHelper.unmarkItemWatched(seriesItem, seriesKey) or changed
+            return changed
+        except Exception:
+            printExc()
+            return False
+
+    def _refreshParentStateAfterAction(self, item, action):
+        try:
+            if not isinstance(item, dict):
+                return
+            category = str(item.get('category', '') or '').strip()
+            if category == 'list_episodes':
+                seasonId = str(item.get('season_num', '') or item.get('f_season', '') or '').strip()
+                if seasonId != '':
+                    seasonParent = dict(item)
+                    seasonParent.pop('isWatched', None)
+                    seasonEpisodes = self.host.cacheSeasons.get(seasonId, [])
+                    if seasonEpisodes:
+                        self.watchedHelper.updateParentWatchedState(seasonParent, seasonEpisodes, self.host._getWatchedKeyForItem)
+                    seriesUrl = str(item.get('series_url', '') or self.host.currItem.get('url', '') or '').strip()
+                    if seriesUrl != '':
+                        seriesParent = {'category': 'list_seasons', 'url': seriesUrl}
+                        seasonChildren = [{'category': 'list_episodes', 'url': seriesUrl, 'series_url': seriesUrl, 'season_num': str(sid)} for sid in list(self.host.cacheSeasons.keys())]
+                        self.watchedHelper.updateParentWatchedState(seriesParent, seasonChildren, self.host._getWatchedKeyForItem)
+            elif category == 'list_seasons':
+                seriesUrl = str(item.get('url', '') or '').strip()
+                if seriesUrl != '':
+                    seriesParent = {'category': 'list_seasons', 'url': seriesUrl}
+                    seasonChildren = [{'category': 'list_episodes', 'url': seriesUrl, 'series_url': seriesUrl, 'season_num': str(sid)} for sid in list(self.host.cacheSeasons.keys())]
+                    self.watchedHelper.updateParentWatchedState(seriesParent, seasonChildren, self.host._getWatchedKeyForItem)
+            elif str(item.get('type', '') or '').strip() in ['video', 'audio']:
+                # item is a single episode (category is intentionally empty for these,
+                # see listEpisodes()) - recompute its season+series from current state
+                self.host._propagateEpisodeWatchedState(item)
+        except Exception:
+            printExc()
+
+    def performCustomAction(self, privateData):
+        ret = self.watchedHelper.performCustomAction(privateData)
+        if ret.status == RetHost.OK:
+            self.refreshAfterWatchedFlagChange = True
+            try:
+                action = privateData.get('action', '')
+                if action in ('unset_watched_flag', 'set_watched_flag'):
+                    idx = privateData.get('item_index', -1)
+                    item = self.host.currList[idx] if 0 <= idx < len(self.host.currList) else {}
+                    category = item.get('category', '')
+                    if category == 'list_episodes':
+                        self._setWatchedStateForSeasonItem(item, action)
+                    elif category == 'list_seasons':
+                        self._setWatchedStateForSeriesItem(item, action)
+                    self._refreshParentStateAfterAction(item, action)
+                    self.watchedHelper.recomputeAllGroupsWatched(self.host.cacheSeasons, self.host._getWatchedKeyForItem, self.host._buildSeasonItem)
+            except Exception:
+                printExc()
+        return ret
+
+    def getSuggestionsProvider(self, index=-1):
+        from Plugins.Extensions.IPTVPlayer.suggestions.google import SuggestionsProvider as google_Provider
+        return RetHost(status=RetHost.OK, value=[google_Provider()])
+
+    def withArticleContent(self, cItem):
+        if "video" == cItem.get("type", "") or "explore_item" == cItem.get("category", ""):
+            return True
+        return False

--- a/hosts/hostserienstreamto.py
+++ b/hosts/hostserienstreamto.py
@@ -1,0 +1,785 @@
+# -*- coding: utf-8 -*-
+# Last Modified: 23.08.2026 - withArticleContent() now checks type for episodes, fixes wrong Info text on episode press, getSuggestionsProvider() added (forces Google search suggestions) - Kamikaze24
+import re
+import json
+
+from Plugins.Extensions.IPTVPlayer.components.e2ivkselector import GetVirtualKeyboard
+from Plugins.Extensions.IPTVPlayer.components.asynccall import MainSessionWrapper
+from Components.config import ConfigSelection, config, getConfigListEntry, ConfigYesNo, ConfigText
+from Plugins.Extensions.IPTVPlayer.components.ihost import CBaseHostClass, CHostBase, RetHost
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
+from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote_plus
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, sidecarFromUrlMeta, decorateUrl, decorateResolvedLinkItems
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhostmixin import WatchedFlagHostMixin
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
+
+
+config.plugins.iptvplayer.serienstreamto_hosts = ConfigSelection(default="http://186.2.175.5/", choices=[("http://186.2.175.5/", "186.2.175.5"), ("https://serienstream.to/", "serienstream.to"), ("https://serienstream.cx/", "serienstream.cx")])  # NOSONAR
+config.plugins.iptvplayer.serienstreamto_uselogin = ConfigYesNo(default=False)
+config.plugins.iptvplayer.serienstreamto_login = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.serienstreamto_password = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.serienstreamto_omdb_apikey = ConfigText(default="", fixed_size=False)
+config.plugins.iptvplayer.serienstreamto_mkv = ConfigYesNo(default=True)
+config.plugins.iptvplayer.serienstreamto_legacy_titles = ConfigYesNo(default=False)
+
+
+def GetConfigList():
+    # "Allow watched flag to be set" / "The color of the viewed item" / "Create sidecar
+    # files" now live in the global E2iPlayer settings (components/iptvconfigmenu.py),
+    # not per-host
+    optionList = [getConfigListEntry(_("Use login") + ":", config.plugins.iptvplayer.serienstreamto_uselogin),
+                  getConfigListEntry(_("e-mail") + ":", config.plugins.iptvplayer.serienstreamto_login),
+                  getConfigListEntry(_("password") + ":", config.plugins.iptvplayer.serienstreamto_password),
+                  getConfigListEntry(_("OMDb API Key") + ":", config.plugins.iptvplayer.serienstreamto_omdb_apikey),
+                  getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.serienstreamto_mkv),
+                  getConfigListEntry(_("Use legacy title format") + ":", config.plugins.iptvplayer.serienstreamto_legacy_titles)]
+    optionList.append(getConfigListEntry(_("host") + ":", config.plugins.iptvplayer.serienstreamto_hosts))
+    return optionList
+
+
+def gettytul():
+    return "https://serienstream.to/"
+
+
+def language(item):
+    lang_map = {"german": "(DE)", "english": "(EN)", "english-german": "(EN/DE-UT)"}
+    flags = re.findall(r'<use href="#icon-flag-([^"]+)', item)
+    return "" if not flags else " ".join(lang_map.get(f, f) for f in flags)
+
+
+class SerienStreamTo(CBaseHostClass):
+    def __init__(self):
+        CBaseHostClass.__init__(self, {"history": "SerienStreamTo", "cookie": "SerienStreamTo.cookie"})
+        self.HEADER = self.cm.getDefaultHeader()
+        self.defaultParams = {"header": self.HEADER, "use_cookie": True, "load_cookie": True, "save_cookie": True, "cookiefile": self.COOKIE_FILE}
+        self.MAIN_URL = config.plugins.iptvplayer.serienstreamto_hosts.value
+        self.DEFAULT_ICON_URL = "https://raw.githubusercontent.com/oe-mirrors/e2iplayer/gh-pages/Thumbnails/serienstream.to.png"
+        self.imdb_cache = {}
+        self.cacheSeriesSeasons = {}
+        self.sessionEx = MainSessionWrapper()
+        self.watchedHelper = IPTVWatchedHelper('serienstreamto')
+        self.MENU = [{"category": "list_items", "title": _("Series"), "url": self.getFullUrl("suche")},
+                     {"category": "list_newepisodes", "title": "Neueste Episoden"},
+                     {"category": "list_items", "title": _("Collections"), "url": self.getFullUrl("sammlungen")},
+                     {"category": "list_value", "title": _("Genres"), "s": ">Genres</h2>"},
+                     {"category": "list_AZ", "title": "A-Z"},
+                     {"category": "list_value", "title": _("Country"), "s": ">Länder</h2>"},
+                     {"category": "list_value", "title": _("Persons"), "s": ">Personen</h2>"},
+                     {"category": "list_items", "title": _("All"), "url": self.getFullUrl("serien")}] + self.searchItems()
+
+    def _useLegacyTitles(self):
+        return config.plugins.iptvplayer.serienstreamto_legacy_titles.value
+
+    def _getWatchedKeyForItem(self, cItem):
+        # printDBG("SerienStreamTo._getWatchedKeyForItem")
+        try:
+            if not isinstance(cItem, dict):
+                return ""
+            itemType = str(cItem.get("type", "") or "").strip()
+            category = str(cItem.get("category", "") or "").strip()
+            if itemType in ["video", "audio"]:
+                url = str(cItem.get("url", "") or "").strip()
+                if url == "":
+                    return ""
+                return "url:%s" % url
+            if category == "list_episodes":
+                seriesUrl = str(cItem.get("series_url", "") or "").strip()
+                seasonNum = str(cItem.get("season_num", "") or "").strip()
+                if seriesUrl == "" or seasonNum == "":
+                    return ""
+                return "season:%s|%s" % (seriesUrl, seasonNum)
+            if category == "list_seasons":
+                url = str(cItem.get("url", "") or "").strip()
+                if url == "":
+                    return ""
+                return "series:%s" % url
+            if category == "list_newepisodes":
+                url = str(cItem.get("url", "") or "").strip()
+                if url == "":
+                    return ""
+                return "url:%s" % url
+            return ""
+        except Exception:
+            printExc()
+            return ""
+
+    def _buildCurrentSeasonItem(self):
+        return {"category": "list_episodes", "series_url": self.currItem.get("series_url", ""), "season_num": str(self.currItem.get("season_num", ""))}
+
+    def _buildSeriesItem(self, seriesUrl):
+        return {"category": "list_seasons", "url": seriesUrl}
+
+    def _propagateEpisodeWatchedState(self, item):
+        # recomputes season+series state right when an episode's own watched/started
+        # state changes, instead of relying on listEpisodes()/listSeasons() being
+        # re-run later - the "refresh from cache" shortcut used after playback/marking
+        # often skips that
+        try:
+            if not isinstance(item, dict):
+                return
+            seriesUrl = str(item.get("series_url", "") or "").strip()
+            seasonNum = str(item.get("season_num", "") or "").strip()
+            if seriesUrl == "" or seasonNum == "":
+                return
+            seasonParent = {"category": "list_episodes", "series_url": seriesUrl, "season_num": seasonNum}
+            seasonEpisodes = [child for child in self.currList if isinstance(child, dict) and child.get("type", "") in ["video", "audio"]]
+            if seasonEpisodes:
+                self.watchedHelper.updateParentWatchedState(seasonParent, seasonEpisodes, self._getWatchedKeyForItem)
+            seasonChildren = self.cacheSeriesSeasons.get(seriesUrl, [])
+            if seasonChildren:
+                self.watchedHelper.updateParentWatchedState({"category": "list_seasons", "url": seriesUrl}, seasonChildren, self._getWatchedKeyForItem)
+        except Exception:
+            printExc()
+
+    def getPage(self, baseUrl, addParams=None, post_data=None):
+        if addParams is None:
+            addParams = dict(self.defaultParams)
+        return self.cm.getPageCFProtection(baseUrl, addParams, post_data)
+
+    def getJumpItem(self, max_page, page, url, name):
+        name = (name or "category").split('-')[0] + "-JUMP"
+        if max_page:
+            return {"good_for_fav": False, "title": "%s %s/%s" % (_("Jump"), page, max_page),
+                    "desc": _("Jump to a selected page, max: {}").format(max_page),
+                    "category": "jump_to_page", "type": "category", "url": url, "name": name,
+                    "icon": "", "max_page": max_page, "current_page": page, "image_type": "JUMP"}
+        else:
+            return {"good_for_fav": False, "title": _("Jump"),
+                    "desc": _("Jump to a selected page"),
+                    "category": "jump_to_page", "type": "category", "url": url, "name": name,
+                    "icon": "", "max_page": max_page, "current_page": page, "image_type": "JUMP"}
+
+    def jumpToPage(self, cItem):
+        printDBG("SerienStreamTo.jumpToPage begin")
+        root_url = cItem["url"]
+        root_url = re.sub(r"/\d+/?$", "/", root_url)
+        root_url = re.sub(r"\?page=\d+|&page=\d+", "", root_url).rstrip("?&")
+        printDBG("ROOT JUMP: [%s]" % root_url)
+        max_page = int(cItem.get("max_page", 99))
+        if max_page < 1:
+            max_page = 99
+        current_page = int(cItem.get("current_page", 1))
+        if current_page > max_page:
+            current_page = max_page
+        title = _("Jump to a selected page, max: {}").format(max_page) if max_page else _("Jump to a selected page")
+        ret = self.sessionEx.waitForFinishOpen(GetVirtualKeyboard(), title=title, text=str(current_page))
+        if isinstance(ret, tuple) and len(ret):
+            ret = ret[0]
+        if not ret or not ret.strip():
+            page = current_page
+        elif ret.isdigit():
+            page = int(ret)
+        else:
+            page = current_page
+        if page < 1:
+            page = 1
+        if page > max_page:
+            page = max_page
+        sep = "?" if "?" not in root_url else "&"
+        jump_url = root_url + sep + "page=%s" % page
+        printDBG("JUMP von %d → %d: [%s]" % (current_page, page, jump_url))
+        jump_cItem = dict(cItem)
+        jump_cItem.pop("image_type", None)
+        jump_cItem.pop("imageType", None)
+        jump_cItem.update({"url": jump_url, "category": "list_items", "page": page, "max_page": max_page, "current_page": page})
+        self.currItem["url"] = jump_cItem["url"]
+        self.currItem["page"] = jump_cItem["page"]
+        self.currItem["max_page"] = jump_cItem["max_page"]
+        self.currItem["current_page"] = jump_cItem["current_page"]
+        self.currItem.pop("image_type", None)
+        self.currItem.pop("imageType", None)
+        self.listItems(jump_cItem)
+
+    def getMaxPageFromPagination(self, html):
+        pages = []
+        for m in re.finditer(r'href="[^"]*page=(\d+)[^"]*"', html, re.IGNORECASE):
+            try:
+                pages.append(int(m.group(1)))
+            except Exception:
+                pass
+        return max(pages) if pages else None
+
+    def extractImdbId(self, data):
+        if not data:
+            return ""
+        imdb_match = re.search(r"\b(tt\d{7,10})\b", data, re.IGNORECASE)
+        return imdb_match.group(1) if imdb_match else ""
+
+    def getOMDbData(self, imdb_id):
+        if not imdb_id:
+            return {}
+        if not re.match(r"^tt\d{7,10}$", imdb_id):
+            return {}
+        cache_key = "omdb_%s" % imdb_id
+        if cache_key in self.imdb_cache:
+            return self.imdb_cache[cache_key]
+        api_key = config.plugins.iptvplayer.serienstreamto_omdb_apikey.value.strip()
+        if not api_key:
+            return {}
+        api_url = "http://www.omdbapi.com/?i=%s&apikey=%s" % (imdb_id, api_key)
+        printDBG("||OMDb: %s" % api_url)
+        params = dict(self.defaultParams)
+        params["header"] = dict(self.HEADER)
+        params["header"]["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        params["timeout"] = 8
+        try:
+            sts, data = self.cm.getPage(api_url, params)
+            if not sts or not data:
+                return {}
+            j = json.loads(data)
+            if j.get("Response") != "True":
+                return {}
+            self.imdb_cache[cache_key] = j
+            return j
+        except Exception:
+            printExc("||OMDb EXCEPTION")
+            return {}
+
+    def getIMDBRating(self, imdb_id):
+        omdb = self.getOMDbData(imdb_id)
+        rating = omdb.get("imdbRating", "") if omdb else ""
+        if rating in ("", "N/A", None):
+            return "-"
+        return str(rating)
+
+    def listItems(self, cItem):
+        printDBG("SerienStreamTo.listItems |%s|" % cItem)
+        sts, htm = self.getPage(cItem["url"])
+        if not sts:
+            return
+        max_page = self.getMaxPageFromPagination(htm)
+        page = cItem.get("page", 1)
+        baseItem = dict(cItem)
+        baseItem.pop("image_type", None)
+        baseItem.pop("imageType", None)
+        if (baseItem.get("name", "") or "").endswith("-JUMP"):
+            baseItem["name"] = "category"
+        baseItem.pop("desc", None)
+        data = self.cm.ph.getAllItemsBeetwenMarkers(htm, 'class="col-6', "</div>")
+        if not data:
+            data = self.cm.ph.getAllItemsBeetwenMarkers(htm, 'class="series-item"', "</li>")
+        if not data:
+            data = self.cm.ph.getAllItemsBeetwenMarkers(htm, 'class="collection-item-cover', "</small>")
+        if data is None:
+            data = []
+        for item in data:
+            url = self.getFullUrl(self.cm.ph.getSearchGroups(item, 'href="([^"]+)')[0])
+            icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(item, 'src="([^"]+)')[0])
+            title1 = self.cm.ph.getSearchGroups(item, 'data-search="([^"]+)')[0]
+            title2 = self.cm.ph.getSearchGroups(item, 'title="([^"]+)')[0]
+            title = title1 or title2
+            params = dict(baseItem)
+            params.update({"good_for_fav": True, "category": "list_seasons", "title": self.cleanHtmlStr(title), "url": url, "icon": icon, "desc": ""})
+            if "sammlung" in url:
+                params.update({"category": "list_items"})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addDir(params)
+        if max_page and max_page > 1:
+            self.addDir({"title": "************************", "category": "empty"})
+            self.addDir(self.getJumpItem(max_page, page, cItem["url"], baseItem.get("name", "category")))
+            nextPage = self.cm.ph.getSearchGroups(htm, r'class="page-link"\s*href="([^"]+?)"\s*rel="next"')[0]
+            if nextPage:
+                next_params = dict(baseItem)
+                next_params.update({"page": page + 1, "title": _("Next page"), "max_page": max_page, "current_page": page + 1, "category": "list_items", "url": self.getFullUrl(nextPage)})
+                self.addDir(next_params)
+
+    def AZ(self, cItem):
+        az = [chr(t) for t in range(ord("A"), ord("Z") + 1)] + ["0-9"]
+        for title in az:
+            url = "katalog/" + title
+            params = dict(cItem)
+            params.update({"good_for_fav": False, "category": "list_items", "title": title, "url": self.getFullUrl(url)})
+            self.addDir(params)
+
+    def listSeasons(self, cItem):
+        printDBG("SerienStreamTo.listSeasons")
+        sts, data = self.getPage(cItem["url"])
+        if not sts:
+            return
+        trailer = self.cm.ph.getSearchGroups(data, 'data-trailer-url="([^"]+)')[0]
+        desc = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, 'description-text">([^<]+)')[0])
+        icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(data, 'data-src="([^"]+)')[0])
+        imdb_id = self.extractImdbId(data)
+        printDBG("IMDb DEBUG listSeasons id=[%s]" % imdb_id)
+        imdb_rating = self.getIMDBRating(imdb_id) if imdb_id else "-"
+        printDBG("IMDb DEBUG listSeasons rating=[%s]" % imdb_rating)
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'id="season-nav">', "</ul>")
+        if not data:
+            return
+        data = re.compile(r'href="([^"]+).*?data-season-pill="(\d+)', re.DOTALL).findall(data[0])
+        seriesUrl = cItem.get("url", "")
+        self.cacheSeriesSeasons[seriesUrl] = []
+        for url, se in data:
+            imdb_text = (" | IMDb: %s" % imdb_rating) if imdb_rating != "-" else ""
+            title = "%s - %s" % (cItem["title"], _("Movies") if se == "0" else _("Season") + " " + str(se))
+            desc_show = desc + imdb_text
+            params = dict(cItem)
+            params.update({"good_for_fav": True, "category": "list_episodes", "title": title,
+            "url": self.getFullUrl(url), "icon": icon, "desc": desc_show,
+            "imdb_rating": imdb_rating, "imdb_id": imdb_id, "imdb_lookup_url": self.getFullUrl(url),
+            "series_url": seriesUrl, "season_num": str(se)})
+            if trailer:
+                params.update({"trailer": trailer})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addDir(params)
+            self.cacheSeriesSeasons[seriesUrl].append({"category": "list_episodes", "url": self.getFullUrl(url), "series_url": seriesUrl, "season_num": str(se)})
+
+        seasonItems = self.cacheSeriesSeasons.get(seriesUrl, [])
+        if seasonItems:
+            self.watchedHelper.updateParentWatchedState({"category": "list_seasons", "url": seriesUrl}, seasonItems, self._getWatchedKeyForItem)
+
+    def listEpisodes(self, cItem):
+        printDBG("SerienStreamTo.listEpisodes")
+        sts, data = self.getPage(cItem["url"])
+        if not sts:
+            return
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="episode-row', "</tr>")
+        episodeItems = []
+        for item in data:
+            url = self.getFullUrl(self.cm.ph.getSearchGroups(item, "location='([^']+)'")[0])
+            name = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, 'title="([^"]+)">')[0])
+            ep = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, r'cell">(\d+)')[0])
+            if "Releases soon" in name:
+                continue
+            if self._useLegacyTitles():
+                ep_prefix = "" if ("Episode" in name or "Folge" in name) else "%s %s - " % (_("Episode"), ep)
+                title = "%s - %s%s %s" % (cItem["title"], ep_prefix, name, language(item))
+            else:
+                season_num = str(cItem.get("season_num", ""))
+                if not season_num:
+                    season_num = self.cm.ph.getSearchGroups(cItem.get("title", ""), r'Staffel\s+(\d+)')[0]
+                if not season_num:
+                    season_num = self.cm.ph.getSearchGroups(cItem.get("url", ""), r'/staffel-(\d+)')[0]
+                season_num = int(season_num) if str(season_num).isdigit() else 0
+                series_title = cItem.get("title", "").split(" - Staffel")[0].strip()
+                ep_num = int(ep) if ep.isdigit() else 0
+                se_tag = "S%02dE%02d" % (season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
+                lang = language(item)
+                lang_suffix = " - %s" % lang if lang else ""
+                title = "%s - %s - %s%s" % (series_title, se_tag, name, lang_suffix) if se_tag else "%s - %s%s" % (series_title, name, lang_suffix)
+            params = dict(cItem)
+            params.update({"good_for_fav": True, "title": title, "url": url, "type": "video",
+            # cItem is the season item (category="list_episodes") - clear it here so this
+            # episode isn't mistaken for its own season/series container elsewhere
+            "category": "",
+            "imdb_lookup_url": cItem.get("imdb_lookup_url", "") or cItem.get("url", ""),
+            "series_url": cItem.get("series_url", "") or cItem.get("url", ""),
+            "season_num": str(cItem.get("season_num", ""))})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addVideo(params)
+            episodeItems.append(params)
+
+        if episodeItems:
+            seasonParent = {"category": "list_episodes", "series_url": episodeItems[0].get("series_url", ""), "season_num": episodeItems[0].get("season_num", "")}
+            self.watchedHelper.updateParentWatchedState(seasonParent, episodeItems, self._getWatchedKeyForItem)
+
+    def listNewEpisodes(self, cItem):
+        printDBG("SerienStreamTo.listNewEpisodes")
+        sts, data = self.getPage(gettytul())
+        if not sts:
+            return
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="latest-episode', "</a>")
+        if data:
+            for item in data:
+                url = self.getFullUrl(self.cm.ph.getSearchGroups(item, 'href="([^"]+)')[0])
+                name = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, r'ep-title"\stitle="([^"]+)')[0])
+                se = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, r'ep-season">([^<]+)')[0])
+                ep = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, r'ep-episode">([^<]+)')[0])
+                icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(item, 'src="([^"]+)')[0])
+                lang = language(item)
+                if self._useLegacyTitles():
+                    title = "%s - %s - %s%s" % (name, se, ep, (" %s" % lang if lang else ""))
+                else:
+                    season_num = self.cm.ph.getSearchGroups(se, r'(\d+)')[0]
+                    episode_num = self.cm.ph.getSearchGroups(ep, r'(\d+)')[0]
+                    season_ep = "S%sE%s" % (season_num.zfill(2), episode_num.zfill(2)) if season_num and episode_num else "%s %s" % (se, ep)
+                    title = "%s - %s%s" % (name, season_ep, (" - %s" % lang) if lang else "")
+                imdb_lookup_url = re.sub(r'/staffel-\d+/episode-\d+/?$', '/', url)
+                params = dict(cItem)
+                params.update({"good_for_fav": False, "title": title, "url": url, "icon": icon, "imdb_id": "", "imdb_rating": "-", "imdb_lookup_url": imdb_lookup_url})
+                self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+                self.addVideo(params)
+
+    def listValue(self, cItem):
+        printDBG("SerienStreamTo.listValue")
+        sts, data = self.getPage(self.getFullUrl("suche"))
+        if not sts:
+            return
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, cItem["s"], "</ul>")
+        if not data:
+            return
+        data = re.compile('href="([^"]+).*?>([^<]+)', re.DOTALL).findall(data[0])
+        dub = set()
+        for url, title in data:
+            if url not in dub:
+                dub.add(url)
+                params = dict(cItem)
+                params.update({"good_for_fav": True, "category": "list_items", "title": self.cleanHtmlStr(title), "url": self.getFullUrl(url)})
+                self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+                self.addDir(params)
+
+    def listSearchResult(self, cItem, searchPattern, searchType):
+        printDBG("SerienStreamTo.listSearchResult cItem[%s], searchPattern[%s] searchType[%s]" % (cItem, searchPattern, searchType))
+        cItem = dict(cItem)
+        cItem["url"] = self.getFullUrl("suche?term=%s" % urllib_quote_plus(searchPattern))
+        self.listItems(cItem)
+
+    def getLinksForVideo(self, cItem):
+        printDBG("SerienStreamTo.getLinksForVideo [%s]" % cItem)
+        # NOTE: marking the item "started" happens later, in iptvplayerwidget.py's
+        # playVideo() - not here. This method resolves links for both actually
+        # streaming AND downloading, and can also fail/return nothing, so marking
+        # here would (and used to) tag failed attempts and downloads as "started" too.
+        urltab = []
+        sidecarTxt = ""
+        sidecarImg = ""
+        sidecarEnabled = IsSidecarEnabled()
+        imdb_rating = cItem.get("imdb_rating", "")
+        sidecarYear = ""
+        sidecarGenre = ""
+
+        mkvEnabled = config.plugins.iptvplayer.serienstreamto_mkv.value
+        imdb_id = cItem.get("imdb_id", "")
+        imdb_lookup_url = cItem.get("imdb_lookup_url", "") or cItem.get("url", "")
+
+        if sidecarEnabled or mkvEnabled:
+            try:
+                article = self.getArticleContent(cItem)
+                if article and isinstance(article, list):
+                    articleItem = article[0]
+                    sidecarTxt = articleItem.get("text", "")
+                    images = articleItem.get("images", [])
+                    if images and images[0].get("url"):
+                        sidecarImg = images[0].get("url")
+                    otherInfo = articleItem.get("other_info", {})
+                    if not imdb_rating or imdb_rating == "-":
+                        imdb_rating = otherInfo.get("imdb_rating", "")
+                    sidecarGenre = otherInfo.get("genres", "") or otherInfo.get("genre", "")
+            except Exception:
+                printExc("getArticleContent for sidecar failed")
+
+            if not sidecarTxt:
+                sidecarTxt = cItem.get("desc", "")
+            if not sidecarImg:
+                sidecarImg = cItem.get("icon", "")
+
+            try:
+                if not imdb_id and imdb_lookup_url:
+                    printDBG("||SIDECAR imdb lookup url: [%s]" % imdb_lookup_url)
+                    sts, lookupData = self.getPage(imdb_lookup_url)
+                    if sts:
+                        imdb_id = self.extractImdbId(lookupData)
+                        printDBG("||SIDECAR imdb id from lookup url: [%s]" % imdb_id)
+                if not imdb_id and cItem.get("url", "") != imdb_lookup_url:
+                    sts, pageData = self.getPage(cItem["url"])
+                    if sts:
+                        imdb_id = self.extractImdbId(pageData)
+                        printDBG("||SIDECAR imdb id from item url: [%s]" % imdb_id)
+                if imdb_id:
+                    omdb = self.getOMDbData(imdb_id)
+                    printDBG("||SIDECAR OMDb: [%s]" % omdb)
+                    if omdb:
+                        if not imdb_rating or imdb_rating in ("-", "", "N/A"):
+                            imdb_rating = omdb.get("imdbRating", "")
+                        sidecarYear = omdb.get("Year", "")
+                        if not sidecarGenre:
+                            sidecarGenre = omdb.get("Genre", "")
+            except Exception:
+                printExc("OMDb sidecar lookup failed")
+        else:
+            if not sidecarTxt:
+                sidecarTxt = cItem.get("desc", "")
+            if not sidecarImg:
+                sidecarImg = cItem.get("icon", "")
+
+        if sidecarTxt.startswith("IMDb:"):
+            sidecarTxt = sidecarTxt.split("\n", 1)[1] if "\n" in sidecarTxt else ""
+        sidecarLines = []
+        if imdb_rating and imdb_rating not in ("-", "N/A", ""):
+            sidecarLines.append(u"IMDb: %s/10" % imdb_rating)
+        infoLine = []
+        if sidecarYear and sidecarYear not in ("N/A", ""):
+            infoLine.append(u"Jahr: %s" % sidecarYear)
+        if infoLine:
+            sidecarLines.append(u" / ".join(infoLine))
+        if sidecarGenre and sidecarGenre not in ("N/A", ""):
+            sidecarLines.append(sidecarGenre)
+        if sidecarLines:
+            prefix = u"\n".join(sidecarLines)
+            if sidecarTxt:
+                sidecarTxt = prefix + u"\n\n" + sidecarTxt
+            else:
+                sidecarTxt = prefix
+        sidecar = buildSidecar(sidecarEnabled, sidecarTxt, sidecarImg)
+        sts, data = self.getPage(cItem["url"])
+        if not sts:
+            return []
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'id="episode-links"', "</article>")
+        if not data:
+            return []
+        data = re.compile(r'data-play-url="([^"]+).*?data-provider-name="([^"]+).*?data-language-label="([^"]+)', re.DOTALL).findall(data[0])
+        for url, title, lang in data:
+            fullUrl = decorateUrl(self.getFullUrl(url), referer=config.plugins.iptvplayer.serienstreamto_hosts.value, sidecar=sidecar)
+            urltab.append({"name": "%s (%s)" % (title, lang), "url": fullUrl, "need_resolve": 1})
+        if cItem.get("trailer"):
+            trailerUrl = decorateUrl(cItem.get("trailer"), sidecar=sidecar)
+            urltab.append({"name": "Trailer", "url": trailerUrl, "need_resolve": 1})
+        return urltab
+
+    def getVideoLinks(self, url):
+        printDBG("SerienStreamTo.getVideoLinks [%s]" % url)
+        cfgSidecarEnabled = IsSidecarEnabled()
+        cfgMkvEnabled = config.plugins.iptvplayer.serienstreamto_mkv.value
+        sidecar = sidecarFromUrlMeta(url, cfgSidecarEnabled)
+
+        def _addFinalMeta(videoLinks):
+            return decorateResolvedLinkItems(videoLinks, sidecar=sidecar, mkvEnabled=cfgMkvEnabled)
+        if "youtube" in url:
+            return _addFinalMeta(self.up.getVideoLinkExt(url))
+        params = dict(self.defaultParams)
+        params["no_redirection"] = True
+        sts, data = self.cm.getPage(url, params)
+        if self.cm.meta["status_code"] == 302:
+            if self.cm.meta.get("location"):
+                url = self.cm.meta.get("location")
+                if self.cm.isValidUrl(url):
+                    return _addFinalMeta(self.up.getVideoLinkExt(url))
+        elif sts:
+            if "frameBridge" in data:
+                SetIPTVPlayerLastHostError("Der Link ist geschützt ein s.to Login ist nötig. \nGeben Sie Login und Passwort in der Host Konfiguration (blau) ein und versuchen Sie es erneut.")
+                return []
+            url = self.cm.ph.getSearchGroups(data, 'href="([^"]+)')[0]
+            if self.cm.isValidUrl(url):
+                return _addFinalMeta(self.up.getVideoLinkExt(url))
+        return []
+
+    def getArticleContent(self, cItem):
+        printDBG("SerienStreamTo.getArticleContent [%s]" % cItem)
+        otherInfo = {}
+        sts, data = self.getPage(cItem["url"])
+        if not sts:
+            return []
+        desc = self.cm.ph.getDataBeetwenMarkers(data, '<div class="small text-body lh-lg mb-3">', "</div>", withMarkers=False)[1]
+        if not desc:
+            desc = self.cm.ph.getSearchGroups(data, 'description-text">([^<]+)')[0]
+        desc = self.cleanHtmlStr(desc)
+        icon = strwithmeta(self.getFullIconUrl(self.cm.ph.getSearchGroups(data, 'data-src="([^"]+)')[0]) or cItem.get("icon", ""))
+        imdb_id = cItem.get("imdb_id", "") or self.extractImdbId(data)
+        if not imdb_id:
+            lookup_url = cItem.get("imdb_lookup_url", "")
+            if lookup_url and lookup_url != cItem.get("url", ""):
+                sts2, data2 = self.getPage(lookup_url)
+                if sts2:
+                    imdb_id = self.extractImdbId(data2)
+        printDBG("IMDb DEBUG article id=[%s]" % imdb_id)
+        imdb_rating = self.getIMDBRating(imdb_id) if imdb_id else "-"
+        printDBG("IMDb DEBUG article rating=[%s]" % imdb_rating)
+        if imdb_rating != "-":
+            otherInfo["imdb_rating"] = imdb_rating
+        bc = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="flex-grow-1">', "</span>")
+        if bc:
+            bc = self.cm.ph.getSearchGroups(bc[0], 'title="([^"]+)')[0]
+            if bc:
+                otherInfo["broadcast"] = bc
+        fields = {"country": '<strong class="me-1">Land:</strong>', "director": '<strong class="me-1">Regisseur:</strong>', "actors": '<strong class="me-1">Besetzung:</strong>', "genres": '<strong class="me-1">Genre:</strong>', "production": '<strong class="me-1">Produzent:</strong>'}
+        for key, pattern in fields.items():
+            value = self.cm.ph.getAllItemsBeetwenMarkers(data, pattern, "</li>")
+            if value:
+                val = re.findall('light">([^<]+)', value[0])
+                if val:
+                    otherInfo[key] = ", ".join(val)
+        episode = {"country": '<strong class="me-1">Land:</strong>', "director": ">Regisseure</div>", "actors": ">Besetzung</div>", "production": ">Produzenten</div>"}
+        for key, pattern in episode.items():
+            value = self.cm.ph.getAllItemsBeetwenMarkers(data, pattern, "</div>")
+            if value:
+                val = re.findall('title="([^"]+)', value[0])
+                if val:
+                    otherInfo[key] = ", ".join(val)
+        return [{"title": cItem["title"], "text": desc, "images": [{"title": "", "url": icon}], "other_info": otherInfo}]
+
+    def login(self):
+        login = config.plugins.iptvplayer.serienstreamto_login.value.strip()
+        passw = config.plugins.iptvplayer.serienstreamto_password.value.strip()
+        if login == "" and passw == "":
+            return
+        lurl = self.getFullUrl("/login")
+        sts, data = self.getPage(lurl)
+        if sts:
+            token = self.cm.ph.getSearchGroups(data, r'csrf-token" content="([^"]+)')
+            post = {"_token": token[0], "email": login, "password": passw}
+            params = dict(self.defaultParams)
+            params["no_redirection"] = True
+            self.cm.getPage(lurl, params, post_data=post)
+            if self.cm.meta["status_code"] == 302 and self.cm.meta.get("location") != lurl:
+                printDBG("Login OK")
+            else:
+                printDBG("Login fehlgeschlagen")
+
+    def handleService(self, index, refresh=0, searchPattern="", searchType=""):
+        CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
+        name = self.currItem.get("name", "")
+        category = self.currItem.get("category", "")
+        printDBG("handleService start\nhandleService: name[%s], category[%s] " % (name, category))
+        self.currList = []
+        if category == "jump_to_page" or ((name or "").endswith("-JUMP")):
+            self.jumpToPage(self.currItem)
+        elif name is None:
+            self.listsTab(self.MENU, {"name": "category"})
+            if config.plugins.iptvplayer.serienstreamto_uselogin.value:
+                self.login()
+        elif category == "list_items":
+            self.listItems(self.currItem)
+        elif category == "list_seasons":
+            self.listSeasons(self.currItem)
+        elif category == "list_episodes":
+            self.listEpisodes(self.currItem)
+        elif category == "list_value":
+            self.listValue(self.currItem)
+        elif category == "list_AZ":
+            self.AZ(self.currItem)
+        elif category == "list_newepisodes":
+            self.listNewEpisodes(self.currItem)
+        elif category in ["search", "search_next_page"]:
+            cItem = dict(self.currItem)
+            cItem.update({"search_item": False, "name": "category"})
+            self.listSearchResult(cItem, searchPattern, searchType)
+        elif category == "search_history":
+            self.listsHistory({"name": "history", "category": "search"}, "desc")
+        elif category == "empty":
+            pass
+        else:
+            printExc()
+        CBaseHostClass.endHandleService(self, index, refresh)
+
+
+class IPTVHost(WatchedFlagHostMixin, CHostBase):
+    def __init__(self):
+        CHostBase.__init__(self, SerienStreamTo(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('serienstreamto')
+
+    def _setWatchedStateForSeasonItem(self, seasonItem, action):
+        try:
+            seasonKey = self.host._getWatchedKeyForItem(seasonItem)
+            if seasonKey == '':
+                return False
+            seasonUrl = str(seasonItem.get('url', '') or '').strip()
+            if seasonUrl == '':
+                return False
+            sts, data = self.host.getPage(seasonUrl)
+            if not sts:
+                return False
+            data = self.host.cm.ph.getAllItemsBeetwenMarkers(data, 'class="episode-row', "</tr>")
+            changed = False
+            for item in data:
+                url = self.host.getFullUrl(self.host.cm.ph.getSearchGroups(item, "location='([^']+)'")[0])
+                name = self.host.cleanHtmlStr(self.host.cm.ph.getSearchGroups(item, 'title="([^"]+)">')[0])
+                ep = self.host.cleanHtmlStr(self.host.cm.ph.getSearchGroups(item, r'cell">(\d+)')[0])
+                if "Releases soon" in name:
+                    continue
+                if self.host._useLegacyTitles():
+                    ep_prefix = "" if ("Episode" in name or "Folge" in name) else "%s %s - " % (_("Episode"), ep)
+                    title = "%s - %s%s %s" % (seasonItem.get('title', '') or self.host.currItem.get('title', ''), ep_prefix, name, language(item))
+                else:
+                    season_num = str(seasonItem.get('season_num', ''))
+                    if not season_num:
+                        season_num = self.host.cm.ph.getSearchGroups(seasonItem.get('title', ''), r'Staffel\s+(\d+)')[0]
+                    if not season_num:
+                        season_num = self.host.cm.ph.getSearchGroups(seasonItem.get('url', ''), r'/staffel-(\d+)')[0]
+                    season_num = int(season_num) if str(season_num).isdigit() else 0
+                    series_title = (seasonItem.get('title', '') or self.host.currItem.get('title', '')).split(" - Staffel")[0].strip()
+                    ep_num = int(ep) if ep.isdigit() else 0
+                    se_tag = "S%02dE%02d" % (season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
+                    lang = language(item)
+                    lang_suffix = " - %s" % lang if lang else ""
+                    title = "%s - %s - %s%s" % (series_title, se_tag, name, lang_suffix) if se_tag else "%s - %s%s" % (series_title, name, lang_suffix)
+                params = dict(seasonItem)
+                params.update({"good_for_fav": True, "title": title, "url": url, "type": "video",
+                "imdb_lookup_url": seasonItem.get("imdb_lookup_url", "") or seasonItem.get("url", ""),
+                "series_url": seasonItem.get("series_url", "") or seasonItem.get("url", ""),
+                "season_num": str(seasonItem.get("season_num", ""))})
+                episodeKey = self.host._getWatchedKeyForItem(params)
+                if episodeKey == '':
+                    continue
+                if action == 'set_watched_flag':
+                    changed = self.watchedHelper.markItemWatched(params, episodeKey) or changed
+                else:
+                    changed = self.watchedHelper.unmarkItemWatched(params, episodeKey) or changed
+            if action == 'set_watched_flag':
+                changed = self.watchedHelper.markItemWatched(seasonItem, seasonKey) or changed
+            else:
+                changed = self.watchedHelper.unmarkItemWatched(seasonItem, seasonKey) or changed
+            return changed
+        except Exception:
+            printExc()
+            return False
+
+    def _setWatchedStateForSeriesItem(self, seriesItem, action):
+        try:
+            seriesUrl = str(seriesItem.get('url', '') or '').strip()
+            if seriesUrl == '':
+                return False
+            changed = False
+            for seasonItem in self.host.cacheSeriesSeasons.get(seriesUrl, []):
+                if seasonItem.get('url', ''):
+                    changed = self._setWatchedStateForSeasonItem(seasonItem, action) or changed
+            seriesKey = self.host._getWatchedKeyForItem(seriesItem)
+            if seriesKey != '':
+                if action == 'set_watched_flag':
+                    changed = self.watchedHelper.markItemWatched(seriesItem, seriesKey) or changed
+                else:
+                    changed = self.watchedHelper.unmarkItemWatched(seriesItem, seriesKey) or changed
+            return changed
+        except Exception:
+            printExc()
+            return False
+
+    def performCustomAction(self, privateData):
+        ret = self.watchedHelper.performCustomAction(privateData)
+        if ret.status == RetHost.OK:
+            self.refreshAfterWatchedFlagChange = True
+            try:
+                action = privateData.get('action', '')
+                if action in ('unset_watched_flag', 'set_watched_flag'):
+                    idx = privateData.get('item_index', -1)
+                    item = self.host.currList[idx] if 0 <= idx < len(self.host.currList) else {}
+                    category = item.get('category', '')
+                    if category == 'list_episodes':
+                        self._setWatchedStateForSeasonItem(item, action)
+                        seasonParent = dict(item)
+                        seasonParent.pop('isWatched', None)
+                        seasonItems = []
+                        for child in self.host.currList:
+                            if isinstance(child, dict) and child.get('type', '') in ['video', 'audio']:
+                                seasonItems.append(child)
+                        if seasonItems:
+                            self.watchedHelper.updateParentWatchedState(seasonParent, seasonItems, self.host._getWatchedKeyForItem)
+                        seriesUrl = str(item.get('series_url', '') or '').strip()
+                        if seriesUrl != '':
+                            seasonItems = self.host.cacheSeriesSeasons.get(seriesUrl, [])
+                            if seasonItems:
+                                self.watchedHelper.updateParentWatchedState({'category': 'list_seasons', 'url': seriesUrl}, seasonItems, self.host._getWatchedKeyForItem)
+                    elif category == 'list_seasons':
+                        self._setWatchedStateForSeriesItem(item, action)
+                        seriesUrl = str(item.get('url', '') or '').strip()
+                        if seriesUrl != '':
+                            seasonItems = self.host.cacheSeriesSeasons.get(seriesUrl, [])
+                            if seasonItems:
+                                self.watchedHelper.updateParentWatchedState({'category': 'list_seasons', 'url': seriesUrl}, seasonItems, self.host._getWatchedKeyForItem)
+                    elif item.get('type', '') in ['video', 'audio']:
+                        self.watchedHelper.updateItemFlag(item, self.host._getWatchedKeyForItem(item))
+                        self.host._propagateEpisodeWatchedState(item)
+            except Exception:
+                printExc()
+        return ret
+
+    def getSuggestionsProvider(self, index=-1):
+        from Plugins.Extensions.IPTVPlayer.suggestions.google import SuggestionsProvider as google_Provider
+        return RetHost(status=RetHost.OK, value=[google_Provider()])
+
+    def withArticleContent(self, cItem):
+        return cItem.get("type", "") in ["video", "audio"] or cItem.get("category", "") in ["list_seasons", "list_episodes", "list_newepisodes"]

--- a/iptvdm/mergedownloader.py
+++ b/iptvdm/mergedownloader.py
@@ -1,0 +1,865 @@
+# -*- coding: utf-8 -*-
+# IPTV download manager API
+# Last Modified: 19.08.2026 - Fixed ffmpeg merge/chapter-mux steps reporting exit code 1 despite writing a
+# complete, correct output file. Root causes handled: (1) added '-y' to all ffmpeg post-process invocations
+# so ffmpeg never blocks on stdin waiting for an "Overwrite? [y/N]" prompt on a stale leftover output file;
+# (2) stopped discarding ffmpeg's merge/mux stderr into /dev/null - it's now captured via stderrAvail like the
+# duration probe already does, and logged on failure; (3) eConsoleAppContainer can report a spurious non-zero
+# exit code for the short second ffmpeg pass (remux with -map_metadata from the tiny .ffmeta file) even though
+# ffmpeg's own stderr shows a completely clean finish (the "Lsize=...muxing overhead:" summary only appears
+# after a successful write) - this is now treated as authoritative success, overriding the bogus exit code,
+# for both the merge and chapters post-process steps - Kamikaze24
+###################################################
+# LOCAL import
+###################################################
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, iptv_system, eConnectCallback, GetNice, rm, E2PrioFix
+from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import enum, strwithmeta
+from Plugins.Extensions.IPTVPlayer.iptvdm.basedownloader import BaseDownloader
+from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdh import DMHelper
+from Plugins.Extensions.IPTVPlayer.iptvdm.downloaderhelpers import ensureText, fsPath, shellQuote, writeUtf8TextFile, SidecarMixin
+###################################################
+# FOREIGN import
+###################################################
+from Tools.BoundFunction import boundFunction
+from enigma import eConsoleAppContainer
+from time import sleep
+import re
+import datetime
+import os
+import struct
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
+try:
+    try:
+        import json
+    except Exception:
+        import simplejson as json
+except Exception:
+    printExc()
+###################################################
+
+###################################################
+# One instance of this class can be used only for
+# one download
+###################################################
+
+
+class MergeDownloader(BaseDownloader, SidecarMixin):
+
+    def __init__(self):
+        printDBG('MergeDownloader.__init__ ----------------------------------')
+        BaseDownloader.__init__(self)
+
+        # instance of E2 console
+        self.console = None
+        self.console_appClosed_conn = None
+        self.console_stderrAvail_conn = None
+        self.iptv_sys = None
+
+        # sidecar support (console instance + state), shared via SidecarMixin
+        self._initSidecarState()
+
+        self.knownDurationMs = -1
+
+        self.multi = {'urls': [], 'files': [], 'remote_size': [], 'remote_content_type': [], 'local_size': []}
+        self.currIdx = 0
+
+        self.makeMkvChapters = False
+        self.makeCutsFile = False
+        self.tempMergePath = ''
+        self.chapterMetaPath = ''
+        self.finalizedPath = ''
+        self.postProcessMode = 'merge'
+        self.mergedFileDurationMs = 0
+        self.probeOutData = ''
+        self.ffmpegErrData = ''
+        self._pendingChapters = []
+
+        self.channelName = ''
+        self.downloadChannelName = ''
+        self.downloadUseChannelName = False
+        self.originalFilePath = ''
+        self.preCheckOnly = False
+
+    def __del__(self):
+        printDBG("MergeDownloader.__del__ ----------------------------------")
+
+    def _safeRm(self, path):
+        try:
+            fpath = fsPath(path)
+            if fpath and os.path.exists(fpath):
+                rm(fpath)
+        except Exception:
+            printExc()
+
+    def _cleanUp(self):
+        for item in self.multi['files']:
+            self._safeRm(item)
+        if self.tempMergePath:
+            self._safeRm(self.tempMergePath)
+        if self.chapterMetaPath:
+            self._safeRm(self.chapterMetaPath)
+
+    def _cleanupBeforeStart(self, filePath):
+        try:
+            basePath = self._getBasePath(filePath)
+            for idx in range(0, 10):
+                self._safeRm(filePath + '.iptv.tmp.%d.dash' % idx)
+            self._safeRm(basePath + '.iptv.merge.tmp.mp4')
+            self._safeRm(basePath + '.chapters.ffmeta')
+            # also remove a stale MKV target from a previous aborted run so ffmpeg never
+            # has to prompt "Overwrite? [y/N]" on a leftover file (hangs/exits 1 without -y)
+            self._safeRm(basePath + '.mkv')
+        except Exception:
+            printExc()
+
+    def _downloadAlreadyPresent(self, filePath):
+        try:
+            filePath = ensureText(filePath)
+            if os.path.isfile(fsPath(filePath)) and DMHelper.getFileSize(fsPath(filePath)) > 0:
+                return True
+            mkvPath = self._getBasePath(filePath) + '.mkv'
+            if os.path.isfile(fsPath(mkvPath)) and DMHelper.getFileSize(fsPath(mkvPath)) > 0:
+                return True
+            return False
+        except Exception:
+            printExc()
+            return False
+
+    def getName(self):
+        return "MergeDownloader"
+
+    def isWorkingCorrectly(self, callBackFun):
+        self.iptv_sys = iptv_system(DMHelper.GET_FFMPEG_PATH() + ' -version ' + " 2>&1 ", boundFunction(self._checkWorkingCallBack, callBackFun))
+
+    def _checkWorkingCallBack(self, callBackFun, code, data):
+        reason = ''
+        sts = True
+        if code != 0:
+            sts = False
+            reason = data
+            self.iptv_sys = None
+            callBackFun(sts, reason)
+        else:  # Need wget for correct working, so check also if wget working correctly
+            self._isWgetWorkingCorrectly(callBackFun)
+
+    def _isWgetWorkingCorrectly(self, callBackFun):
+        self.iptv_sys = iptv_system(DMHelper.GET_WGET_PATH() + " -V 2>&1 ", boundFunction(self._checkWgetWorkingCallBack, callBackFun))
+
+    def _checkWgetWorkingCallBack(self, callBackFun, code, data):
+        reason = ''
+        sts = True
+        if code != 0:
+            sts = False
+            reason = data
+        self.iptv_sys = None
+        callBackFun(sts, reason)
+
+    def _clearSidecarData(self):
+        SidecarMixin._clearSidecarData(self)
+        self.makeMkvChapters = False
+        self.makeCutsFile = False
+
+        self.channelName = ''
+        self.downloadChannelName = ''
+        self.downloadUseChannelName = False
+
+    def _prepareSidecarData(self, meta):
+        self._clearSidecarData()
+        try:
+            if meta.get('e2i_sidecar_enabled', False):
+                self.sidecarEnabled = True
+                self.sidecarTxt = meta.get('e2i_sidecar_txt', '')
+                self.sidecarImg = meta.get('e2i_sidecar_img', '')
+                printDBG("MergeDownloader sidecar enabled")
+
+            if meta.get('e2i_mkv_chapters', False):
+                self.makeMkvChapters = True
+                if not self.sidecarTxt:
+                    self.sidecarTxt = meta.get('e2i_sidecar_txt', '')
+                printDBG("MergeDownloader MKV chapters enabled")
+
+            if meta.get('e2i_cuts_chapters', False):
+                self.makeCutsFile = True
+                if not self.sidecarTxt:
+                    self.sidecarTxt = meta.get('e2i_sidecar_txt', '')
+                printDBG("MergeDownloader Enigma2 cuts enabled")
+
+            self.channelName = ensureText(meta.get('e2i_channel_name', '')).strip()
+            self.downloadChannelName = self.channelName
+            self.downloadUseChannelName = bool(self.downloadChannelName)
+
+            if self.downloadUseChannelName:
+                printDBG("MergeDownloader channel name [%s]" % self.downloadChannelName)
+        except Exception:
+            printExc()
+
+    def _sanitizeFileNamePart(self, value):
+        value = ensureText(value)
+        value = value.strip()
+        value = re.sub(r'[\r\n\t]+', ' ', value)
+        value = re.sub(r'\s+', ' ', value)
+        value = re.sub(r'[\\/:\*\?"<>\|]', '_', value)
+        value = value.strip(' ._-')
+        return value
+
+    def _applyDownloadChannelToFilePath(self, filePath):
+        try:
+            filePath = ensureText(filePath)
+
+            if not self.downloadUseChannelName or not self.downloadChannelName:
+                return filePath
+
+            dirName = os.path.dirname(filePath)
+            baseName = os.path.basename(filePath)
+            titlePart, extPart = os.path.splitext(baseName)
+
+            cleanChannel = self._sanitizeFileNamePart(self.downloadChannelName)
+            cleanTitle = self._sanitizeFileNamePart(titlePart)
+
+            if not cleanChannel or not cleanTitle:
+                return filePath
+
+            prefix = cleanChannel + ' - '
+            if cleanTitle.startswith(prefix):
+                newBaseName = cleanTitle + extPart
+            else:
+                newBaseName = prefix + cleanTitle + extPart
+
+            if dirName:
+                newPath = os.path.join(dirName, newBaseName)
+            else:
+                newPath = newBaseName
+
+            printDBG("MergeDownloader filePath with channel [%s] -> [%s]" % (filePath, newPath))
+            return newPath
+        except Exception:
+            printExc()
+            return ensureText(filePath)
+
+    def _getBasePath(self, filePath):
+        return ensureText(filePath).rsplit('.', 1)[0]
+
+    def _getMkvPath(self):
+        return self._getBasePath(self.filePath) + '.mkv'
+
+    def _getCutsPath(self, filePath):
+        return ensureText(filePath) + '.cuts'
+
+    def _extractClenFromUrl(self, url):
+        try:
+            qs = parse_qs(urlparse(ensureText(url)).query)
+            clenVals = qs.get('clen')
+            if clenVals:
+                return int(clenVals[0])
+        except Exception:
+            printExc()
+        return -1
+
+    def _extractDurMsFromUrl(self, url):
+        try:
+            qs = parse_qs(urlparse(ensureText(url)).query)
+            durVals = qs.get('dur')
+            if durVals:
+                return int(float(durVals[0]) * 1000.0)
+        except Exception:
+            printExc()
+        return -1
+
+    def _moveFile(self, src, dst):
+        try:
+            srcPath = fsPath(src)
+            dstPath = fsPath(dst)
+            if srcPath == dstPath:
+                return True
+            if os.path.isfile(dstPath):
+                rm(dstPath)
+            os.rename(srcPath, dstPath)
+            return os.path.isfile(dstPath)
+        except Exception:
+            printExc()
+        return False
+
+    def _normalizeChapterTitle(self, title):
+        title = ensureText(title).strip()
+        title = re.sub(r'\s+', ' ', title)
+        if not title:
+            title = 'Chapter'
+        return title
+
+    def _timeStrToMs(self, timeStr):
+        parts = ensureText(timeStr).split(':')
+        try:
+            parts = [int(x) for x in parts]
+        except Exception:
+            return None
+
+        if len(parts) == 2:
+            hh = 0
+            mm = parts[0]
+            ss = parts[1]
+        elif len(parts) == 3:
+            hh = parts[0]
+            mm = parts[1]
+            ss = parts[2]
+        else:
+            return None
+
+        return ((hh * 3600) + (mm * 60) + ss) * 1000
+
+    def _msToPts(self, ms):
+        return int(ms) * 90
+
+    def _escapeFfmeta(self, txt):
+        txt = ensureText(txt)
+        txt = txt.replace('\\', '\\\\')
+        txt = txt.replace('=', '\\=')
+        txt = txt.replace(';', '\\;')
+        txt = txt.replace('#', '\\#')
+        txt = txt.replace('\n', ' ')
+        txt = txt.replace('\r', ' ')
+        return txt
+
+    def _extractChaptersFromText(self, txt):
+        chapters = []
+        if not txt:
+            return chapters
+
+        workTxt = ensureText(txt)
+        lines = workTxt.replace('\r', '\n').split('\n')
+        seen = {}
+
+        for line in lines:
+            line = ensureText(line).strip()
+            if not line:
+                continue
+
+            timeStr = ''
+            title = ''
+
+            m = re.match(r'^\[(?P<ts>(?:\d{1,2}:)?\d{1,2}:\d{2})\]\([^)]+\)\s*(?P<title>.+?)\s*$', line)
+            if m:
+                timeStr = m.group('ts')
+                title = m.group('title').strip()
+            else:
+                m = re.match(r'^(?P<ts>(?:\d{1,2}:)?\d{1,2}:\d{2})\s+(?P<title>.+?)\s*$', line)
+                if m:
+                    timeStr = m.group('ts')
+                    title = m.group('title').strip()
+                else:
+                    continue
+
+            title = re.sub(r'^\-\s*', '', title)
+            title = self._normalizeChapterTitle(title)
+
+            startMs = self._timeStrToMs(timeStr)
+            if startMs is None:
+                continue
+            if startMs in seen:
+                continue
+
+            seen[startMs] = True
+            chapters.append({'start': startMs, 'title': title})
+
+        chapters.sort(key=lambda item: item['start'])
+
+        out = []
+        prevStart = None
+        for item in chapters:
+            if prevStart is not None and item['start'] == prevStart:
+                continue
+            out.append(item)
+            prevStart = item['start']
+
+        if len(out) < 2:
+            return []
+        return out
+
+    def _parseProbeDuration(self, data):
+        try:
+            data = ensureText(data)
+            m = re.search(r'Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)', data)
+            if m:
+                hh = int(m.group(1))
+                mm = int(m.group(2))
+                ss = float(m.group(3))
+                return int((((hh * 3600) + (mm * 60)) + ss) * 1000.0)
+        except Exception:
+            printExc()
+        return 0
+
+    def _probeDataAvail(self, data):
+        if data is None:
+            return
+        self.probeOutData += ensureText(data)
+
+    def _ffmpegErrDataAvail(self, data):
+        # captures ffmpeg's stderr for the merge/chapter-mux steps instead of throwing it away,
+        # so a failing 'code[1]' can actually be diagnosed from the log instead of guessed at
+        if data is None:
+            return
+        self.ffmpegErrData += ensureText(data)
+        if len(self.ffmpegErrData) > 8000:
+            self.ffmpegErrData = self.ffmpegErrData[-8000:]
+
+    def _ffmpegReportedCleanFinish(self):
+        # eConsoleAppContainer can report a spurious non-zero exit code for a short-lived second
+        # ffmpeg pass (e.g. remuxing with -map_metadata from a tiny .ffmeta file) even though
+        # ffmpeg itself completed normally. ffmpeg only prints the final "Lsize=...muxing overhead:"
+        # summary line after a clean successful write, so treat its presence as authoritative
+        # success, overriding a bogus non-zero exit code from the console container.
+        try:
+            tail = ensureText(self.ffmpegErrData)
+            return bool(re.search(r'Lsize=\s*\S+.*muxing overhead', tail, re.DOTALL))
+        except Exception:
+            printExc()
+        return False
+
+    def _logFfmpegFailure(self, stepName):
+        try:
+            tail = self.ffmpegErrData.strip()
+            if tail:
+                lines = tail.replace('\r', '\n').split('\n')
+                tailLines = [l for l in lines if l.strip()][-15:]
+                printDBG("MergeDownloader %s ffmpeg stderr tail:\n%s" % (stepName, '\n'.join(tailLines)))
+            else:
+                printDBG("MergeDownloader %s ffmpeg produced no stderr output" % stepName)
+        except Exception:
+            printExc()
+
+    def _startDurationProbe(self, filePath):
+        self.postProcessMode = 'probe_duration'
+        self.probeOutData = ''
+        inPath = shellQuote(filePath)
+        cmd = DMHelper.GET_FFMPEG_PATH() + ' -y -i "{0}"'.format(inPath)
+        printDBG("MergeDownloader _startDurationProbe cmd[%s]" % cmd)
+        self.console = eConsoleAppContainer()
+        self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
+        self.console_stderrAvail_conn = eConnectCallback(self.console.stderrAvail, self._probeDataAvail)
+        if hasattr(self.console, "setNice"):
+            self.console.setNice(GetNice() + 2)
+            self.console.execute(cmd)
+        else:
+            self.console.execute(E2PrioFix(cmd))
+
+    def _buildFfmetadata(self, chapters, durationMs):
+        lines = [';FFMETADATA1']
+        idx = 0
+        count = len(chapters)
+
+        while idx < count:
+            start = chapters[idx]['start']
+            if idx + 1 < count:
+                end = chapters[idx + 1]['start']
+            else:
+                end = durationMs
+
+            if end <= start:
+                end = start + 1000
+
+            title = self._escapeFfmeta(chapters[idx]['title'])
+
+            lines.append('[CHAPTER]')
+            lines.append('TIMEBASE=1/1000')
+            lines.append('START=%d' % start)
+            lines.append('END=%d' % end)
+            lines.append('title=%s' % title)
+            idx += 1
+
+        return '\n'.join(lines) + '\n'
+
+    def _startChapterMetadataFlow(self):
+        # kicks off the async duration probe; the actual ffmeta file is written
+        # from _cmdFinished once the probe process closes (see 'probe_duration' mode)
+        try:
+            chapters = self._extractChaptersFromText(self.sidecarTxt)
+            if len(chapters) < 2:
+                printDBG("MergeDownloader no usable chapters found in description")
+                return False
+
+            self._pendingChapters = chapters
+            self._startDurationProbe(self.tempMergePath)
+            return True
+        except Exception:
+            printExc("MergeDownloader _startChapterMetadataFlow failed")
+        return False
+
+    def _finishChapterMetadataFlow(self, durationMs):
+        try:
+            chapters = self._pendingChapters
+            self._pendingChapters = []
+            self.mergedFileDurationMs = durationMs
+            if durationMs <= 0:
+                printDBG("MergeDownloader duration probe failed")
+                return False
+
+            lastStart = chapters[-1]['start']
+            if durationMs <= lastStart:
+                printDBG("MergeDownloader duration smaller/equal than last chapter start")
+                return False
+
+            self.chapterMetaPath = self._getBasePath(self.filePath) + '.chapters.ffmeta'
+            ffmeta = self._buildFfmetadata(chapters, durationMs)
+
+            if writeUtf8TextFile(self.chapterMetaPath, ffmeta):
+                printDBG("MergeDownloader chapter metadata saved [%s]" % self.chapterMetaPath)
+                return True
+            else:
+                printDBG("MergeDownloader chapter metadata save failed [%s]" % self.chapterMetaPath)
+        except Exception:
+            printExc("MergeDownloader _finishChapterMetadataFlow failed")
+        return False
+
+    def _writeCutsFile(self, finalPath):
+        try:
+            chapters = self._extractChaptersFromText(self.sidecarTxt)
+            if len(chapters) < 1:
+                printDBG("MergeDownloader no usable cut markers found in description")
+                return False
+
+            cutsPath = self._getCutsPath(finalPath)
+
+            f = open(fsPath(cutsPath), 'wb')
+            try:
+                for item in chapters:
+                    pts = self._msToPts(item['start'])
+                    if pts < 0:
+                        continue
+                    entry = struct.pack('>QI', pts, 2)
+                    f.write(entry)
+            finally:
+                f.close()
+
+            printDBG("MergeDownloader cuts saved [%s]" % cutsPath)
+            return os.path.isfile(fsPath(cutsPath)) and os.path.getsize(fsPath(cutsPath)) > 0
+        except Exception:
+            printExc("MergeDownloader _writeCutsFile failed")
+        return False
+
+    def start(self, url, filePath, params={}):
+        self.downloaderParams = params
+        self.fileExtension = ''  # should be implemented in future
+        self.url = url
+        self.chapterMetaPath = ''
+        self.finalizedPath = ''
+        self.postProcessMode = 'merge'
+        self.mergedFileDurationMs = 0
+        self.probeOutData = ''
+        self.ffmpegErrData = ''
+        self._pendingChapters = []
+        self.knownDurationMs = -1
+        self.originalFilePath = ensureText(filePath)
+        self.preCheckOnly = False
+
+        self.multi = {'urls': [], 'files': [], 'remote_size': [], 'remote_content_type': [], 'local_size': []}
+        self.currIdx = 0
+
+        meta = strwithmeta(url).meta
+        self._prepareSidecarData(meta)
+
+        self.filePath = self._applyDownloadChannelToFilePath(self.originalFilePath)
+
+        if self._downloadAlreadyPresent(self.filePath):
+            printDBG("MergeDownloader download already present [%s]" % self.filePath)
+            self.status = DMHelper.STS.DOWNLOADED
+            self.finalizedPath = self.filePath
+            self.localFileSize = DMHelper.getFileSize(fsPath(self.filePath))
+            self.remoteFileSize = self.localFileSize
+            self.preCheckOnly = True
+            self.onFinish()
+            return BaseDownloader.CODE_OK
+
+        self._cleanupBeforeStart(self.filePath)
+        self.tempMergePath = self._getBasePath(self.filePath) + '.iptv.merge.tmp.mp4'
+
+        try:
+            urlsKeys = self.url.split('merge://')[1].split('|')
+            idx = 0
+            for item in urlsKeys:
+                itemUrl = meta[item]
+                self.multi['urls'].append(itemUrl)
+                tmpFilePath = self.filePath + '.iptv.tmp.{0}.dash'.format(idx)
+                self.multi['files'].append(tmpFilePath)
+                self.multi['remote_size'].append(self._extractClenFromUrl(itemUrl))
+                self.multi['local_size'].append(-1)
+                self.multi['remote_content_type'].append('')
+                itemDurMs = self._extractDurMsFromUrl(itemUrl)
+                if itemDurMs > self.knownDurationMs:
+                    self.knownDurationMs = itemDurMs
+                idx += 1
+        except Exception:
+            printExc()
+
+        self.doStartDownload()
+        return BaseDownloader.CODE_OK
+
+    def doStartDownload(self):
+        self.outData = ''
+        self.contentType = 'unknown'
+        filePath = self.multi['files'][self.currIdx]
+        url = self.multi['urls'][self.currIdx]
+
+        info = ""
+        retries = 0
+
+        cmd = DMHelper.getBaseWgetCmd(self.downloaderParams) + (' %s -t %d ' % (info, retries)) + '"' + shellQuote(url) + '" -O "' + shellQuote(filePath) + '" > /dev/null'
+        printDBG("doStartDownload cmd[%s]" % cmd)
+
+        self.console = eConsoleAppContainer()
+        self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
+        self.console_stderrAvail_conn = eConnectCallback(self.console.stderrAvail, self._dataAvail)
+        if hasattr(self.console, "setNice"):
+            self.console.setNice(GetNice() + 2)
+            self.console.execute(cmd)
+        else:
+            self.console.execute(E2PrioFix(cmd))
+
+        self.status = DMHelper.STS.DOWNLOADING
+        self.onStart()
+        return BaseDownloader.CODE_OK
+
+    def doStartPostProcess(self):
+        self.postProcessMode = 'merge'
+        self.ffmpegErrData = ''
+        cmd = DMHelper.GET_FFMPEG_PATH() + ' -y '
+        for item in self.multi['files']:
+            cmd += ' -i "{0}" '.format(shellQuote(item))
+        cmd += ' -map 0:0 -map 1:0 -vcodec copy -acodec copy "{0}" '.format(shellQuote(self.tempMergePath))
+        printDBG("doStartPostProcess cmd[%s]" % cmd)
+        self.console = eConsoleAppContainer()
+        self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
+        self.console_stderrAvail_conn = eConnectCallback(self.console.stderrAvail, self._ffmpegErrDataAvail)
+        if hasattr(self.console, "setNice"):
+            self.console.setNice(GetNice() + 2)
+            self.console.execute(cmd)
+        else:
+            self.console.execute(E2PrioFix(cmd))
+
+    def _startMkvChapterMux(self):
+        self.postProcessMode = 'chapters'
+        self.ffmpegErrData = ''
+        mkvPath = self._getMkvPath()
+        cmd = DMHelper.GET_FFMPEG_PATH() + ' -y -i "{0}" -i "{1}" -map 0 -c copy -map_metadata 1 "{2}" '.format(shellQuote(self.tempMergePath), shellQuote(self.chapterMetaPath), shellQuote(mkvPath))
+        printDBG("MergeDownloader _startMkvChapterMux cmd[%s]" % cmd)
+        self.console = eConsoleAppContainer()
+        self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
+        self.console_stderrAvail_conn = eConnectCallback(self.console.stderrAvail, self._ffmpegErrDataAvail)
+        if hasattr(self.console, "setNice"):
+            self.console.setNice(GetNice() + 2)
+            self.console.execute(cmd)
+        else:
+            self.console.execute(E2PrioFix(cmd))
+
+    def _finalizeSuccess(self, finalPath):
+        self.filePath = ensureText(finalPath)
+        self.finalizedPath = ensureText(finalPath)
+        self.localFileSize = DMHelper.getFileSize(fsPath(finalPath))
+        if self.localFileSize > 0:
+            self.remoteFileSize = self.localFileSize
+        self.status = DMHelper.STS.DOWNLOADED
+
+        self._writeTxtSidecar(finalPath)
+
+        if self.makeCutsFile:
+            self._writeCutsFile(finalPath)
+
+        if self.sidecarEnabled and self.sidecarImg:
+            self._startImgSidecarDownload(finalPath)
+            return
+        else:
+            self.status = DMHelper.STS.INTERRUPTED
+
+        self._finishDownloadFlow()
+
+    def _finalizeMp4Fallback(self):
+        try:
+            if os.path.isfile(fsPath(self.tempMergePath)):
+                if self._moveFile(self.tempMergePath, self.filePath):
+                    printDBG("MergeDownloader fallback finalized as original target [%s]" % self.filePath)
+                    self._finalizeSuccess(self.filePath)
+                    return True
+            if os.path.isfile(fsPath(self.filePath)):
+                self._finalizeSuccess(self.filePath)
+                return True
+        except Exception:
+            printExc()
+        return False
+
+    def _dataAvail(self, data):
+        if None is data:
+            return
+        self.outData += ensureText(data)
+        # only parse+reset once the full header block has arrived - wget's
+        # stderr can split a 'Length:' line across two callbacks, and
+        # resetting outData on every call would drop the first half before
+        # the second one arrives
+        if 'Saving to:' in self.outData:
+            self.console_stderrAvail_conn = None
+            lines = self.outData.replace('\r', '\n').split('\n')
+            for idx in range(len(lines)):
+                if 'Length:' in lines[idx]:
+                    match = re.search(r" ([0-9]+?) ", lines[idx])
+                    if match:
+                        parsedSize = int(match.group(1))
+                        if parsedSize > 0:
+                            self.multi['remote_size'][self.currIdx] = parsedSize
+                    match = re.search(r"(\[[^]]+?\])", lines[idx])
+                    if match:
+                        self.multi['remote_content_type'][self.currIdx] = match.group(1)
+            self.outData = ''
+
+    def _terminate(self):
+        printDBG("MergeDownloader._terminate")
+        if None is not self.iptv_sys:
+            self.iptv_sys.kill()
+            self.iptv_sys = None
+
+        self._terminateSidecar()
+
+        if self.status in [DMHelper.STS.DOWNLOADING, DMHelper.STS.POSTPROCESSING]:
+            if self.console:
+                if hasattr(self.console, "sendCtrlC"):
+                    self.console.sendCtrlC()  # kill produce zombies
+                elif hasattr(self.console, "kill"):
+                    self.console.kill()  # kill produce zombies
+            self._cmdFinished(-1, True)
+            return BaseDownloader.CODE_OK
+        return BaseDownloader.CODE_NOT_DOWNLOADING
+
+    def _cmdFinished(self, code, terminated=False):
+        printDBG("MergeDownloader._cmdFinished code[%r] terminated[%r] mode[%s]" % (code, terminated, self.postProcessMode))
+        if self.preCheckOnly:
+            printDBG("MergeDownloader._cmdFinished ignored preCheckOnly")
+            return
+
+        # break circular references
+        if None is not self.console:
+            self.console_appClosed_conn = None
+            self.console_stderrAvail_conn = None
+            self.console = None
+
+        if terminated:
+            self.status = DMHelper.STS.INTERRUPTED
+            self._cleanUp()
+            return
+
+        if self.status == DMHelper.STS.POSTPROCESSING:
+            if self.postProcessMode == 'merge':
+                mergedSize = DMHelper.getFileSize(fsPath(self.tempMergePath))
+                printDBG("POSTPROCESSING merge finished tempMergePath[%s] localFileSize[%r] code[%r]" % (self.tempMergePath, mergedSize, code))
+
+                if mergedSize > 0 and (code == 0 or self._ffmpegReportedCleanFinish()):
+                    if code != 0:
+                        printDBG("MergeDownloader merge step reported code[%r] but ffmpeg stderr shows a clean finish -> treating as success" % code)
+                    if self.makeMkvChapters and self._startChapterMetadataFlow():
+                        return
+
+                    if self._finalizeMp4Fallback():
+                        return
+                    self.status = DMHelper.STS.INTERRUPTED
+                else:
+                    self._logFfmpegFailure("merge")
+                    self.status = DMHelper.STS.INTERRUPTED
+
+            elif self.postProcessMode == 'probe_duration':
+                durationMs = self._parseProbeDuration(self.probeOutData)
+                self.probeOutData = ''
+                if durationMs <= 0 and self.knownDurationMs > 0:
+                    printDBG("MergeDownloader duration probe failed/N-A, falling back to duration from stream URL metadata [%d ms]" % self.knownDurationMs)
+                    durationMs = self.knownDurationMs
+
+                if self._finishChapterMetadataFlow(durationMs):
+                    self._startMkvChapterMux()
+                    return
+
+                if self._finalizeMp4Fallback():
+                    return
+                self.status = DMHelper.STS.INTERRUPTED
+
+            elif self.postProcessMode == 'chapters':
+                mkvPath = self._getMkvPath()
+                mkvSize = DMHelper.getFileSize(fsPath(mkvPath))
+                printDBG("POSTPROCESSING chapters finished mkvPath[%s] localFileSize[%r] code[%r]" % (mkvPath, mkvSize, code))
+
+                if mkvSize > 0 and (code == 0 or self._ffmpegReportedCleanFinish()):
+                    if code != 0:
+                        printDBG("MergeDownloader chapters step reported code[%r] but ffmpeg stderr shows a clean finish -> treating as success" % code)
+                    self._finalizeSuccess(mkvPath)
+                    return
+
+                self._logFfmpegFailure("chapters")
+                printDBG("MergeDownloader chapter mux failed -> fallback to original target name")
+                if self._finalizeMp4Fallback():
+                    return
+                self.status = DMHelper.STS.INTERRUPTED
+
+        elif code == 0:
+            if (self.currIdx + 1) < len(self.multi['urls']):
+                self.currIdx += 1
+                self.doStartDownload()
+                return
+            else:
+                self.status = DMHelper.STS.POSTPROCESSING
+                self.doStartPostProcess()
+                return
+        else:
+            self.status = DMHelper.STS.INTERRUPTED
+
+        if not terminated:
+            self._finishDownloadFlow()
+
+    def _localFileSize(self, update=True):
+        printDBG(">>>>>>>>>>>>>>>>>>>>> _localFileSize [%r] loacalSize[%r] = %r" % (self.localFileSize, self.currIdx, self.multi['local_size']))
+        if self.localFileSize > 0:
+            return self.localFileSize
+        else:
+            if update and self.currIdx < len(self.multi['files']):
+                self.multi['local_size'][self.currIdx] = DMHelper.getFileSize(fsPath(self.multi['files'][self.currIdx]))
+            localFileSize = 0
+            for item in self.multi['local_size']:
+                if item > 0:
+                    localFileSize += item
+            return localFileSize
+
+    def _remoteFileSize(self):
+        printDBG(">>>>>>>>>>>>>>>>>>>>> _remoteFileSize [%r]" % (self.remoteFileSize))
+        if self.remoteFileSize > 0:
+            return self.remoteFileSize
+        else:
+            remoteFileSize = 0
+            num = 0
+            for item in self.multi['remote_size']:
+                if item > 0:
+                    remoteFileSize += item
+                num += 1
+            if num == len(self.multi['remote_size']):
+                return remoteFileSize
+        return -1
+
+    def updateStatistic(self):
+        prevUpdateTime = self.lastUpadateTime
+        newTime = datetime.datetime.now()
+        # calculate downloaded Speed
+        if prevUpdateTime:
+            localFileSize = self._localFileSize()
+            deltaSize = localFileSize - self.prevLocalFileSize
+            deltaTime = (newTime - prevUpdateTime).seconds
+            if deltaTime > 0:
+                self.downloadSpeed = deltaSize / deltaTime
+        self.lastUpadateTime = newTime
+        self.prevLocalFileSize = self._localFileSize()
+
+    def getRemoteFileSize(self):
+        return self._remoteFileSize()
+
+    def getLocalFileSize(self, update=False):
+        return self._localFileSize(update)
+
+    def getDownloadSpeed(self):
+        return self.downloadSpeed
+
+    def getPlayableFileSize(self):
+        self.getLocalFileSize()
+        return self.localFileSize

--- a/version.py
+++ b/version.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# YYYY.MM.DD.DAY_RELEASE
+# oe-mirrors Version
+
+IPTV_VERSION = "2026.08.24.01"


### PR DESCRIPTION
### [Search History]
* Now remembers the last selected entry in the search history list globally and jumps back to it when the list is reopened, instead of always starting at index 0. Can be disabled via the new "Remember last search history selection" option.

### [T9 Letter Jump]
* Now also works in normal main/category lists (hosts, folders, series, favourites, search history editor) — previously only available in the search history list itself. A single central switch, "T9 letter jump in lists", controls all of these consistently.

### [Filmpalast.to / SerienStream.to]
* Search suggestions now always use Google instead of provider-specific suggestions. *SerienStream.to: pressing Info on an episode now shows the correct content (previously showed the wrong text due to a faulty type check).

### [Download Manager (merge downloads, e.g. YouTube)]
* ffmpeg post-processing no longer hangs on an "Overwrite?" prompt caused by a leftover file from a previous run.
* ffmpeg's error output is now logged instead of being discarded.
* A known false non-zero exit code from the short remux step is now correctly recognized as success (based on ffmpeg's own completion message). Internal Bugfixes
* Fixed a timing bug where the parsed download size could be lost if a "Length:" line arrived split across two network chunks.

Thx **Kamikaze24**