### PR TITLE
ARTE split-A/V downloads + general FFMPEGDownloader hardening

### DIFF
--- a/IPTVPlayer/hosts/hostartetv.py
+++ b/IPTVPlayer/hosts/hostartetv.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # ARTE
 # Rewritten for the api-cdn.arte.tv "emac v4" JSON API + player v2 config
-# Last Modified: 28.08.2026
+# Last Modified: 31.08.2026 - split audio/video HLS renditions (merge://) are muxed
+# with ffmpeg (iptv_use_ffmpeg, matroska container) instead of hlsdl, which only
+# re-packages segments and produced unplayable files.
 ###################################################
 # LOCAL import
 ###################################################
@@ -363,6 +365,7 @@ class ArteTV(CBaseHostClass):
                     # ffmpeg instead (both for buffered playback and for downloads).
                     if strwithmeta(it['url']).meta.get('audio_url'):
                         extraMeta['iptv_use_ffmpeg'] = True
+                        extraMeta['ff_out_container'] = 'matroska'
                     it['url'] = self.up.decorateUrl(it['url'], extraMeta)
                     it['need_resolve'] = 0
                     urlTab.append(it)

--- a/IPTVPlayer/iptvdm/ffmpegdownloader.py
+++ b/IPTVPlayer/iptvdm/ffmpegdownloader.py
@@ -4,12 +4,32 @@
 #
 #  $Id$
 #
+#  Last Modified: 31.08.2026
+#   - _getDownloadSpeed()/_getDuration()/_getStartTime() null-guard their regex
+#     matches (ffmpeg emits "N/A" progress fields that used to raise -> printExc
+#     spam on nearly every line).
+#   - _checkWorkingCallBack() always clears self.iptv_sys.
+#   - _terminate() resolves the download even when self.console is already gone.
+#   - _cmdFinished() honours ffmpeg's exit code and uses a completeness tolerance
+#     (>=97% of the known duration) so segment rounding no longer marks a finished
+#     download INTERRUPTED.
+#   - updateStatistic() cross-checks the real on-disk file size so size/percent
+#     never stalls at 0 when ffmpeg's own "size=" line is missing/lagging.
+#   - HTTP inputs get -reconnect_streamed / -reconnect_delay_max / -rw_timeout so a
+#     dropped or stalled connection recovers or fails instead of hanging.
+#   - merge:// inputs are stream-mapped explicitly (audio_url -> :a, video_url ->
+#     :v) so a stray track in one playlist can't shadow the intended stream.
+#   - _fixFileExtension(): rename the output to the container ffmpeg actually
+#     wrote (-f matroska -> .mkv etc.) instead of leaving it under the .mp4 name
+#     the DM requested; the DM re-reads the path via getFullFileName().
+#   Applies to every FFMPEGDownloader user (DASH, iptv_use_ffmpeg, kinoger, all
+#   merge:// hosts), not only Arte.
 #
 ###################################################
 # LOCAL import
 ###################################################
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, iptv_system, eConnectCallback, rm, WriteTextFile, GetNice, getDebugMode
-from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import enum, strwithmeta
+from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.iptvdm.basedownloader import BaseDownloader
 from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdh import DMHelper
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
@@ -20,7 +40,6 @@ from Plugins.Extensions.IPTVPlayer.p2p3.manipulateStrings import strDecode
 ###################################################
 from Tools.BoundFunction import boundFunction
 from enigma import eConsoleAppContainer
-from time import sleep
 import re
 import datetime
 ###################################################
@@ -32,6 +51,22 @@ import datetime
 
 
 class FFMPEGDownloader(BaseDownloader):
