### PR TITLE
Videa & HDFilme host fixes

### DIFF
--- a/IPTVPlayer/hosts/hosthdfilme.py
+++ b/IPTVPlayer/hosts/hosthdfilme.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-#  2025 Team Jogi  #
-# Last Modified: 24.08.2026 - Adapted to the new meinecloud.click player backend, restored season/episode navigation, added watched/started flag support, switched to the current hdfilme.win domain
+# Last Modified: 25.08.2026 - strip the leading "S<n> E<n>" NUMBERS from the site's raw episode label and keep whatever separator character the site itself already uses (dash or em-dash) untouched, instead of re-building a custom separator; removed the unnecessary EM_DASH/EN_DASH constants and literal-unicode-escape decoding machinery from the previous iteration.
 
 import re
 
 from Plugins.Extensions.IPTVPlayer.components.ihost import CBaseHostClass, CHostBase, RetHost
-from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
 from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote_plus
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
@@ -22,6 +21,44 @@ def gettytul():
     return "https://hdfilme.win/"
 
 
+def _extractNum(rawValue, default=0):
+    """First run of digits in the value as int, else default. Anchored to the first digit
+    group so a trailing '(2019)' or similar in a label cannot leak into the number."""
+    m = re.search(r"\d+", str(rawValue))
+    return int(m.group(0)) if m else default
+
+
+def _formatSxxExx(seasonNum, episodeNum=None):
+    """Build a zero-padded SxxExx tag from already-resolved season/episode numbers (not internal DB ids)."""
+    sNum = _extractNum(seasonNum, 0)
+    if episodeNum is None:
+        return "S%02d" % sNum
+    eNum = _extractNum(episodeNum, 0)
+    return "S%02dE%02d" % (sNum, eNum)
+
+
+def _parseLeadingSxEx(label):
+    """Detect a leading 'S1 E1' / 'S01E01' style tag inside a raw episode label; returns (seasonNum, episodeNum) or (None, None)."""
+    m = re.match(r"\s*S\s*(\d+)\s*E\s*(\d+)", label, re.IGNORECASE)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return None, None
+
+
+def _stripLeadingSeasonEpisodeNumbers(label):
+    """Remove only the leading 'S<digits> E<digits>' numbers from a raw episode label. Whatever
+    separator character the site itself put right after (dash, em-dash, colon, nothing) is left
+    untouched, so we never fight with the site's own formatting."""
+    return re.sub(r"^\s*S\s*\d+\s*E\s*\d+\s*", "", label, flags=re.IGNORECASE)
+
+
+def _trimTrailingDashPart(title):
+    """Drop a trailing ' – <type>' marker the listing appends after the real title (en/em dash
+    only, never a plain hyphen). Runs on already-HTML-decoded text so it works whether the site
+    emits a literal dash or the &#8211; entity."""
+    return re.split(r"\s+[–—]\s*", title, maxsplit=1)[0].strip()
+
+
 class HDFilme(CBaseHostClass):
 
     def __init__(self):
@@ -36,9 +73,7 @@ class HDFilme(CBaseHostClass):
             {"category": "list_items", "title": _("New"), "url": self.getFullUrl("filme1/")},
             {"category": "list_items", "title": _("Cinema movies"), "url": self.getFullUrl("kinofilme/")},
             {"category": "list_items", "title": _("Series"), "url": self.getFullUrl("serien/")},
-            {"category": "list_genres", "title": "Genres"},
-            {"category": "list_year", "title": _("Year")},
-            {"category": "list_country", "title": _("Country")}] + self.searchItems()
+            {"category": "list_genres", "title": "Genres"}] + self.searchItems()
 
     def getPage(self, baseUrl, addParams=None, post_data=None):
         if addParams is None:
@@ -53,8 +88,11 @@ class HDFilme(CBaseHostClass):
             category = cItem.get("category", "")
             if itemType in ["video", "audio"]:
                 url = str(cItem.get("url", "") or "").strip()
+                seasonId = str(cItem.get("season_id", "") or "").strip()
                 streamUrl = str(cItem.get("stream_url", "") or "").strip()
-                if url != "" and streamUrl != "":
+                # only episodes (which share the series url) need the stream_url to stay unique;
+                # a standalone movie must key on the plain url so its listing tile matches
+                if seasonId != "" and url != "" and streamUrl != "":
                     return "url:%s|%s" % (url, streamUrl)
                 if url != "":
                     return "url:%s" % url
@@ -73,12 +111,14 @@ class HDFilme(CBaseHostClass):
             return ""
         except Exception:
             printExc()
-        return ""
+            return ""
 
     def _buildSeasonItem(self, seasonId):
         return {"category": "list_episodes", "url": self.currItem.get("url", ""), "season_id": seasonId}
 
     def _propagateEpisodeWatchedState(self, item):
+        """Recompute the season-parent and series-parent watched state for an episode-ish item
+        (an episode video, or a list_episodes season node). No-op for anything without a season."""
         try:
             if not isinstance(item, dict):
                 return
@@ -86,44 +126,45 @@ class HDFilme(CBaseHostClass):
             url = str(item.get("url", "") or self.currItem.get("url", "") or "").strip()
             if seasonId == "" or url == "":
                 return
-            seasonParent = self._buildSeasonItem(seasonId)
             seasonEpisodes = self.cacheSeasons.get(seasonId, [])
             if seasonEpisodes:
-                self.watchedHelper.updateParentWatchedState(seasonParent, seasonEpisodes, self._getWatchedKeyForItem)
+                self.watchedHelper.updateParentWatchedState(self._buildSeasonItem(seasonId), seasonEpisodes, self._getWatchedKeyForItem)
             seasonChildren = [self._buildSeasonItem(sid) for sid in self.cacheSeasons]
             if seasonChildren:
-                seriesParent = {"category": "list_seasons", "url": url}
-                self.watchedHelper.updateParentWatchedState(seriesParent, seasonChildren, self._getWatchedKeyForItem)
+                self.watchedHelper.updateParentWatchedState({"category": "list_seasons", "url": url}, seasonChildren, self._getWatchedKeyForItem)
         except Exception:
             printExc()
 
     def listItems(self, cItem):
         printDBG("HDFilme.listItems |%s|" % cItem)
-        url = cItem["url"]
-        sts, data = self.getPage(url)
+        sts, data = self.getPage(cItem["url"])
         if not sts:
+            return
+        if "Fatal error: Uncaught" in data[:2000]:
+            SetIPTVPlayerLastHostError(_("The website returned a server error for this request."))
             return
         nextPage = re.findall('nav_ext">.*?next">.*?href="([^"]+)', data, re.DOTALL)
         items = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="item relative', 'class="absolute')
         if not items:
             items = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="pages">', "<svg")
-
         for item in items:
+            itemUrl = self.getFullUrl(self.cm.ph.getSearchGroups(item, 'href="([^"]+)')[0])
+            title = self.cm.ph.getSearchGroups(item, 'title="([^"]+)')[0]
+            if not title:
+                title = self.cm.ph.getSearchGroups(item, '<strong>(.*?)</strong>')[0]
+            title = _trimTrailingDashPart(self.cleanHtmlStr(title))
+            if not title or not self.cm.isValidUrl(itemUrl):
+                continue
             desc = ""
