### PR TITLE
Search History + T9 Letter Jump improvments + Some Fixes - #539

### DIFF
--- a/IPTVPlayer/components/iptvconfigmenu.py
+++ b/IPTVPlayer/components/iptvconfigmenu.py
@@ -181,6 +181,8 @@ config.plugins.iptvplayer.fakExtMoviePlayerList = ConfigSelection(default="fake"
 config.plugins.iptvplayer.hidden_ext_player_def_aspect_ratio = ConfigSelection(default="-1", choices=[("-1", _("default")), ("0", _("4:3 Letterbox")), ("1", _("4:3 PanScan")), ("2", _("16:9")), ("3", _("16:9 always")), ("4", _("16:10 Letterbox")), ("5", _("16:10 PanScan")), ("6", _("16:9 Letterbox"))])
 
 config.plugins.iptvplayer.search_history_size = ConfigInteger(50, (0, 1000000))
+config.plugins.iptvplayer.enableT9MainList = ConfigYesNo(default=True)
+config.plugins.iptvplayer.rememberHistorySelection = ConfigYesNo(default=True)
 config.plugins.iptvplayer.autoplay_start_delay = ConfigInteger(3, (0, 9))
 
 config.plugins.iptvplayer.favourites_use_watched_flag = ConfigYesNo(default=True)
@@ -503,6 +505,8 @@ class ConfigMenu(ConfigBaseWidget):
 
         list.append(getConfigListEntry(_("----- OTHER SETTINGS -----"), ))
         list.append(getConfigListEntry(_("The number of items in the search history"), config.plugins.iptvplayer.search_history_size))
+        list.append(getConfigListEntry(_("Remember last search history selection"), config.plugins.iptvplayer.rememberHistorySelection))
+        list.append(getConfigListEntry(_("T9 letter jump in lists"), config.plugins.iptvplayer.enableT9MainList))
         list.append(getConfigListEntry(_("Write current title to file:"), config.plugins.iptvplayer.curr_title_file))
         list.append(getConfigListEntry(_("MIPS Floating Point Architecture"), config.plugins.iptvplayer.plarformfpuabi))
         list.append(getConfigListEntry(_("Prefer hlsld for playlist with alt. media"), config.plugins.iptvplayer.prefer_hlsdl_for_pls_with_alt_media))

--- a/IPTVPlayer/components/iptvfavouriteswidgets.py
+++ b/IPTVPlayer/components/iptvfavouriteswidgets.py
@@ -20,6 +20,7 @@ from enigma import getDesktop, gRGB
 from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 from Screens.ChoiceBox import ChoiceBox
+from Components.config import config
 from Components.Label import Label
 from Components.ActionMap import ActionMap
 from Tools.NumericalTextInput import NumericalTextInput
@@ -668,6 +669,8 @@ class IPTVFavouritesMainWidget(Screen):
     def keyNumberJump(self, digit):
         if self.reorderingMode:
             return
+        if not config.plugins.iptvplayer.enableT9MainList.value:
+            return
 
         letter = self.t9Input.getKey(int(digit))
         if not letter:
@@ -678,7 +681,9 @@ class IPTVFavouritesMainWidget(Screen):
             if ":groups:" == self.menu:
                 groups = self.favourites.getGroups()
                 total = len(groups)
-                getTitle = lambda i: groups[i].get('title', '')
+
+                def getTitle(i):
+                    return groups[i].get('title', '')
             else:
                 if not self.loadGroupItems(self.menu):
                     return
@@ -686,7 +691,9 @@ class IPTVFavouritesMainWidget(Screen):
                 if not sts:
                     return
                 total = len(items)
-                getTitle = lambda i: getattr(items[i], 'name', '')
+
+                def getTitle(i):
+                    return getattr(items[i], 'name', '')
 
             idx = findT9JumpIndex(total, currentIdx, letter, getTitle)
             if idx >= 0:

--- a/IPTVPlayer/components/iptvplayerwidget.py
+++ b/IPTVPlayer/components/iptvplayerwidget.py
@@ -258,6 +258,11 @@ class E2iPlayerWidget(Screen):
         self.currItem = CDisplayListItem()
         self.favouritesCurrentGroupId = ''
 
+        # global (not per-host) memory of the last selected search-history entry,
+        # see _rememberHistorySelection()/_restoreHistorySelection()
+        self._lastHistorySelection = None
+        self._isLoadingList = False
+
         self.visible = True
         self.bufferSize = config.plugins.iptvplayer.requestedBuffSize.value * 1024 * 1024
 
@@ -320,8 +325,15 @@ class E2iPlayerWidget(Screen):
         self.prevVideoMode = None
         # no handleTimeout: we act on every press immediately (list jump,
         # not text composition), so the commit-after-timeout callback and
-        # its eTimer aren't needed - only the digit-cycling in getKey() is
+        # its eTimer aren't needed - only the digit-cycling in getKey() is.
+        # Separate instances per list context: NumericalTextInput only resets
+        # its letter-cycle position when a DIFFERENT digit is pressed, so
+        # sharing one instance between the search-history and main-list T9
+        # jump would leak cycle state across an unrelated list switch (e.g.
+        # pressing '2' in the history list, then '2' again in the main list,
+        # would resume the cycle at 'b' instead of restarting at 'a').
         self.t9HistoryInput = NumericalTextInput(handleTimeout=False)
+        self.t9MainListInput = NumericalTextInput(handleTimeout=False)
 
         # test if path for js and cookies temporary files
         # is writable, without this plugin can not works
@@ -1061,6 +1073,7 @@ class E2iPlayerWidget(Screen):
     def onSelectionChanged(self):
         self.updateDownloadButton()
         self.changeBottomPanel()
+        self._rememberHistorySelection()
 
     def back_pressed(self):
         if self.stopAutoPlaySequencer() and self.autoPlaySeqTimerValue:
@@ -1129,26 +1142,95 @@ class E2iPlayerWidget(Screen):
 
         return False
 
+    def _rememberHistorySelection(self):
+        # global (not per-host) memory of the last selected search-history
+        # entry, restored by _restoreHistorySelection() in reloadList() so
+        # reopening the history list lands back on it instead of index 0.
+        # Skipped while a list is being (re)loaded, since moveToIndex() below
+        # fires this same callback and would otherwise overwrite the value
+        # we are about to restore with whatever index/name it lands on first.
+        try:
+            if not config.plugins.iptvplayer.rememberHistorySelection.value:
+                return
+            if self._isLoadingList or not self.isSearchHistoryList():
+                return
+            item = self.getSelItem()
+            name = getattr(item, 'name', None) if item is not None else None
+            if name:
+                self._lastHistorySelection = name
+        except Exception:
+            printExc()
+
+    def _restoreHistorySelection(self):
+        # name-based, not index-based: new searches insert at the front of
+        # the history list and shift every existing entry's index
+        try:
+            if not config.plugins.iptvplayer.rememberHistorySelection.value:
+                return
+            if not self.isSearchHistoryList():
+                return
+            wanted = self._lastHistorySelection
+            if not wanted:
+                return
+            for idx, it in enumerate(self.currList):
+                if getattr(it, 'name', None) == wanted:
+                    self["list"].moveToIndex(idx)
+                    break
+        except Exception:
+            printExc()
+
     def keyT9Jump(self, digit):
-        if not self.isSearchHistoryList():
+        # single global switch for the whole T9 letter-jump feature (this
+        # method's search-history AND main-list branch alike, plus the
+        # independent keyNumberJump() copies in iptvfavouriteswidgets.py and
+        # searchhistoryeditor.py) - off restores plain keyT9_1/4/8 fallback
+        # behaviour (ok_pressed1/4, startAutoPlaySequencer) everywhere
+        if not config.plugins.iptvplayer.enableT9MainList.value:
             return False
 
-        letter = self.t9HistoryInput.getKey(int(digit))
-        if not letter:
+        # search-history list: every digit press is consumed by the T9 jump
+        # (always returns True), digits have no other meaning in this list
+        if self.isSearchHistoryList():
+            letter = self.t9HistoryInput.getKey(int(digit))
+            if not letter:
+                return True
+
+            try:
+                currentIdx = self['list'].getCurrentIndex()
+                idx = findT9JumpIndex(len(self.currList), currentIdx, letter, lambda i: getattr(self.currList[i], 'name', ''))
+                if idx >= 0:
+                    self['list'].moveToIndex(idx)
+                    printDBG('T9 history jump key[%s] letter[%s] index[%d]' % (digit, letter, idx))
+                else:
+                    printDBG('T9 history jump key[%s] letter[%s] no match' % (digit, letter))
+            except Exception:
+                printExc()
+
             return True
 
+        # any other list (main menu, categories, series, favourites, ...):
+        # only intercept the digit when it actually produced a jump, so
+        # keyT9_1/4/8's secondary binding (ok_pressed1/4, startAutoPlaySequencer)
+        # still fires normally when there is no match
+        if not self.currList:
+            return False
+
         try:
+            letter = self.t9MainListInput.getKey(int(digit))
+            if not letter:
+                return True
+
             currentIdx = self['list'].getCurrentIndex()
             idx = findT9JumpIndex(len(self.currList), currentIdx, letter, lambda i: getattr(self.currList[i], 'name', ''))
             if idx >= 0:
                 self['list'].moveToIndex(idx)
-                printDBG('T9 history jump key[%s] letter[%s] index[%d]' % (digit, letter, idx))
-            else:
-                printDBG('T9 history jump key[%s] letter[%s] no match' % (digit, letter))
+                printDBG('T9 main list jump key[%s] letter[%s] index[%d]' % (digit, letter, idx))
+                return True
+            printDBG('T9 main list jump key[%s] letter[%s] no match' % (digit, letter))
+            return False
         except Exception:
             printExc()
-
-        return True
+            return False
 
     def keyT9_1(self):
         if not self.keyT9Jump('1'):
@@ -2360,6 +2442,9 @@ class E2iPlayerWidget(Screen):
 
     def reloadList(self, params):
         printDBG("reloadList")
+        # suppresses _rememberHistorySelection() while the list below is being
+        # (re)built and its selection moved around programmatically
+        self._isLoadingList = True
         refresh = params['add_param'].get('refresh', 0)
         selIndex = params['add_param'].get('selIndex', -1)
         ret = params['ret']
@@ -2409,6 +2494,8 @@ class E2iPlayerWidget(Screen):
 
             self.setStatusTex("")
             self["list"].show()
+        self._isLoadingList = False
+        self._restoreHistorySelection()
         self.updateDownloadButton()
         if 2 == refresh:
             self.autoPlaySequencerNext(False)

--- a/IPTVPlayer/components/searchhistoryeditor.py
+++ b/IPTVPlayer/components/searchhistoryeditor.py
@@ -13,6 +13,7 @@ from enigma import gRGB
 from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 from Screens.ChoiceBox import ChoiceBox
+from Components.config import config
 from Components.ActionMap import ActionMap
 from Components.Label import Label
 from Components.MenuList import MenuList
@@ -396,6 +397,8 @@ class SearchHistoryEditor(Screen):
         if self.manualReorderMode:
             return
         if not self.entries:
+            return
+        if not config.plugins.iptvplayer.enableT9MainList.value:
             return
 
         letter = self.numberInput.getKey(int(digit))

--- a/IPTVPlayer/hosts/hostfilmpalast.py
+++ b/IPTVPlayer/hosts/hostfilmpalast.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 06.08.2026 - Centralized watched helper integration incl. favourite hash sync, Custom menu action handling (mark/unmark watched) added, sidecar/MKV article request now skipped when both are disabled - Kamikaze24
+# Last Modified: 23.08.2026 - getSuggestionsProvider() added (forces Google search suggestions) - Kamikaze24
 ###################################################
 # LOCAL import
 ###################################################
@@ -716,6 +716,10 @@ class IPTVHost(WatchedFlagHostMixin, CHostBase):
             except Exception:
                 printExc()
         return ret
+
+    def getSuggestionsProvider(self, index=-1):
+        from Plugins.Extensions.IPTVPlayer.suggestions.google import SuggestionsProvider as google_Provider
+        return RetHost(status=RetHost.OK, value=[google_Provider()])
 
     def withArticleContent(self, cItem):
         if "video" == cItem.get("type", "") or "explore_item" == cItem.get("category", ""):

--- a/IPTVPlayer/hosts/hostserienstreamto.py
+++ b/IPTVPlayer/hosts/hostserienstreamto.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 06.08.2026 Centralized watched helper integration incl. favourite hash sync, Custom menu action handling (mark/unmark watched) added, sidecar/MKV/OMDb lookups now skipped when both are disabled - Kamikaze24
+# Last Modified: 23.08.2026 - withArticleContent() now checks type for episodes, fixes wrong Info text on episode press, getSuggestionsProvider() added (forces Google search suggestions) - Kamikaze24
 import re
 import json
 
@@ -777,5 +777,9 @@ class IPTVHost(WatchedFlagHostMixin, CHostBase):
                 printExc()
         return ret
 
+    def getSuggestionsProvider(self, index=-1):
+        from Plugins.Extensions.IPTVPlayer.suggestions.google import SuggestionsProvider as google_Provider
+        return RetHost(status=RetHost.OK, value=[google_Provider()])
+
     def withArticleContent(self, cItem):
-        return cItem["category"] in ["video", "list_seasons", "list_episodes", "list_newepisodes"]
+        return cItem.get("type", "") in ["video", "audio"] or cItem.get("category", "") in ["list_seasons", "list_episodes", "list_newepisodes"]

--- a/IPTVPlayer/iptvdm/mergedownloader.py
+++ b/IPTVPlayer/iptvdm/mergedownloader.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 # IPTV download manager API
-# Last Modified: 07.08.2026 - Extracted shared helpers (ensureText/fsPath/shellQuote/writeUtf8TextFile) and sidecar logic into downloaderhelpers.SidecarMixin, shared with wgetdownloader.py and hlsdownloader.py, instead of duplicating them here. Added 'clen'/'dur' URL-metadata fallback for merge:// downloads (YouTube audio/video streams): remote_size no longer relies solely on wget's "Length:" stderr line, and the ffmpeg chapter-duration probe falls back to the stream's 'dur' value when ffmpeg reports "Duration: N/A" on raw DASH-muxed files - Kamikaze24
+# Last Modified: 19.08.2026 - Fixed ffmpeg merge/chapter-mux steps reporting exit code 1 despite writing a
+# complete, correct output file. Root causes handled: (1) added '-y' to all ffmpeg post-process invocations
+# so ffmpeg never blocks on stdin waiting for an "Overwrite? [y/N]" prompt on a stale leftover output file;
+# (2) stopped discarding ffmpeg's merge/mux stderr into /dev/null - it's now captured via stderrAvail like the
+# duration probe already does, and logged on failure; (3) eConsoleAppContainer can report a spurious non-zero
+# exit code for the short second ffmpeg pass (remux with -map_metadata from the tiny .ffmeta file) even though
+# ffmpeg's own stderr shows a completely clean finish (the "Lsize=...muxing overhead:" summary only appears
+# after a successful write) - this is now treated as authoritative success, overriding the bogus exit code,
+# for both the merge and chapters post-process steps - Kamikaze24
 ###################################################
 # LOCAL import
 ###################################################
@@ -31,7 +39,6 @@ try:
 except Exception:
     printExc()
 ###################################################
-
 
 ###################################################
 # One instance of this class can be used only for
@@ -67,6 +74,7 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
         self.postProcessMode = 'merge'
         self.mergedFileDurationMs = 0
         self.probeOutData = ''
+        self.ffmpegErrData = ''
         self._pendingChapters = []
 
         self.channelName = ''
@@ -101,6 +109,9 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
                 self._safeRm(filePath + '.iptv.tmp.%d.dash' % idx)
             self._safeRm(basePath + '.iptv.merge.tmp.mp4')
             self._safeRm(basePath + '.chapters.ffmeta')
+            # also remove a stale MKV target from a previous aborted run so ffmpeg never
+            # has to prompt "Overwrite? [y/N]" on a leftover file (hangs/exits 1 without -y)
+            self._safeRm(basePath + '.mkv')
         except Exception:
             printExc()
 
@@ -269,7 +280,7 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
             return os.path.isfile(dstPath)
         except Exception:
             printExc()
-            return False
+        return False
 
     def _normalizeChapterTitle(self, title):
         title = ensureText(title).strip()
@@ -384,11 +395,45 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
             return
         self.probeOutData += ensureText(data)
 
+    def _ffmpegErrDataAvail(self, data):
+        # captures ffmpeg's stderr for the merge/chapter-mux steps instead of throwing it away,
+        # so a failing 'code[1]' can actually be diagnosed from the log instead of guessed at
+        if data is None:
+            return
+        self.ffmpegErrData += ensureText(data)
+        if len(self.ffmpegErrData) > 8000:
+            self.ffmpegErrData = self.ffmpegErrData[-8000:]
+
+    def _ffmpegReportedCleanFinish(self):
+        # eConsoleAppContainer can report a spurious non-zero exit code for a short-lived second
+        # ffmpeg pass (e.g. remuxing with -map_metadata from a tiny .ffmeta file) even though
+        # ffmpeg itself completed normally. ffmpeg only prints the final "Lsize=...muxing overhead:"
+        # summary line after a clean successful write, so treat its presence as authoritative
+        # success, overriding a bogus non-zero exit code from the console container.
+        try:
+            tail = ensureText(self.ffmpegErrData)
+            return bool(re.search(r'Lsize=\s*\S+.*muxing overhead', tail, re.DOTALL))
+        except Exception:
+            printExc()
+        return False
+
+    def _logFfmpegFailure(self, stepName):
+        try:
+            tail = self.ffmpegErrData.strip()
+            if tail:
+                lines = tail.replace('\r', '\n').split('\n')
+                tailLines = [l for l in lines if l.strip()][-15:]
+                printDBG("MergeDownloader %s ffmpeg stderr tail:\n%s" % (stepName, '\n'.join(tailLines)))
+            else:
+                printDBG("MergeDownloader %s ffmpeg produced no stderr output" % stepName)
+        except Exception:
+            printExc()
+
     def _startDurationProbe(self, filePath):
         self.postProcessMode = 'probe_duration'
         self.probeOutData = ''
         inPath = shellQuote(filePath)
-        cmd = DMHelper.GET_FFMPEG_PATH() + ' -i "{0}"'.format(inPath)
+        cmd = DMHelper.GET_FFMPEG_PATH() + ' -y -i "{0}"'.format(inPath)
         printDBG("MergeDownloader _startDurationProbe cmd[%s]" % cmd)
         self.console = eConsoleAppContainer()
         self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
@@ -491,7 +536,7 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
             return os.path.isfile(fsPath(cutsPath)) and os.path.getsize(fsPath(cutsPath)) > 0
         except Exception:
             printExc("MergeDownloader _writeCutsFile failed")
-            return False
+        return False
 
     def start(self, url, filePath, params={}):
         self.downloaderParams = params
@@ -502,6 +547,7 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
         self.postProcessMode = 'merge'
         self.mergedFileDurationMs = 0
         self.probeOutData = ''
+        self.ffmpegErrData = ''
         self._pendingChapters = []
         self.knownDurationMs = -1
         self.originalFilePath = ensureText(filePath)
@@ -576,13 +622,15 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
 
     def doStartPostProcess(self):
         self.postProcessMode = 'merge'
-        cmd = DMHelper.GET_FFMPEG_PATH() + ' '
+        self.ffmpegErrData = ''
+        cmd = DMHelper.GET_FFMPEG_PATH() + ' -y '
         for item in self.multi['files']:
             cmd += ' -i "{0}" '.format(shellQuote(item))
-        cmd += ' -map 0:0 -map 1:0 -vcodec copy -acodec copy "{0}" >/dev/null 2>&1 '.format(shellQuote(self.tempMergePath))
+        cmd += ' -map 0:0 -map 1:0 -vcodec copy -acodec copy "{0}" '.format(shellQuote(self.tempMergePath))
         printDBG("doStartPostProcess cmd[%s]" % cmd)
         self.console = eConsoleAppContainer()
         self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
+        self.console_stderrAvail_conn = eConnectCallback(self.console.stderrAvail, self._ffmpegErrDataAvail)
         if hasattr(self.console, "setNice"):
             self.console.setNice(GetNice() + 2)
             self.console.execute(cmd)
@@ -591,11 +639,13 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
 
     def _startMkvChapterMux(self):
         self.postProcessMode = 'chapters'
+        self.ffmpegErrData = ''
         mkvPath = self._getMkvPath()
-        cmd = DMHelper.GET_FFMPEG_PATH() + ' -i "{0}" -i "{1}" -map 0 -c copy -map_metadata 1 "{2}" >/dev/null 2>&1 '.format(shellQuote(self.tempMergePath), shellQuote(self.chapterMetaPath), shellQuote(mkvPath))
+        cmd = DMHelper.GET_FFMPEG_PATH() + ' -y -i "{0}" -i "{1}" -map 0 -c copy -map_metadata 1 "{2}" '.format(shellQuote(self.tempMergePath), shellQuote(self.chapterMetaPath), shellQuote(mkvPath))
         printDBG("MergeDownloader _startMkvChapterMux cmd[%s]" % cmd)
         self.console = eConsoleAppContainer()
         self.console_appClosed_conn = eConnectCallback(self.console.appClosed, self._cmdFinished)
+        self.console_stderrAvail_conn = eConnectCallback(self.console.stderrAvail, self._ffmpegErrDataAvail)
         if hasattr(self.console, "setNice"):
             self.console.setNice(GetNice() + 2)
             self.console.execute(cmd)
@@ -641,6 +691,10 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
         if None is data:
             return
         self.outData += ensureText(data)
+        # only parse+reset once the full header block has arrived - wget's
+        # stderr can split a 'Length:' line across two callbacks, and
+        # resetting outData on every call would drop the first half before
+        # the second one arrives
         if 'Saving to:' in self.outData:
             self.console_stderrAvail_conn = None
             lines = self.outData.replace('\r', '\n').split('\n')
@@ -696,7 +750,9 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
                 mergedSize = DMHelper.getFileSize(fsPath(self.tempMergePath))
                 printDBG("POSTPROCESSING merge finished tempMergePath[%s] localFileSize[%r] code[%r]" % (self.tempMergePath, mergedSize, code))
 
-                if mergedSize > 0 and code == 0:
+                if mergedSize > 0 and (code == 0 or self._ffmpegReportedCleanFinish()):
+                    if code != 0:
+                        printDBG("MergeDownloader merge step reported code[%r] but ffmpeg stderr shows a clean finish -> treating as success" % code)
                     if self.makeMkvChapters and self._startChapterMetadataFlow():
                         return
 
@@ -704,6 +760,7 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
                         return
                     self.status = DMHelper.STS.INTERRUPTED
                 else:
+                    self._logFfmpegFailure("merge")
                     self.status = DMHelper.STS.INTERRUPTED
 
             elif self.postProcessMode == 'probe_duration':
@@ -726,10 +783,13 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
                 mkvSize = DMHelper.getFileSize(fsPath(mkvPath))
                 printDBG("POSTPROCESSING chapters finished mkvPath[%s] localFileSize[%r] code[%r]" % (mkvPath, mkvSize, code))
 
-                if mkvSize > 0 and code == 0:
+                if mkvSize > 0 and (code == 0 or self._ffmpegReportedCleanFinish()):
+                    if code != 0:
+                        printDBG("MergeDownloader chapters step reported code[%r] but ffmpeg stderr shows a clean finish -> treating as success" % code)
                     self._finalizeSuccess(mkvPath)
                     return
 
+                self._logFfmpegFailure("chapters")
                 printDBG("MergeDownloader chapter mux failed -> fallback to original target name")
                 if self._finalizeMp4Fallback():
                     return
@@ -776,7 +836,7 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
                 num += 1
             if num == len(self.multi['remote_size']):
                 return remoteFileSize
-            return -1
+        return -1
 
     def updateStatistic(self):
         prevUpdateTime = self.lastUpadateTime

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.08.19.01"
+IPTV_VERSION = "2026.08.24.01"


### PR DESCRIPTION
### [Search History]
* Now remembers the last selected entry in the search history list globally and jumps back to it when the list is reopened, instead of always starting at index 0. Can be disabled via the new "Remember last search history selection" option.

### [T9 Letter Jump]
* Now also works in normal main/category lists (hosts, folders, series, favourites, search history editor) — previously only available in the search history list itself. A single central switch, "T9 letter jump in lists", controls all of these consistently.

### [Filmpalast.to / SerienStream.to]
* Search suggestions now always use Google instead of provider-specific suggestions. *SerienStream.to: pressing Info on an episode now shows the correct content (previously showed the wrong text due to a faulty type check).

### [Download Manager (merge downloads, e.g. YouTube)]
* ffmpeg post-processing no longer hangs on an "Overwrite?" prompt caused by a leftover file from a previous run.
* ffmpeg's error output is now logged instead of being discarded.
* A known false non-zero exit code from the short remux step is now correctly recognized as success (based on ffmpeg's own completion message). Internal Bugfixes
* Fixed a timing bug where the parsed download size could be lost if a "Length:" line arrived split across two network chunks.

Thx **Kamikaze24**