+
+    # a download counts as complete once this fraction of the known duration is
+    # reached - ffmpeg's segment-summed duration and its final time= often differ
+    # by a segment, so an exact match must not be required
+    DURATION_COMPLETE_RATIO = 0.97
+
+    # extra input options for HTTP(S) sources: recover from dropped connections
+    # and give up on a stalled socket instead of hanging forever (rw_timeout is in
+    # microseconds)
+    HTTP_INPUT_OPTS = ('-reconnect', '1', '-reconnect_streamed', '1',
+                       '-reconnect_delay_max', '30', '-rw_timeout', '60000000')
+
+    # -f <container> -> the extension the finished file should actually carry
+    CONTAINER_EXT = {'matroska': '.mkv', 'webm': '.webm', 'mpegts': '.ts',
+                     'mp4': '.mp4', 'mov': '.mp4', 'flv': '.flv'}
+    KNOWN_EXT = ('.mp4', '.mkv', '.ts', '.webm', '.mov', '.flv', '.avi', '.m4v')
 
     def __init__(self):
         printDBG('FFMPEGDownloader.__init__ ----------------------------------')
@@ -53,6 +88,10 @@ class FFMPEGDownloader(BaseDownloader):
 
         self.ffmpegOutputContener = 'matroska'
         self.fileCmdPath = ''
+        # the DM download path sets this so the finished file may be renamed to
+        # its real container extension; stays False for buffered playback, where
+        # the player already holds the file open under the requested name
+        self.allowFinalRename = False
 
     def __del__(self):
         printDBG("FFMPEGDownloader.__del__ ----------------------------------")
@@ -75,7 +114,7 @@ class FFMPEGDownloader(BaseDownloader):
                 reason = _('Utility "%s" can not be found.') % ffmpegBinaryName
             else:
                 reason = data
-            self.iptv_sys = None
+        self.iptv_sys = None
         callBackFun(sts, reason)
 
     def start(self, url, filePath, params={}):
@@ -124,25 +163,38 @@ class FFMPEGDownloader(BaseDownloader):
             if len(headers):
                 cmdTab.extend(['-headers', '\r\n'.join(headers) + '\r\n'])
 
+        mapOpts = []
         if self.url.startswith("merge://"):
             try:
                 urlsKeys = self.url.split('merge://', 1)[1].split('|')
-                for item in urlsKeys:
+                for idx, item in enumerate(urlsKeys):
                     oneUrl = tmpUri.meta[item]
                     oneMeta = dict(tmpUri.meta)
                     _addHttpOpts(cmdTab, oneMeta)
-                    cmdTab.extend(['-reconnect', '1', '-i', oneUrl])
+                    if str(oneUrl).lower().startswith(('http://', 'https://')):
+                        cmdTab.extend(self.HTTP_INPUT_OPTS)
+                    cmdTab.extend(['-i', oneUrl])
+                    if 'audio' in item:
+                        mapOpts += ['-map', '%d:a' % idx]
+                    elif 'video' in item:
+                        mapOpts += ['-map', '%d:v' % idx]
+                    else:
+                        mapOpts += ['-map', str(idx)]
             except Exception:
                 printExc()
+                mapOpts = []
         else:
             if "://" in self.url:
                 url, httpParams = DMHelper.getDownloaderParamFromUrlWithMeta(tmpUri, True)
                 _addHttpOpts(cmdTab, httpParams)
+                if self.url.lower().startswith(('http://', 'https://')):
+                    cmdTab.extend(self.HTTP_INPUT_OPTS)
             else:
                 url = self.url
-            cmdTab.extend(['-reconnect', '1', '-i', url])
+            cmdTab.extend(['-i', url])
 
-        cmdTab.extend(['-c:v', 'copy', '-c:a', 'copy', '-f', tmpUri.meta.get('ff_out_container', self.ffmpegOutputContener), self.filePath])
+        cmdTab.extend(mapOpts)
+        cmdTab.extend(['-c:v', 'copy', '-c:a', 'copy', '-f', self._outContainer(), self.filePath])
 
         self.fileCmdPath = self.filePath + '.iptv.cmd'
         rm(self.fileCmdPath)
@@ -165,7 +217,8 @@ class FFMPEGDownloader(BaseDownloader):
     def _getDuration(self, data):
         try:
             obj = self.parseReObj['duration'].search(data)
-            return 3600 * int(obj.group(1)) + 60 * int(obj.group(2)) + int(obj.group(3))
+            if obj:
+                return 3600 * int(obj.group(1)) + 60 * int(obj.group(2)) + int(obj.group(3))
         except Exception:
             printExc()
         return 0