-            url = self.getFullUrl(self.cm.ph.getSearchGroups(item, 'href="([^"]+)')[0])
             icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(item, 'data-src="([^"]+)')[0])
-            duration = self.cm.ph.getSearchGroups(item, r"<span>(\d+ min)</span>")
-            year = self.cm.ph.getSearchGroups(item, r"<span>(\d{4})</span>")
+            duration = self.cm.ph.getSearchGroups(item, r'<span[^>]*>(\d+ min)</span>')
+            year = self.cm.ph.getSearchGroups(item, r'<span[^>]*>(\d{4})</span>')
             if year:
                 desc += "Jahr: %s \n" % year[0]
             if duration:
                 desc += "Dauer: %s" % duration[0]
-            title = self.cm.ph.getSearchGroups(item, 'title="([^"]+)')[0]
-            if not title:
-                title = self.cm.ph.getSearchGroups(item, "<strong>(.*?)</strong>")[0]
-            title = title.split(" &#8211;")[0]
             params = dict(cItem)
-            params.update({"good_for_fav": True, "category": "list_seasons", "title": self.cleanHtmlStr(title), "url": url, "icon": icon, "desc": desc})
+            params.update({"good_for_fav": True, "category": "list_seasons", "title": title, "url": itemUrl, "icon": icon, "desc": desc})
             self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addDir(params)
         if nextPage:
@@ -152,10 +193,51 @@ class HDFilme(CBaseHostClass):
             return "direct", fallbackUrl
         return None, None
 
+    def _buildEpisodesForSeason(self, seasonId, seasonNum, seriesName, url, icon, desc, blocksById):
+        episodes = []
+        episodeMatches = re.findall(r'data-link="([^"]+)"[^>]*?data-label="([^"]+)"', blocksById.get(seasonId, ""))
+        for episodeIndex, (link, label) in enumerate(episodeMatches, start=1):
+            cleanLabelRaw = self.cleanHtmlStr(label)
+            embeddedSeason, embeddedEpisode = _parseLeadingSxEx(cleanLabelRaw)
+            seasonNumForTag = embeddedSeason if embeddedSeason is not None else seasonNum
+            episodeNum = embeddedEpisode if embeddedEpisode is not None else episodeIndex
+            epTag = _formatSxxExx(seasonNumForTag, episodeNum)
+            rest = _stripLeadingSeasonEpisodeNumbers(cleanLabelRaw).strip()
+            if seriesName:
+                episodeTitle = "%s - %s %s" % (seriesName, epTag, rest) if rest else "%s - %s" % (seriesName, epTag)
+            else:
+                episodeTitle = "%s %s" % (epTag, rest) if rest else epTag
+            episodes.append({"type": "video", "url": url, "title": episodeTitle, "icon": icon, "desc": desc, "stream_url": link, "stream_type": "direct", "season_id": seasonId})
+        return episodes
+
+    def _loadSeriesCache(self, playerUrl, seriesName, seriesUrl, icon, desc):
+        """Fetch the meinecloud player page and (re)populate self.cacheSeasons.
+        Returns (seasons, seasonNumsById); seasons is [] on failure."""
+        self.cacheSeasons = {}
+        seasonNumsById = {}
+        sts, data = self.getPage(playerUrl)
+        if not sts:
+            return [], seasonNumsById
+        tabs = self.cm.ph.getDataBeetwenMarkers(data, 'class="_stabs"', 'class="_now"', False)[1]
+        seasons = re.findall(r'data-season="(\d+)"[^>]*>\s*(\S+)', tabs)
+        seasonBlocks = data.split('class="_season-eps')
+        del seasonBlocks[0]
+        blocksById = {}
+        for block in seasonBlocks:
+            blockId = self.cm.ph.getSearchGroups(block, r'data-season="(\d+)"')[0]
+            if blockId != "":
+                blocksById[blockId] = block
+        for seasonIndex, (seasonId, seasonLabelRaw) in enumerate(seasons, start=1):
+            seasonNumFromLabel = _extractNum(self.cleanHtmlStr(seasonLabelRaw), 0)
+            seasonNum = seasonNumFromLabel if seasonNumFromLabel > 0 else seasonIndex
+            seasonNumsById[seasonId] = seasonNum
+            self.cacheSeasons[seasonId] = self._buildEpisodesForSeason(seasonId, seasonNum, seriesName, seriesUrl, icon, desc, blocksById)
+        return seasons, seasonNumsById
+
     def listSeasons(self, cItem):
         printDBG("HDFilme.listSeasons |%s|" % cItem)
         url = cItem["url"]
-        icon = cItem["icon"]
+        icon = cItem.get("icon", "") or self.DEFAULT_ICON_URL
         sts, data = self.getPage(url)
         if not sts:
             return
@@ -169,30 +251,23 @@ class HDFilme(CBaseHostClass):
             self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addVideo(params)
             return
-        sts, data = self.getPage(target)
-        if not sts:
+        seriesName = self.cleanHtmlStr(cItem.get("title", "") or "")
+        seasons, seasonNumsById = self._loadSeriesCache(target, seriesName, url, icon, desc)
+        if not seasons:
             return
-        tabs = self.cm.ph.getDataBeetwenMarkers(data, 'class="_stabs"', 'class="_now"', False)[1]
-        seasons = re.findall(r'data-season="(\d+)">\s*(\S+)', tabs)
-        seasonBlocks = data.split('class="_season-eps')
-        del seasonBlocks[0]
-        blocksById = {}
-        for block in seasonBlocks:
-            blockId = self.cm.ph.getSearchGroups(block, r'data-season="(\d+)"')[0]
-            if blockId != "":
-                blocksById[blockId] = block
-        self.cacheSeasons = {}
+        if len(seasons) == 1:
+            self.listEpisodes(dict(cItem, season_id=seasons[0][0], series_name=seriesName))
+            return
         seasonParams = {}
-        for seasonId, seasonLabel in seasons:
-            episodes = []
-            for link, label in re.findall(r'data-link="([^"]+)"\s*data-label="([^"]+)"', blocksById.get(seasonId, "")):
-                episodes.append({"type": "video", "url": url, "title": self.cleanHtmlStr(label), "icon": icon, "desc": desc, "stream_url": link, "stream_type": "direct", "season_id": seasonId})
-            self.cacheSeasons[seasonId] = episodes
-            title = cItem["title"] + " - " + seasonLabel
+        for seasonId, _seasonLabelRaw in seasons:
+            seasonNum = seasonNumsById.get(seasonId, 0)
+            episodes = self.cacheSeasons.get(seasonId, [])
+            seasonTag = _formatSxxExx(seasonNum)
+            title = "%s - %s" % (seriesName, seasonTag) if seriesName else seasonTag
             params = dict(cItem)
             params.pop("isWatched", None)
             params.pop("isStarted", None)
-            params.update({"good_for_fav": True, "category": "list_episodes", "title": title, "url": url, "icon": icon, "desc": desc, "season_id": seasonId})
+            params.update({"good_for_fav": True, "category": "list_episodes", "title": title, "url": url, "icon": icon, "desc": desc, "season_id": seasonId, "series_name": seriesName})
             if episodes:
                 self.watchedHelper.updateParentWatchedState(params, episodes, self._getWatchedKeyForItem)
             else:
@@ -206,23 +281,53 @@ class HDFilme(CBaseHostClass):
     def listEpisodes(self, cItem):
         printDBG("HDFilme.listEpisodes |%s|" % cItem)
         seasonId = cItem.get("season_id", "")
+        if seasonId and seasonId not in self.cacheSeasons:
+            self._rebuildSeasonCache(cItem)
         for item in self.cacheSeasons.get(seasonId, []):
             params = dict(item)
             self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addVideo(params)
 
-    def listValue(self, cItem, v):
-        printDBG("HDFilme.Value |%s|" % cItem)
+    def _rebuildSeasonCache(self, cItem):
+        """cacheSeasons is only filled while browsing a series live; rebuild it when a season
+        node is reopened from favourites/history (empty cache) so its episodes show up."""
+        seriesUrl = cItem.get("url", "") or self.currItem.get("url", "")
+        if not seriesUrl:
+            return
+        seriesName = cItem.get("series_name", "")
+        if not seriesName:
+            seriesName = re.sub(r"\s*-\s*S\d+(?:E\d+)?\s*$", "", self.cleanHtmlStr(cItem.get("title", "") or ""))
+        sts, data = self.getPage(seriesUrl)
+        if not sts:
+            return
+        kind, target = self._resolveMeineCloud(data)
+        if kind != "series":
+            return
+        icon = cItem.get("icon", "") or self.DEFAULT_ICON_URL
+        desc = cItem.get("desc", "") or self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, 'og:description" content="([^"]+)')[0])
+        self._loadSeriesCache(target, seriesName, seriesUrl, icon, desc)
+
+    def listGenres(self, cItem):
+        printDBG("HDFilme.listGenres")
         sts, data = self.getPage(self.MAIN_URL)
         if not sts:
             return
-        data = self.cm.ph.getAllItemsBeetwenMarkers(data, ">%s<" % v, "<div class")
-        data = re.findall('href="([^"]+).*?>([^<]+)', data[0], re.DOTALL)
-        for url, title in data:
+        pos = data.find('class="mr-1">Genre<')
+        if pos != -1:
+            pos = data.find("dropdown-content", pos)
+        if pos == -1:
+            return
+        block = self.cm.ph.getDataBeetwenMarkers(data[pos:], ">", "</div>", False)[1]
+        for url, title in re.findall(r'<a\s+href="([^"]+)"[^>]*>([^<]+)</a>', block):
+            title = self.cleanHtmlStr(title).strip()
+            url = self.getFullUrl(url)
+            if not title or not self.cm.isValidUrl(url):
+                continue
+            # the genre dropdown also carries a few plain nav links (Serien, Demnächst, kinofilme)
             if "ino" in title or "erien" in title or "chst" in title:
                 continue
             params = dict(cItem)
-            params.update({"good_for_fav": True, "category": "list_items", "title": title, "url": self.getFullUrl(url)})
+            params.update({"good_for_fav": True, "category": "list_items", "title": title, "url": url})
             self.addDir(params)
 
     def listSearchResult(self, cItem, searchPattern, searchType):
@@ -253,10 +358,9 @@ class HDFilme(CBaseHostClass):
 
     def getVideoLinks(self, videoUrl):
         printDBG("HDFilme.getVideoLinks [%s]" % videoUrl)
-        urlTab = []
         if self.cm.isValidUrl(videoUrl):
             return self.up.getVideoLinkExt(videoUrl)
-        return urlTab
+        return []
 
     def getArticleContent(self, cItem):
         printDBG("HDFilme.getArticleContent [%s]" % cItem)
@@ -267,10 +371,10 @@ class HDFilme(CBaseHostClass):
         desc = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, 'og:description" content="([^"]+)')[0]) or cItem.get("desc", "")
         actors = self.cm.ph.getAllItemsBeetwenMarkers(data, "Schauspieler:", "</li>")
         if actors:
-            names = re.findall('">([^<]+)', actors[0], re.DOTALL)
+            names = re.findall('>([^<]+)</a>', actors[0], re.DOTALL)
             if names:
                 otherInfo["actors"] = ", ".join(names)
-        released = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, r"<span>(\d{4})</span>")[0])
+        released = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, r'<span[^>]*>(\d{4})</span>')[0])
         if released:
             otherInfo["released"] = released
         duration = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, r"(\d+ min)")[0])
@@ -285,7 +389,7 @@ class HDFilme(CBaseHostClass):
         CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
         name = self.currItem.get("name", "")
         category = self.currItem.get("category", "")
-        printDBG("handleService: |||||||||||||||||||||||||||||||||||| name[%s], category[%s] " % (name, category))
+        printDBG("handleService: name[%s], category[%s]" % (name, category))
         self.currList = []
         if name is None:
             self.listsTab(self.MENU, {"name": "category"})
@@ -296,11 +400,7 @@ class HDFilme(CBaseHostClass):
         elif category == "list_episodes":
             self.listEpisodes(self.currItem)
         elif category == "list_genres":
-            self.listValue(self.currItem, "Genre")
-        elif category == "list_year":
-            self.listValue(self.currItem, "Jahres")
-        elif category == "list_country":
-            self.listValue(self.currItem, "Land")
+            self.listGenres(self.currItem)
         elif category in ["search", "search_next_page"]:
             cItem = dict(self.currItem)
             cItem.update({"search_item": False, "name": "category"})
@@ -308,7 +408,7 @@ class HDFilme(CBaseHostClass):
         elif category == "search_history":
             self.listsHistory({"name": "history", "category": "search"}, "desc")
         else:
-            printExc()
+            printDBG("HDFilme.handleService: unknown category [%s]" % category)
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
@@ -318,7 +418,7 @@ class IPTVHost(WatchedFlagHostMixin, CHostBase):
         CHostBase.__init__(self, HDFilme(), True, [])
         self.cachedRet = None
         self.refreshAfterWatchedFlagChange = False
-        self.watchedHelper = IPTVWatchedHelper("hdfilme")
+        self.watchedHelper = self.host.watchedHelper
 
     def _setWatchedStateForSeasonItem(self, seasonItem, action):
         try:
@@ -352,8 +452,7 @@ class IPTVHost(WatchedFlagHostMixin, CHostBase):
             changed = False
             if str(self.host.currItem.get("url", "") or "").strip() == url:
                 for seasonId in list(self.host.cacheSeasons):
-                    seasonItem = self.host._buildSeasonItem(seasonId)
-                    changed = self._setWatchedStateForSeasonItem(seasonItem, action) or changed
+                    changed = self._setWatchedStateForSeasonItem(self.host._buildSeasonItem(seasonId), action) or changed
             seriesKey = self.host._getWatchedKeyForItem(seriesItem)
             if seriesKey == "":
                 return changed
@@ -371,26 +470,15 @@ class IPTVHost(WatchedFlagHostMixin, CHostBase):
             if not isinstance(item, dict):
                 return
             category = str(item.get("category", "") or "").strip()