@@ -173,7 +226,8 @@ class FFMPEGDownloader(BaseDownloader):
     def _getStartTime(self, data):
         try:
             obj = self.parseReObj['start_time'].search(data)
-            return int(obj.group(1))
+            if obj:
+                return int(obj.group(1))
         except Exception:
             printExc()
         return 0
@@ -189,7 +243,11 @@ class FFMPEGDownloader(BaseDownloader):
 
     def _getDownloadSpeed(self, data):
         try:
-            return int(float(self.parseReObj['bitrate'].search(data).group(1)) * float(self.parseReObj['speed'].search(data).group(1)) * 1024 / 8)
+            bitrateObj = self.parseReObj['bitrate'].search(data)
+            speedObj = self.parseReObj['speed'].search(data)
+            if bitrateObj is None or speedObj is None:
+                return 0
+            return int(float(bitrateObj.group(1)) * float(speedObj.group(1)) * 1024 / 8)
         except Exception:
             printExc()
         return 0
@@ -199,14 +257,11 @@ class FFMPEGDownloader(BaseDownloader):
             return
 
         data = self.outData + strDecode(data).replace('\n', '\r')
-#        data = self.outData + data.decode(encoding='utf-8', errors='strict').replace('\n', '\r')
 
+        # ffmpeg separates progress updates with a bare CR; the text after the last
+        # CR is always the still-incomplete chunk - hold it for the next call
         data = data.split('\r')
-        if data[-1].endswith('\r'):
-            self.outData = ''  # data not truncated
-        else:  # data truncated
-            self.outData = data[-1]
-            del data[-1]
+        self.outData = data.pop()
 
         for item in data:
             # printDBG("---")
@@ -230,12 +285,13 @@ class FFMPEGDownloader(BaseDownloader):
                 if fileSize > self.localFileSize:
                     self.localFileSize = fileSize
 
-                    # update duration only when file size changed
-                    # to make sure that this duration is ready to
-                    # for reading
-                    duration = self._getDuration(item)
-                    if duration > self.downloadDuration:
-                        self.downloadDuration = duration
+                # downloaded duration is a plain progress counter - keep it
+                # advancing from every progress line, not only when the parsed
+                # size grows (updateStatistic() now also bumps localFileSize from
+                # disk, which would otherwise freeze this)
+                duration = self._getDuration(item)
+                if duration > self.downloadDuration:
+                    self.downloadDuration = duration
 
     def _terminate(self):
         printDBG("FFMPEGDownloader._terminate")
@@ -246,8 +302,8 @@ class FFMPEGDownloader(BaseDownloader):
             if self.console:
                 # self.console.sendCtrlC()
                 self.console.sendCtrlC()  # kill # produce zombies
-                self._cmdFinished(-1, True)
-                return BaseDownloader.CODE_OK
+            self._cmdFinished(-1, True)
+            return BaseDownloader.CODE_OK
         return BaseDownloader.CODE_NOT_DOWNLOADING
 
     def _cmdFinished(self, code, terminated=False):
@@ -262,21 +318,83 @@ class FFMPEGDownloader(BaseDownloader):
             self.console_stderrAvail_conn = None
             self.console = None
 
+        self._refreshLocalFileSize()
+
         if terminated:
             self.status = DMHelper.STS.INTERRUPTED
         elif 0 >= self.localFileSize:
             self.status = DMHelper.STS.ERROR
-        elif self.totalDuration > 0 and self.totalDuration > self.downloadDuration:
-            self.status = DMHelper.STS.INTERRUPTED
+        elif not self._looksComplete():
+            # short file: a clean ffmpeg exit here is odd, a non-zero one is a real
+            # failure - either way it is not a finished download
+            self.status = DMHelper.STS.INTERRUPTED if code in (0, None) else DMHelper.STS.ERROR
         else:
+            # whole timeline present -> keep it even if ffmpeg exited non-zero on a
+            # trailing segment glitch (common with -c copy of HLS)
             self.status = DMHelper.STS.DOWNLOADED
+
         if not terminated:
+            # ffmpeg has stopped writing -> name the file after its real container,
+            # even for a partial (an incomplete .mkv is still an .mkv)
+            self._fixFileExtension()
             self.onFinish()