-            if category == "list_episodes":
-                seasonId = str(item.get("season_id", "") or "").strip()
-                url = str(item.get("url", "") or "").strip()
-                if seasonId != "" and url != "":
-                    seasonParent = dict(item)
-                    seasonParent.pop("isWatched", None)
-                    seasonEpisodes = self.host.cacheSeasons.get(seasonId, [])
-                    if seasonEpisodes:
-                        self.watchedHelper.updateParentWatchedState(seasonParent, seasonEpisodes, self.host._getWatchedKeyForItem)
-                    seriesParent = {"category": "list_seasons", "url": url}
-                    seasonChildren = [self.host._buildSeasonItem(sid) for sid in self.host.cacheSeasons]
-                    self.watchedHelper.updateParentWatchedState(seriesParent, seasonChildren, self.host._getWatchedKeyForItem)
+            itemType = str(item.get("type", "") or "").strip()
+            if category == "list_episodes" or itemType in ("video", "audio"):
+                self.host._propagateEpisodeWatchedState(item)
             elif category == "list_seasons":
                 url = str(item.get("url", "") or "").strip()
                 if url != "" and str(self.host.currItem.get("url", "") or "").strip() == url:
                     seriesParent = {"category": "list_seasons", "url": url}
                     seasonChildren = [self.host._buildSeasonItem(sid) for sid in self.host.cacheSeasons]
                     self.watchedHelper.updateParentWatchedState(seriesParent, seasonChildren, self.host._getWatchedKeyForItem)
-            elif str(item.get("type", "") or "").strip() in ["video", "audio"]:
-                self.host._propagateEpisodeWatchedState(item)
         except Exception:
             printExc()
 

--- a/IPTVPlayer/hosts/hostvidea.py
+++ b/IPTVPlayer/hosts/hostvidea.py
@@ -1,46 +1,26 @@
 # -*- coding: utf-8 -*-
 ###################################################
-# 2026-08-24 by WhiteWolf
+# 2026-08-27 - some fixes and cleanup - by WhiteWolf
 ###################################################
-HOST_VERSION = "1.5"
+HOST_VERSION = "1.6"
 ###################################################
 # LOCAL import
 ###################################################
-from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
-from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass, CDisplayListItem, RetHost, CUrlItem
-from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, GetLogoDir, MergeDicts
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
+from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, MergeDicts
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Playlist, getF4MLinksWithMeta, getMPDLinksWithMeta
 from Plugins.Extensions.IPTVPlayer.libs.urlparser import urlparser
-from Plugins.Extensions.IPTVPlayer.libs import ph
-
 ###################################################
 
 ###################################################
 # FOREIGN import
 ###################################################
-from Components.config import config, ConfigYesNo, ConfigDirectory, getConfigListEntry
-from os.path import normpath
-import os
+from Components.config import config, ConfigYesNo, getConfigListEntry
 import re
-import urllib.parse
 import random
-import datetime
-import time
-import zlib
-import base64
-import codecs
-import traceback
-
-try:
-    import subprocess
-
-    FOUND_SUB = True
-except Exception:
-    FOUND_SUB = False
-from Tools.Directories import resolveFilename, SCOPE_PLUGINS
-from Screens.MessageBox import MessageBox
-
+import urllib.parse
 ###################################################
 
 ###################################################
@@ -68,11 +48,10 @@ class videa(CBaseHostClass):
         CBaseHostClass.__init__(self, {"history": "videa", "cookie": "videa.cookie"})
         self.USER_AGENT = "User-Agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36"
         self.HEADER = self.cm.getDefaultHeader()
-        self.DEFAULT_ICON_URL = "https://www.figyelmeztetes.hu/videa_logo.jpg"
+        self.DEFAULT_ICON_URL = "https://videa.hu/static/uis/redesign/images/product-logos/videa-logo-footer.png"
         self.MAIN_URL = "https://videa.hu"
         self.vmkrs = self.MAIN_URL + "/kereses"
         self.aid = config.plugins.iptvplayer.videa_id.value
-        self.aid_ki = ""
         self.vszkzrs = []
         self.defaultParams = {"header": self.HEADER, "use_cookie": False, "load_cookie": False, "save_cookie": False, "cookiefile": self.COOKIE_FILE}
 
@@ -90,28 +69,19 @@ class videa(CBaseHostClass):
         def _getFullUrl(url):
             if self.cm.isValidUrl(url):
                 return url
-            else:
-                return urllib.parse.urljoin(baseUrl, url)
+            return urllib.parse.urljoin(baseUrl, url)
 
         addParams["cloudflare_params"] = {"domain": self.up.getDomain(baseUrl), "cookie_file": self.COOKIE_FILE, "User-Agent": self.USER_AGENT, "full_url_handle": _getFullUrl}
-        sts, data = self.cm.getPageCFProtection(baseUrl, addParams, post_data)
-        return sts, data
+        return self.cm.getPageCFProtection(baseUrl, addParams, post_data)
 
     def listMainMenu(self, cItem):
         try:
-            if not self.ebbtit():
-                return
             tab_kat = "videa_kategoriak"
             desc_kat = self.getdvdsz(tab_kat, "Videa kategóriáinak megjelenítése...")
             tab_csat = "videa_csatornak"
             desc_csat = self.getdvdsz(tab_csat, "Videa csatornáinak megjelenítése...")
             MAIN_CAT_TAB = [{"category": "list_main", "title": "Kategóriák", "tab_id": tab_kat, "desc": desc_kat}, {"category": "list_main", "title": "Csatornák", "tab_id": tab_csat, "desc": desc_csat}] + self.searchItems()
             self.listsTab(MAIN_CAT_TAB, {"name": "category"})
-            vtb = self.malvadnav(cItem, "7", "12", "0", "14")
-            if len(vtb) > 0:
-                for item in vtb:
-                    item["category"] = "list_third"
-                    self.addVideo(item)
         except Exception:
             return
 
@@ -123,148 +93,55 @@ class videa(CBaseHostClass):
                 self.Vdktgrk(cItem, tabID)
             elif tabID == "videa_csatornak":
                 self.Vdcstrnk(cItem, tabID)
-            elif tabID == "videa_ajanlott":
-                self.Vdajnzttt(cItem, tabID)
-            else:
-                return
+        except Exception:
+            return
+
+    def _listMainSection(self, cItem, tabID, items, descSuffix):
+        mlt = []
+        try:
+            for item in items:
+                url = self.cm.ph.getSearchGroups(item, "href=['\"]([^\"']+?)['\"]")[0]
+                if url.startswith("/"):
+                    url = self.MAIN_URL + url
+                if not self.cm.isValidUrl(url):
+                    continue
+                title = self.cm.ph.getSearchGroups(item, "text\"[>]([^\"']+?)[<]")[0].capitalize()
+                desc = self.getdvdsz(url, '"' + title + '" ' + descSuffix)
+                params = MergeDicts(cItem, {"good_for_fav": False, "category": "list_second", "title": title, "url": url, "icon": "", "desc": desc, "tab_id": tabID})
+                mlt.append(params)
+            if len(mlt) > 0:
+                random.shuffle(mlt)
+                for ipv in mlt:
+                    self.addDir(ipv)
         except Exception:
             return
 
     def Vdktgrk(self, cItem, tabID):
-        mlt = []
-        try:
-            url_ere = self.MAIN_URL
-            sts, data = self.getPage(url_ere)
-            if not sts:
-                return
-            if len(data) == 0:
-                return
-            data = data.split('class="category-item">')
-            if len(data) > 0:
-                del data[0]
-            if len(data) == 0:
-                return
-            for item in data:
-                url = self.cm.ph.getSearchGroups(item, "href=['\"]([^\"^']+?)['\"]")[0]
-                if url.startswith("/"):
-                    url = url_ere + url
-                if not self.cm.isValidUrl(url):
-                    continue
-                title = self.cm.ph.getSearchGroups(item, "text\"[>]([^\"^']+?)[<]")[0].capitalize()
-                desc = self.getdvdsz(url, '"' + title + '" kategória videóinak megjelenítése...')
-                icon = ""
-                params = MergeDicts(cItem, {"good_for_fav": False, "category": "list_second", "title": title, "url": url, "icon": icon, "desc": desc, "tab_id": tabID})
-                mlt.append(params)
-            if len(mlt) > 0:
-                random.shuffle(mlt)
-                for ipv in mlt:
-                    self.addDir(ipv)
-        except Exception:
+        sts, data = self.getPage(self.MAIN_URL)
+        if not sts or len(data) == 0:
             return
+        data = data.split('class="category-item">')
+        del data[0]
+        self._listMainSection(cItem, tabID, data, "kategória videóinak megjelenítése...")
 
     def Vdcstrnk(self, cItem, tabID):
-        mlt = []
-        try:
-            url_ere = self.MAIN_URL
-            sts, data = self.getPage(url_ere)
-            if not sts:
-                return
-            if len(data) == 0:
-                return
-            data = self.cm.ph.getDataBeetwenMarkers(data, 'title list-opener">', "</ul>")[1]
-            if len(data) == 0:
-                return
-            data = data.split("<li>")
-            if len(data) > 0:
-                del data[0]
-            if len(data) == 0:
-                return
-            for item in data:
-                url = self.cm.ph.getSearchGroups(item, "href=['\"]([^\"^']+?)['\"]")[0]
-                if url.startswith("/"):
-                    url = url_ere + url
-                if not self.cm.isValidUrl(url):
-                    continue
-                title = self.cm.ph.getSearchGroups(item, "text\"[>]([^\"^']+?)[<]")[0].capitalize()
-                desc = self.getdvdsz(url, '"' + title + '"  csatorna videóinak megjelenítése...')
-                icon = ""
-                params = MergeDicts(cItem, {"good_for_fav": False, "category": "list_second", "title": title, "url": url, "icon": icon, "desc": desc, "tab_id": tabID})
-                mlt.append(params)
-            if len(mlt) > 0:
-                random.shuffle(mlt)
-                for ipv in mlt:
-                    self.addDir(ipv)
-        except Exception:
+        sts, data = self.getPage(self.MAIN_URL)
+        if not sts or len(data) == 0:
             return
-
-    def Vdajnzttt(self, cItem, tabID):
-        try:
-            tab_ams = "videa_ajnlt_musor"
-            desc_ams = self.getdvdsz(tab_ams, "Ajánlott, nézett tartalmak megjelenítése műsorok szerint...")
-            tab_adt = "videa_ajnlt_datum"
-            desc_adt = self.getdvdsz(tab_adt, "Ajánlott, nézett tartalmak megjelenítése dátum szerint...")
-            tab_anzt = "videa_ajnlt_nezettseg"
-            desc_anzt = self.getdvdsz(tab_anzt, "Ajánlott, nézett tartalmak megjelenítése nézettség szerint...")
-            A_CAT_TAB = [{"category": "list_third", "title": "Dátum szerint", "tab_id": tab_adt, "desc": desc_adt}, {"category": "list_third", "title": "Műsorok szerint", "tab_id": tab_ams, "desc": desc_ams}, {"category": "list_third", "title": "Nézettség szerint", "tab_id": tab_anzt, "desc": desc_anzt}]
-            self.listsTab(A_CAT_TAB, cItem)
-        except Exception:
+        data = self.cm.ph.getDataBeetwenMarkers(data, 'title list-opener">', "</ul>")[1]
+        if len(data) == 0:
             return
+        data = data.split("<li>")
+        del data[0]
+        self._listMainSection(cItem, tabID, data, " csatorna videóinak megjelenítése...")
 
     def listSecondItems(self, cItem):
         try:
             tabID = cItem.get("tab_id", "")
-            if tabID == "videa_kategoriak":
+            if tabID in ("videa_kategoriak", "videa_csatornak"):
                 url = cItem["url"]
-                VK_CAT_TAB = [{"category": "list_items", "title": "Feltöltés ideje szerint", "url": url + "?page=1", "desc": ""}, {"category": "list_items", "title": "Nézettség szerint", "url": url + "?popular&page=1", "desc": ""}, {"category": "list_items", "title": "Legrégebbi elöl", "url": url + "?oldest&page=1", "desc": ""}]
-                self.listsTab(VK_CAT_TAB, cItem)
-            elif tabID == "videa_csatornak":
-                url = cItem["url"]
-                VCS_CAT_TAB = [{"category": "list_items", "title": "Feltöltés ideje szerint", "url": url + "?page=1", "desc": ""}, {"category": "list_items", "title": "Nézettség szerint", "url": url + "?popular&page=1", "desc": ""}, {"category": "list_items", "title": "Legrégebbi elöl", "url": url + "?oldest&page=1", "desc": ""}]
-                self.listsTab(VCS_CAT_TAB, cItem)
-            else:
-                return
-        except Exception:
-            return
-
-    def listThirdItems(self, cItem):
-        try:
-            tabID = cItem.get("tab_id", "")
-            if tabID == "videa_ajnlt_musor":
-                self.Vajnltmsr(cItem)
-            elif tabID == "videa_ajnlt_datum":
-                self.Vajnltdtm(cItem)
-            elif tabID == "videa_ajnlt_nezettseg":
-                self.Vajnltnztsg(cItem)
-            else:
-                return
-        except Exception:
-            return
-
-    def Vajnltmsr(self, cItem):
-        try:
-            vtb = self.malvadnav(cItem, "3", "12", "0")
-            if len(vtb) > 0:
-                for item in vtb:
-                    self.addVideo(item)
-        except Exception:
-            return
-
-    def Vajnltdtm(self, cItem):
-        vtb = []
-        try:
-            vtb = self.malvadnav(cItem, "4", "12", "0")
-            if len(vtb) > 0:
-                for item in vtb:
-                    self.addVideo(item)
-        except Exception:
-            return
-
-    def Vajnltnztsg(self, cItem):
-        try:
-            vtb = self.malvadnav(cItem, "5", "12", "0")
-            if len(vtb) > 0:
-                for item in vtb:
-                    self.addVideo(item)
+                CAT_TAB = [{"category": "list_items", "title": "Feltöltés ideje szerint", "url": url + "?page=1", "desc": ""}, {"category": "list_items", "title": "Nézettség szerint", "url": url + "?popular&page=1", "desc": ""}, {"category": "list_items", "title": "Legrégebbi elöl", "url": url + "?oldest&page=1", "desc": ""}]
+                self.listsTab(CAT_TAB, cItem)
         except Exception:
             return
 
@@ -273,56 +150,53 @@ class videa(CBaseHostClass):
             url_ere = cItem["url"]
             page = cItem.get("page", 1)
             searchMode = cItem.get("search_mode", False)