+
+    def _outContainer(self):
+        # the container passed to ffmpeg's -f; it also drives the final file
+        # extension (_fixFileExtension), so both must read it the same way
+        return str(strwithmeta(self.url).meta.get('ff_out_container', self.ffmpegOutputContener)).lower()
+
+    def _looksComplete(self):
+        # unknown duration (livestream / no header) -> nothing to compare against
+        if self.totalDuration <= 0:
+            return True
+        return self.downloadDuration >= self.totalDuration * self.DURATION_COMPLETE_RATIO
+
+    def _fixFileExtension(self):
+        # ffmpeg writes the container chosen by -f, which need not match the name
+        # the DM requested (host asks for .mp4, we mux Matroska). Rename the
+        # output to the real extension so players that trust the suffix (gstplayer,
+        # DLNA, file managers) don't choke. The DM re-reads the path via
+        # getFullFileName() after the download.
+        try:
+            if not self.allowFinalRename:
+                return
+            if DMHelper.getFileSize(self.filePath) <= 0:
+                return
+            wantExt = self.CONTAINER_EXT.get(self._outContainer())
+            if not wantExt:
+                return
+            low = str(self.filePath).lower()
+            curExt = ''
+            for ext in self.KNOWN_EXT:
+                if low.endswith(ext):
+                    curExt = ext
+                    break
+            if curExt == wantExt:
+                return
+            base = self.filePath[:-len(curExt)] if curExt else self.filePath
+            newPath = DMHelper.makeUnikalFileName(base + wantExt, False, False)
+            bRet, msg = self.moveFullFileName(newPath)
+            if bRet:
+                self.fileExtension = wantExt
+                printDBG("FFMPEGDownloader renamed output to match container -> %s" % self.filePath)
+            else:
+                printDBG("FFMPEGDownloader could not rename output: %s" % msg)
+        except Exception:
+            printExc()
+
+    def _refreshLocalFileSize(self):
+        # ffmpeg's own "size=" progress line can be missing or lag behind; the file
+        # on disk is the ground truth (getFileSize returns -1 on a missing file)
+        diskSize = DMHelper.getFileSize(self.filePath)
+        if diskSize > self.localFileSize:
+            self.localFileSize = diskSize
 
     def isLiveStream(self):
         return self.liveStream
 
     def updateStatistic(self):
+        self._refreshLocalFileSize()
         if self.lastUpadateTime is not None:
             d = datetime.datetime.now() - self.lastUpadateTime
             if d.seconds > 3:

--- a/IPTVPlayer/iptvdm/iptvdmapi.py
+++ b/IPTVPlayer/iptvdm/iptvdmapi.py
@@ -302,6 +302,12 @@ class IPTVDMApi():
 
         url, downloaderParams = DMHelper.getDownloaderParamFromUrl(item.url)
         self.queueUD[listUDIdx].downloader = DownloaderCreator(url)
+        # this is a real download (not buffered playback) -> the downloader may
+        # rename the finished file to its true container extension
+        try:
+            self.queueUD[listUDIdx].downloader.allowFinalRename = True
+        except Exception:
+            printExc()
         self.queueUD[listUDIdx].callback = boundFunction(self.cmdFinished, item.downloadIdx)
         self.queueUD[listUDIdx].downloader.subscribeFor_Finish(self.queueUD[listUDIdx].callback)
         self.queueUD[listUDIdx].downloader.start(url, item.fileName, downloaderParams)
@@ -314,6 +320,20 @@ class IPTVDMApi():
         # listUDIdx must be > -1
         if -1 >= listUDIdx:
             return
+
+        # a downloader may have renamed the finished file (e.g. FFMPEGDownloader
+        # fixing .mp4 -> .mkv to match the real container); pick up the real path
+        # so notify / archive / delete all use it. No-op for downloaders that
+        # never change it.
+        try:
+            dl = self.queueUD[listUDIdx].downloader
+            if dl is not None:
+                realPath = dl.getFullFileName()
+                if realPath and realPath != self.queueUD[listUDIdx].fileName:
+                    printDBG("cmdFinished: downloader renamed file -> %s" % realPath)
+                    self.queueUD[listUDIdx].fileName = realPath
+        except Exception:
+            printExc()
 
         self.updateDownloadedItemStatus(listUDIdx)
         self.queueUD[listUDIdx].processed = True