-            if not searchMode:
-                if page > 0 and "page=" in url_ere:
-                    idx1 = url_ere.rfind("page=")
-                    if -1 < idx1:
-                        url_ere = url_ere[:idx1].strip()
-                        url_ere = url_ere + "page=" + str(page)
+            channelMode = cItem.get("channel_mode", False)
+            if not searchMode and not channelMode and "/csatornak/" in url_ere:
+                channelMode = True
+            if channelMode:
+                url_ere = re.sub(r"[?&]page=\d+", "", url_ere)
+            elif not searchMode and page > 0 and "page=" in url_ere:
+                idx1 = url_ere.rfind("page=")
+                url_ere = url_ere[:idx1].strip() + "page=" + str(page)
             sts, data = self.getPage(url_ere)
-            if not sts:
-                return
-            if len(data) == 0:
+            if not sts or len(data) == 0:
                 return
             nextPage = False
-            if not searchMode:
-                nextPage = self.cm.ph.getSearchGroups(data, "next\"\\shref=['\"]([^\"^']+?)['\"]")[0]
-                if nextPage:
-                    nextPage = True
+            if not searchMode and not channelMode:
+                nextPage = bool(self.cm.ph.getSearchGroups(data, "next\"\\shref=['\"]([^\"']+?)['\"]")[0])
             data = data.split('class="col video-item">')
-            if len(data) > 0:
-                del data[0]
+            del data[0]
+            if channelMode:
+                data = data[:36]
             lastItemId = ""
             for item in data:
                 itemId = self.cm.ph.getSearchGroups(item, """data-item-id=['"]([^"']+?)['"]""")[0]
                 if itemId != "":
                     lastItemId = itemId
-                url = self.cm.ph.getSearchGroups(item, "<a\\shref=['\"]([^\"^']+?)['\"]\\sa")[0]
+                url = self.cm.ph.getSearchGroups(item, "<a\\shref=['\"]([^\"']+?)['\"]\\sa")[0]
                 if not self.cm.isValidUrl(url):
                     continue
-                icon = self.cm.ph.getSearchGroups(item, """data-image=['"]([^"^']+?)['"]""")[0]
+                icon = self.cm.ph.getSearchGroups(item, """data-image=['"]([^"']+?)['"]""")[0]
                 if icon == "":
                     icon = self.DEFAULT_ICON_URL
-                else:
-                    if icon.startswith("/"):
-                        icon = self.MAIN_URL + icon
-                vszrz = self.cm.ph.getSearchGroups(item, """aria-label=['"]([^"^']+?)['"].+\n.+href""")[0]
+                elif icon.startswith("/"):
+                    icon = self.MAIN_URL + icon
+                vszrz = self.cm.ph.getSearchGroups(item, """aria-label=['"]([^"']+?)['"].+\n.+href""")[0]
                 if not vszrz:
-                    vszrz = self.cm.ph.getSearchGroups(item, """uploader.{,50}[>]([^"^']+?)[<]/a""")[0]
+                    vszrz = self.cm.ph.getSearchGroups(item, """uploader.{,50}[>]([^"']+?)[<]/a""")[0]
                 if not vszrz:
-                    vszrz = self.cm.ph.getSearchGroups(item, """tagok[/]([^"^']+?)[-"]""")[0]
-                if len(self.vszkzrs) > 0:
-                    if self.check_string(vszrz, self.vszkzrs):
-                        continue
+                    vszrz = self.cm.ph.getSearchGroups(item, """tagok[/]([^"']+?)[-"]""")[0]
+                if self.vszkzrs and any(s in vszrz for s in self.vszkzrs):
+                    continue
                 vhz = self.cm.ph.getSearchGroups(item, """length"[>]([0-9:]+?)[<]""")[0]
                 vmsg = self.cm.ph.getDataBeetwenMarkers(item, 'div class="hd">', "</div>", False)[1]
                 if vmsg != "":
                     vmsg = "  |  " + vmsg
-                title = self.cm.ph.getSearchGroups(item, """aria-label=['"]([^"^']+?)['"].+\n.+div""")[0]
+                title = self.cm.ph.getSearchGroups(item, """aria-label=['"]([^"']+?)['"].+\n.+div""")[0]
                 if title == "":
                     continue
-                ftlv = self.cm.ph.getSearchGroups(item, """uploaded-at"[>]([^"^']+?)[<]""")[0]
-                desc = title + "\n" + "Időtartam: " + vhz + vmsg + "\nSzerző: " + vszrz + "\nFeltöltve: " + ftlv
+                ftlv = self.cm.ph.getSearchGroups(item, """uploaded-at"[>]([^"']+?)[<]""")[0]
+                desc = title + "\nIdőtartam: " + vhz + vmsg + "\nSzerző: " + vszrz + "\nFeltöltve: " + ftlv
                 params = MergeDicts(cItem, {"good_for_fav": False, "title": title, "url": url, "icon": icon, "desc": desc, "tps": "0"})
                 self.addVideo(params)
             if searchMode:
@@ -331,6 +205,17 @@ class videa(CBaseHostClass):
                     lazyUrl = self.MAIN_URL + "/lazy/kereses/" + urllib.parse.quote_plus(searchPattern) + "?cacheId=" + urllib.parse.quote_plus(searchPattern) + "&lastItemId=" + urllib.parse.quote_plus(lastItemId) + "&itemCount=432&sort=0"
                     params = dict(cItem)
                     params.update({"title": _("Next page"), "url": lazyUrl, "category": "list_items", "search_mode": True, "desc": "Nyugi...\nVan még további tartalom, lapozz tovább!"})
+                    self.addDir(params)
+            elif channelMode:
+                if lastItemId != "":
+                    itemCount = self.cm.ph.getSearchGroups(url_ere, "itemCount=([0-9]+)")[0]
+                    count = (int(itemCount) if itemCount else 0) + len(data)
+                    channelUrl = url_ere.split("?")[0]
+                    if "/lazy/csatornak/" not in channelUrl:
+                        channelUrl = channelUrl.replace("/csatornak/", "/lazy/csatornak/")
+                    lazyUrl = "%s?cacheId=&lastItemId=%s&itemCount=%s&sort=0" % (channelUrl, urllib.parse.quote_plus(lastItemId), count)
+                    params = dict(cItem)
+                    params.update({"title": _("Next page"), "url": lazyUrl, "category": "list_items", "channel_mode": True, "desc": "Nyugi...\nVan még további tartalom, lapozz tovább!"})
                     self.addDir(params)
             elif nextPage:
                 params = dict(cItem)
@@ -351,175 +236,61 @@ class videa(CBaseHostClass):
         url = url.replace("/v/", "?v=").replace("?autoplay=1", "&autoplay=0")
         uri = urlparser.decorateParamsFromUrl(url)
         protocol = uri.meta.get("iptv_proto", "")
-
-        printDBG("PROTOCOL [%s] " % protocol)
-
+        printDBG("Videa: protocol [%s]" % protocol)
         urlSupport = self.up.checkHostSupport(uri)
         if 1 == urlSupport:
-            retTab = self.up.getVideoLinkExt(uri)
-            videoUrls.extend(retTab)
+            videoUrls.extend(self.up.getVideoLinkExt(uri))
         elif 0 == urlSupport and self._uriIsValid(uri):
             if protocol == "m3u8":
-                retTab = getDirectM3U8Playlist(uri, checkExt=False, checkContent=True)
-                videoUrls.extend(retTab)
+                videoUrls.extend(getDirectM3U8Playlist(uri, checkExt=False, checkContent=True))
             elif protocol == "f4m":
-                retTab = getF4MLinksWithMeta(uri)
-                videoUrls.extend(retTab)
+                videoUrls.extend(getF4MLinksWithMeta(uri))
             elif protocol == "mpd":
-                retTab = getMPDLinksWithMeta(uri, False)
-                videoUrls.extend(retTab)
+                videoUrls.extend(getMPDLinksWithMeta(uri, False))
             else:
                 videoUrls.append({"name": "direct link", "url": uri})
         return videoUrls
 
-    def cpve(self, cfpv=""):
-        vissza = False
-        try:
-            if cfpv != "":
-                mk = cfpv
-                if mk != "":
-                    vissza = True
-        except Exception:
-            return False
-        return vissza
-
-    def check_string(self, string, substring_list):
-        for substring in substring_list:
-            if substring in string:
-                return True
-        return False
-
     def getdvdsz(self, pu="", psz=""):
-        bv = ""
-        if pu != "" and psz != "":
+        if pu == "" or psz == "":
+            return ""
+        header = "Videa  v" + HOST_VERSION + "\n" if pu == "videa_kategoriak" else ""
+        if self.aid:
             n_atnav = self.malvadst("1", "12", pu)
-            if n_atnav != "" and self.aid:
+            if n_atnav != "":
                 if pu == "videa_kategoriak":
-                    self.aid_ki = "ID: " + n_atnav + "  |  Videa  v" + HOST_VERSION + "\n"
+                    header = "ID: " + n_atnav + "  |  Videa  v" + HOST_VERSION + "\n"
                 else:
-                    self.aid_ki = "ID: " + n_atnav + "\n"
-            else:
-                if pu == "videa_kategoriak":
-                    self.aid_ki = "Videa  v" + HOST_VERSION + "\n"
-                else:
-                    self.aid_ki = ""
-            bv = self.aid_ki + psz
-        return bv
+                    header = "ID: " + n_atnav + "\n"
+        return header + psz
 
     def malvadst(self, i_md="", i_hgk="", i_mpu=""):
-        uhe = zlib.decompress(base64.b64decode("eJzLKCkpsNLXLy8v10vLTK9MzclNrSpJLUkt1sso1c9IzanUL04sSdQvS8wD0ilJegUZBQD8FROZ")).decode("utf-8")
-        pstd = {"md": i_md, "hgk": i_hgk, "mpu": i_mpu}
-        t_s = ""
-        temp_vn = ""
-        temp_vni = ""
+        uhe = "http://www.figyelmeztetes.hu/hely/sata/vansatdb.php"
         try:
-            if i_md != "" and i_hgk != "" and i_mpu != "":
-                sts, data = self.cm.getPage(uhe, self.defaultParams, pstd)
-                if not sts:
-                    return t_s
-                if len(data) == 0:
-                    return t_s
-                data = self.cm.ph.getDataBeetwenMarkers(data, '<div id="div_a_div', "</div>")[1]
-                if len(data) == 0:
-                    return t_s
-                data = self.cm.ph.getAllItemsBeetwenMarkers(data, "<input", "/>")
-                if len(data) == 0:
-                    return t_s
-                for item in data:
-                    t_i = self.cm.ph.getSearchGroups(item, "id=['\"]([^\"^']+?)['\"]")[0]
-                    if t_i == "vn":
-                        temp_vn = self.cm.ph.getSearchGroups(item, "value=['\"]([^\"^']+?)['\"]")[0]
-                    elif t_i == "vni":
-                        temp_vni = self.cm.ph.getSearchGroups(item, "value=['\"]([^\"^']+?)['\"]")[0]
-                if temp_vn != "":
-                    t_s = temp_vn
-            return t_s
+            if i_md == "" or i_hgk == "" or i_mpu == "":
+                return ""
+            sts, data = self.cm.getPage(uhe, self.defaultParams, {"md": i_md, "hgk": i_hgk, "mpu": i_mpu})
+            if not sts or len(data) == 0:
+                return ""
+            data = self.cm.ph.getDataBeetwenMarkers(data, '<div id="div_a_div', "</div>")[1]
+            if len(data) == 0:
+                return ""
+            for item in self.cm.ph.getAllItemsBeetwenMarkers(data, "<input", "/>"):
+                if self.cm.ph.getSearchGroups(item, "id=['\"]([^\"']+?)['\"]")[0] == "vn":
+                    return self.cm.ph.getSearchGroups(item, "value=['\"]([^\"']+?)['\"]")[0]
+            return ""
         except Exception:
-            return t_s
-
-    def malvadnav(self, cItem, i_md="", i_hgk="", i_mptip="", i_mpdb=""):
-        uhe = zlib.decompress(base64.b64decode("eJzLKCkpsNLXLy8v10vLTK9MzclNrSpJLUkt1sso1c9IzanUzy0tSQQTxYklKUl6BRkFABGoFBk=")).decode("utf-8")
-        t_s = []
-        try:
-            if i_md != "" and i_hgk != "" and i_mptip != "":
-                if i_hgk != "":
-                    i_hgk = base64.b64encode(i_hgk).replace("\n", "").strip()
-                if i_mptip != "":
-                    i_mptip = base64.b64encode(i_mptip).replace("\n", "").strip()
-                if i_mpdb != "":
-                    i_mpdb = base64.b64encode(i_mpdb).replace("\n", "").strip()
-                pstd = {"md": i_md, "hgk": i_hgk, "mptip": i_mptip, "mpdb": i_mpdb}
-                sts, data = self.cm.getPage(uhe, self.defaultParams, pstd)
-                if not sts:
-                    return t_s
-                if len(data) == 0:
-                    return t_s
-                data = self.cm.ph.getDataBeetwenMarkers(data, '<div id="div_a1_div"', '<div id="div_a2_div"')[1]
-                if len(data) == 0:
-                    return t_s
-                data = self.cm.ph.getAllItemsBeetwenMarkers(data, '<div class="d_sor_d"', "</div>")
-                if len(data) == 0:
-                    return t_s
-                for temp_item in data:
-                    temp_data = self.cm.ph.getAllItemsBeetwenMarkers(temp_item, "<span", "</span>")
-                    if len(temp_data) == 0:
-                        return t_s
-                    for item in temp_data:
-                        t_vp = self.cm.ph.getSearchGroups(item, "class=['\"]([^\"^']+?)['\"]")[0]
-                        if t_vp == "c_sor_u":
-                            temp_u = self.cm.ph.getDataBeetwenMarkers(item, '<span class="c_sor_u">', "</span>", False)[1]
-                            if temp_u != "":
-                                temp_u = base64.b64decode(temp_u)
-                        if t_vp == "c_sor_t":
-                            temp_t = self.cm.ph.getDataBeetwenMarkers(item, '<span class="c_sor_t">', "</span>", False)[1]
-                            if temp_t != "":
-                                temp_t = base64.b64decode(temp_t)
-                        if t_vp == "c_sor_i":
-                            temp_i = self.cm.ph.getDataBeetwenMarkers(item, '<span class="c_sor_i">', "</span>", False)[1]
-                            if temp_i != "":
-                                temp_i = base64.b64decode(temp_i)
-                        if t_vp == "c_sor_l":
-                            temp_l = self.cm.ph.getDataBeetwenMarkers(item, '<span class="c_sor_l">', "</span>", False)[1]
-                            if temp_l != "":
-                                temp_l = base64.b64decode(temp_l)
-                        if t_vp == "c_sor_n":
-                            temp_n = self.cm.ph.getDataBeetwenMarkers(item, '<span class="c_sor_n">', "</span>", False)[1]
-                            if temp_n != "":
-                                temp_n = base64.b64decode(temp_n)
-                        if t_vp == "c_sor_tip":
-                            temp_tp = self.cm.ph.getDataBeetwenMarkers(item, '<span class="c_sor_tip">', "</span>", False)[1]
-                            if temp_tp != "":
-                                temp_tp = base64.b64decode(temp_tp)
-                    if temp_u == "" and temp_t == "":
-                        continue
-                    if temp_n == "":
-                        temp_n = "1"
-                    params = MergeDicts(cItem, {"good_for_fav": False, "url": temp_u, "title": temp_t, "icon": temp_i, "desc": temp_l, "nztsg": temp_n, "tps": temp_tp})
-                    t_s.append(params)
-            return t_s
-        except Exception:
-            return []
+            return ""
 
     def malvadkiszrz(self):