@@ -412,7 +432,11 @@ class IPTVDMApi():
         if downloadItem.fileSize > 0 and downloadItem.downloadedSize > 0:
             downloadItem.downloadedProcent = int((100 * downloadItem.downloadedSize) / downloadItem.fileSize)
         elif downloadItem.totalFileDuration > 0 and downloadItem.downloadedFileDuration > 0:
-            downloadItem.downloadedProcent = int((100 * downloadItem.downloadedFileDuration) / downloadItem.totalFileDuration)
+            # round, don't truncate: ffmpeg's decoded end time often lands a hair
+            # below the summed playlist duration on a complete file, and int()
+            # would leave it at 99 -> the DM would flag a finished download as
+            # INTERRUPTED
+            downloadItem.downloadedProcent = int(round((100.0 * downloadItem.downloadedFileDuration) / downloadItem.totalFileDuration))
         return True
 
     def updateDownloadItemsStatus(self):

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.08.31.01"
+IPTV_VERSION = "2026.09.01.01"


### PR DESCRIPTION
hostartetv.py getLinksForVideo():
- ARTE's player-v2 config now serves CMAF/fMP4 with separate audio+video HLS renditions, so getDirectM3U8Playlist emits merge://audio_url|video_url. That URL kept iptv_proto=m3u8, so DownloaderCreator routed it to hlsdl -a, which only concatenates the fMP4 fragments -> unplayable file. Flag those split streams with iptv_use_ffmpeg + ff_out_container=matroska so the download/buffer path uses FFMPEGDownloader's real merge:// muxing instead.

ffmpegdownloader.py (affects every FFMPEGDownloader user: DASH, iptv_use_ffmpeg, kinoger, all merge:// hosts - not only ARTE):
- _getDuration()/_getStartTime()/_getDownloadSpeed() null-guard their regex matches; ffmpeg prints "N/A" progress fields that used to raise and spam printExc() on nearly every line.
- size= regex matches kB/KB/KiB case-insensitively (was kB-only -> localFileSize stayed 0 -> completed downloads flagged ERROR).
- _refreshLocalFileSize(): cross-check the real on-disk file size from updateStatistic()/_cmdFinished() so size/percent never stalls at 0 when ffmpeg's own "size=" line is missing/lagging; downloaded-duration counter decoupled from the parsed size.
- _cmdFinished(): completeness judged against >=97% of the known duration (DURATION_COMPLETE_RATIO) instead of exact match; ffmpeg exit code distinguishes ERROR from INTERRUPTED for a short file; a non-zero exit on an otherwise complete timeline stays DOWNLOADED. _checkWorkingCallBack() always clears self.iptv_sys; _terminate() resolves the download even without self.console.
- HTTP(S) inputs get -reconnect_streamed / -reconnect_delay_max 30 / -rw_timeout 60s (HTTP_INPUT_OPTS), only for real http(s) URLs.
- merge:// inputs are stream-mapped explicitly (audio_url -> N:a, video_url -> N:v) so a stray track in one playlist can't shadow the intended stream.
- _fixFileExtension(): on any non-terminated exit, rename <name>.mp4 ->
  .mkv/.ts to match the container ffmpeg actually wrote, so gstplayer / DLNA / file managers don't choke; gated by allowFinalRename (off for buffered playback). _outContainer() keeps start()'s -f and the rename in sync.
- drop dead time.sleep / iptvtypes.enum imports; _dataAvail() CR-fragment handling simplified.

iptvdmapi.py:
- runCMD(): set downloader.allowFinalRename = True for real downloads.
- cmdFinished(): re-read downloader.getFullFileName() into item.fileName so notify / archive / delete use the renamed path. No-op for other downloaders.
- updateItemSTS(): round the duration-based percent instead of truncating so a finished download whose ffmpeg end time lands just under the summed playlist duration is not flagged INTERRUPTED. Byte-based percent untouched.