-        bv = []
-        ukszrz = zlib.decompress(base64.b64decode("eJzLKCkpsNLXLy8v10vLTK9MzclNrSpJLUkt1sso1c9IzanUzy0tSQQTxYklKUnZmXoFGQUAO30U7Q==")).decode("utf-8")
+        ukszrz = "http://www.figyelmeztetes.hu/hely/muta/mutasatdbki.php"
         try:
             sts, data = self.cm.getPage(ukszrz)
-            if not sts:
+            if not sts or len(data) == 0:
                 return []
-            if len(data) == 0:
-                return []
-            data = self.cm.ph.getAllItemsBeetwenMarkers(data, "<div>", "</div>", False)
-            if len(data) == 0:
-                return []
-            for item in data:
-                bv.append(item)
-            return bv
+            return self.cm.ph.getAllItemsBeetwenMarkers(data, "<div>", "</div>", False)
         except Exception:
             return []
-
-    def ebbtit(self):
-        return True
 
     def listSearchResult(self, cItem, searchPattern, searchType):
         try:
@@ -528,8 +299,9 @@ class videa(CBaseHostClass):
             cItem["search_pattern"] = searchPattern
             cItem["search_mode"] = True
             self.listItems(cItem)
-        except Exception:
-            return
+        except Exception as e:
+            printDBG("Videa search ERROR: listSearchResult [%s]" % str(e))
+            printExc()
 
     def handleService(self, index, refresh=0, searchPattern="", searchType=""):
         try:
@@ -543,11 +315,9 @@ class videa(CBaseHostClass):
                 self.listMainItems(self.currItem)
             elif category == "list_second":
                 self.listSecondItems(self.currItem)
-            elif category == "list_third":
-                self.listThirdItems(self.currItem)
             elif category == "list_items":
                 self.listItems(self.currItem)
-            elif category in ["search", "search_next_page"]:
+            elif category in ("search", "search_next_page"):
                 cItem = dict(self.currItem)
                 cItem.update({"search_item": False, "name": "category"})
                 self.listSearchResult(cItem, searchPattern, searchType)

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -2102,13 +2102,29 @@ class pageParser(CaptchaHelper):
             key = result[16:] + _s + self.cm.meta.get("x-videa-xs", "")
             videaXml = rc4(videaXml, key)
         urltab = []
-        source = re.findall(r'video_source\s*name="([^"]+).*?exp="([^"]+)">([^<]+)', videaXml)
-        if source:
-            for label, exp, url in source:
+        for block in re.findall(r"<video_source\b[^>]*>[^<]*</video_source>", videaXml):
+            label = self.cm.ph.getSearchGroups(block, r'name="([^"]+)"')[0]
+            exp = self.cm.ph.getSearchGroups(block, r'exp="([^"]*)"')[0]
+            url = self.cm.ph.getDataBeetwenMarkers(block, ">", "</video_source>", False)[1].replace("&amp;", "&")
+            if not url:
+                continue
+            url = "https:" + url if url.startswith("//") else url
+            if "md5=" not in url:
+                hsh = re.search(r"<hash_value_%s>([^<]+)<" % re.escape(label), videaXml)
+                if not hsh:
+                    continue
+                if not exp:
+                    exp = self.cm.ph.getSearchGroups(url, r"expires=([0-9]+)")[0]
+                url = "%s?md5=%s&expires=%s" % (url, hsh.group(1), exp)
+            urltab.append({"name": label, "url": url})
+        urltab.reverse()
+        if not urltab:
+            for block in re.findall(r"<audio_source\b[^>]*>[^<]*</audio_source>", videaXml):
+                url = self.cm.ph.getDataBeetwenMarkers(block, ">", "</audio_source>", False)[1].replace("&amp;", "&")
+                if not url:
+                    continue
                 url = "https:" + url if url.startswith("//") else url
-                url = "%s?md5=%s&expires=%s" % (url, re.search(r"<hash_value_%s>([^<]+)<" % label, videaXml).group(1), exp)
-                urltab.append({"name": label, "url": url})
-            urltab.reverse()
+                urltab.append({"name": "Audio", "url": url})
         return urltab
 
     def parserSTREAMUP(self, baseUrl):  # fix 300426

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.08.25.01"
+IPTV_VERSION = "2026.08.27.01"


### PR DESCRIPTION
### Videa — VERSION 1.5 → 1.6

#### Link resolving (`urlparser.parserVIDEA`)
- **Audio-only fallback** — when a Videa page exposes no `<video_source>`, `<audio_source>` entries are parsed and returned instead of an empty list.
- **`md5=` already in the URL** — such source URLs are used as-is instead of rebuilding the hash query.
- **`expires=` fallback** — read from the URL when the source has no `exp="…"` attribute.
- **Missing `<hash_value_*>`** — that single source is skipped instead of raising and dropping *all* sources.
- `&amp;` in source URLs is unescaped.

#### Navigation (`hostvidea`)
- **Channel pagination** — `/csatornak/` listings now page through the `/lazy/csatornak/…` endpoint using `lastItemId` / `itemCount`; channels previously had no "next page" at all.
- Fixed a malformed `…?popular?cacheId=…` URL on the "most viewed" / "oldest" channel sort modes (`channelUrl` is now `url.split("?")[0]`).
- `itemCount` offset is derived from the actual batch size (capped at 36) rather than a hard-coded `+36`, which drifted when a batch returned a different count.

### HDFilme

#### Adopted the local refactor
- New season/episode-label helpers `_extractNum` / `_formatSxxExx` / `_parseLeadingSxEx` / `_stripLeadingSeasonEpisodeNumbers`; episode building split into `_buildEpisodesForSeason`.
- Tighter scraping regexes (`<span[^>]*>`, `href="…"[^>]*>`, `>([^<]+)</a>`).

#### Site redesign (Tailwind / Alpine)
- **Genres restored** — the old `>Genre<` … `</div>` slice only captured the menu trigger's SVG icon, never the links. It now parses the `dropdown-content` block after the label and links to the real `/<genre>/` category pages (they filter correctly and paginate). `listValue` → `listGenres`.