### PR TITLE
Mediathek hosts: watched flag, sidecar files, unified name normalization

### DIFF
--- a/IPTVPlayer/components/iptvconfigmenu.py
+++ b/IPTVPlayer/components/iptvconfigmenu.py
@@ -189,12 +189,22 @@ config.plugins.iptvplayer.favourites_use_watched_flag = ConfigYesNo(default=True
 config.plugins.iptvplayer.watched_item_color = ConfigSelection(default="#808080", choices=COLORS_DEFINITONS)
 config.plugins.iptvplayer.started_item_color = ConfigSelection(default="#FFFF00", choices=COLORS_DEFINITONS)
 config.plugins.iptvplayer.sidecar_enabled = ConfigYesNo(default=True)
+config.plugins.iptvplayer.normalize_media_names = ConfigYesNo(default=True)
 
 
 def IsSidecarEnabled():
     # single central place hosts ask whether to create sidecar .txt/.jpg files,
     # instead of each host keeping its own copy of this config option
     return config.plugins.iptvplayer.sidecar_enabled.value
+
+
+def IsMediaNamingNormalized():
+    # shared toggle for every host that produces media-server friendly item
+    # titles ("Show - SxxExx - Title" / "Title (Year)" / "Show - Title
+    # (YYYY-MM-DD)") instead of the site's raw label - currently the mediathek
+    # hosts (ARD/ZDF/ARTE/ORF/SRG), serienstream.to and hdfilme. The download
+    # filename is derived from the item title, so this normalises that too.
+    return config.plugins.iptvplayer.normalize_media_names.value
 
 
 config.plugins.iptvplayer.usepycurl = ConfigYesNo(default=False)
@@ -402,6 +412,7 @@ class ConfigMenu(ConfigBaseWidget):
             list.append(getConfigListEntry("    " + _("The color of the viewed item"), config.plugins.iptvplayer.watched_item_color))
             list.append(getConfigListEntry("    " + _("The color of the started item"), config.plugins.iptvplayer.started_item_color))
         list.append(getConfigListEntry(_("Create sidecar files (.txt/.jpg)"), config.plugins.iptvplayer.sidecar_enabled))
+        list.append(getConfigListEntry(_("Normalize item / file names (Show - SxxExx - Title)"), config.plugins.iptvplayer.normalize_media_names))
         list.append(getConfigListEntry(_("----- SECURITY CONFIGURATION -----"),))
         list.append(getConfigListEntry(_("Pin protection for plugin"), config.plugins.iptvplayer.pluginProtectedByPin))
         list.append(getConfigListEntry(_("Pin protection for configuration"), config.plugins.iptvplayer.configProtectedByPin))

--- a/IPTVPlayer/hosts/hostardmediathek.py
+++ b/IPTVPlayer/hosts/hostardmediathek.py
@@ -8,6 +8,11 @@
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedfoldermixin import GenericFolderWatchedScraperMixin, GenericFolderWatchedHostMixin
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import normalizeMediathekTitle
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Playlist
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
@@ -49,7 +54,7 @@ def gettytul():
     return 'ARDmediathek'
 
 
-class ARDmediathek(CBaseHostClass):
+class ARDmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
 
     API = 'https://api.ardmediathek.de/page-gateway/'
     CLIENT = 'ard'
@@ -97,6 +102,41 @@ class ARDmediathek(CBaseHostClass):
             {'category': 'audio_menu', 'title': _('Radio') + ' (ARD Audiothek)'},
         ]
         self.MAIN_CAT_TAB += self.searchItems()
+
+        self.watchedHelper = IPTVWatchedHelper('ardmediathek')
+        self.wfInitFolderCache()
+
+    ###################################################
+    # watched flag
+    ###################################################
+    # nav rows that are not real content containers - keep them out of the folder tree
+    # list_widget_inline / list_page(home) carry no own url - dict(cItem) leaves the
+    # enclosing page's url on them, which would collide with the page's own key
+    WF_SKIP_CATEGORIES = ('list_az', 'list_live', 'list_rubriken', 'list_widget_inline',
+                          'audio_menu', 'audio_categories', 'audio_live', 'audio_live_variants',
+                          'search', 'search_next_page', 'search_history')
+
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict) or cItem.get('live'):
+                return ''
+            itemType = cItem.get('type', '')
+            if itemType == 'video':
+                url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+                return 'video:%s' % url if url else ''
+            if itemType in ('audio', 'more', 'marker'):
+                return ''
+            if cItem.get('search_item') or cItem.get('name') == 'history':
+                return ''
+            if cItem.get('category', '') in self.WF_SKIP_CATEGORIES:
+                return ''
+            url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+            if not url or url.rstrip('/').endswith('/home'):
+                return ''
+            return 'folder:%s' % url
+        except Exception:
+            printExc()
+        return ''
 
     ###################################################
     # helpers
@@ -236,6 +276,12 @@ class ARDmediathek(CBaseHostClass):
                 if 'LIVESTREAM' in cat:
                     params['live'] = True
                     params['title'] = '[L] ' + title
+                else:
+                    show = self.cleanHtmlStr((t.get('show') or {}).get('title', '') or '')
+                    params['title'] = normalizeMediathekTitle(
+                        title, date=t.get('broadcastedOn') or '',
+                        sxeHint='%s %s' % (t.get('mediumTitle') or '', t.get('longTitle') or ''),
+                        isMovie=(not show) and cat not in ('EPISODE', 'CLIP'))
                 self.addVideo(params)
             else:
                 params['category'] = 'list_page'
@@ -445,10 +491,13 @@ class ARDmediathek(CBaseHostClass):
             return []
 
         embedded = None
+        synopsis = ''
         live = bool(cItem.get('live'))
         for w in data.get('widgets', []):
             if not isinstance(w, dict):
                 continue
+            if not synopsis and w.get('synopsis'):
+                synopsis = self.cleanHtmlStr(w.get('synopsis'))
             mc = w.get('mediaCollection')
             if not mc:
                 continue
@@ -576,6 +625,8 @@ class ARDmediathek(CBaseHostClass):
             urlTab.append({'need_resolve': 0, 'name': '%s %s' % (item['quality_name'], item['format_name']), 'url': self.up.decorateUrl(item['url'], decorateParams)})
             if onelinkmode:
                 break
+        if not live:
+            urlTab = applySidecarToLinks(urlTab, buildSidecarFromItem(cItem, IsSidecarEnabled(), synopsis))
         return urlTab
 
     ###################################################
@@ -836,10 +887,13 @@ class ARDmediathek(CBaseHostClass):
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
-class IPTVHost(CHostBase):
+class IPTVHost(GenericFolderWatchedHostMixin, CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, ARDmediathek(), True)
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('ardmediathek')
 
     def withArticleContent(self, cItem):
         return cItem.get('type') == 'video'

--- a/IPTVPlayer/hosts/hostartetv.py
+++ b/IPTVPlayer/hosts/hostartetv.py
@@ -10,6 +10,11 @@
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedfoldermixin import GenericFolderWatchedScraperMixin, GenericFolderWatchedHostMixin
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import normalizeMediathekTitle
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Playlist
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
@@ -43,7 +48,7 @@ def gettytul():
     return 'https://www.arte.tv/'
 
 
-class ArteTV(CBaseHostClass):
+class ArteTV(GenericFolderWatchedScraperMixin, CBaseHostClass):
 
     IMG_SIZE = '400x225'
 
@@ -68,6 +73,44 @@ class ArteTV(CBaseHostClass):
         self.DEFAULT_ICON_URL = 'https://www.arte.tv/static/livewebapp/images/apple-touch-icon.png'
         self.USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36'
         self.HTTP_HEADER = {'User-Agent': self.USER_AGENT, 'Accept': 'application/json'}
+
+        self.watchedHelper = IPTVWatchedHelper('artetv')
+        self.wfInitFolderCache()
+
+    ###################################################
+    # watched flag
+    ###################################################
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict) or cItem.get('live'):
+                return ''
+            itemType = cItem.get('type', '')
+            if itemType == 'video':
+                pid = str(cItem.get('program_id', '') or '').strip()
+                return 'video:%s' % pid if pid else ''
+            if itemType in ('audio', 'more', 'marker'):
+                return ''
+            if cItem.get('search_item') or cItem.get('name') == 'history':
+                return ''
+            category = cItem.get('category', '')
+            if category in ('list_menu', 'list_live', 'search', 'search_next_page', 'search_history'):
+                return ''
+            colId = str(cItem.get('col_id', '') or '').strip()
+            seasonCode = str(cItem.get('season_code', '') or '').strip()
+            if seasonCode:
+                return 'folder:arte-season:%s#%s' % (colId, seasonCode)
+            if category == 'list_collection' and colId:
+                return 'folder:arte-col:%s' % colId
+            url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+            # an inline zone (no own endpoint) carries the enclosing page's url via
+            # dict(cItem); "/web/pages/..." are only the HOME / SEARCH / genre nav
+            # pages anyway - never a real content container
+            if not url or '/web/pages/' in url:
+                return ''
+            return 'folder:%s' % url
+        except Exception:
+            printExc()
+        return ''
 
     ###################################################
     def _lang(self):
@@ -158,6 +201,7 @@ class ArteTV(CBaseHostClass):
             params = dict(cItem)
             params.pop('page', None)
             params.pop('zone_url', None)
+            params.pop('season_code', None)
             params.update({'title': title, 'icon': self._img(item), 'desc': self._desc(item), 'good_for_fav': True})
             if kind.get('isCollection') or code in ('TV_SERIES', 'TOPIC', 'COLLECTION') or str(pid).startswith('RC-'):
                 params.update({'category': 'list_collection', 'col_id': pid, 'url': self._api('collections/%s' % pid)})
@@ -166,6 +210,12 @@ class ArteTV(CBaseHostClass):
                 params.update({'program_id': pid, 'f_url': item.get('url', '')})
                 if code in ('LIVESTREAM',) or item.get('livestreamRights'):
                     params['live'] = True
+                else:
+                    epInfo = item.get('episodeInfo') or ''
+                    params['title'] = normalizeMediathekTitle(
+                        title, sxeHint=epInfo if isinstance(epInfo, str) else '',
+                        date=item.get('firstBroadcastDate') or item.get('availableFrom') or '',
+                        isMovie=not epInfo)
                 self.addVideo(params)
         except Exception:
             printExc()
@@ -289,7 +339,8 @@ class ArteTV(CBaseHostClass):
                 items = self._zoneData(z)[0]
                 params = dict(cItem)
                 params.pop('page', None)
-                params.update({'category': 'list_zone_inline', 'title': self.cleanHtmlStr(z.get('title') or _('Season')), 'zone_items': items, 'good_for_fav': False, 'icon': self._img(items[0]) if items else ''})
+                params.update({'category': 'list_zone_inline', 'title': self.cleanHtmlStr(z.get('title') or _('Season')), 'zone_items': items, 'good_for_fav': False, 'icon': self._img(items[0]) if items else '',
+                               'col_id': cItem.get('col_id', ''), 'season_code': z.get('code') or self.cleanHtmlStr(z.get('title') or '')})
                 self.addDir(params)
             return
 
@@ -335,6 +386,11 @@ class ArteTV(CBaseHostClass):
         if not streams:
             return []
         live = bool(attrs.get('live'))
+        _md = attrs.get('metadata') or {}
+        _mdDesc = _md.get('description')
+        if isinstance(_mdDesc, dict):
+            _mdDesc = _mdDesc.get('text') or ''
+        synopsis = self.cleanHtmlStr(_mdDesc or _md.get('subtitle') or '')
         onlyLang = config.plugins.iptvplayer.artetv_audio.value
         bestOnly = config.plugins.iptvplayer.artetv_quality.value
         langName = dict(config.plugins.iptvplayer.artetv_lang.choices).get(self._lang(), '')
@@ -383,6 +439,8 @@ class ArteTV(CBaseHostClass):
             mx = max(_res(u) for u in urlTab)
             if mx > 0:
                 urlTab = [u for u in urlTab if _res(u) == mx] or urlTab
+        if not live:
+            urlTab = applySidecarToLinks(urlTab, buildSidecarFromItem(cItem, IsSidecarEnabled(), synopsis))
         return urlTab
 
     ###################################################
@@ -425,7 +483,10 @@ class ArteTV(CBaseHostClass):
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
-class IPTVHost(CHostBase):
+class IPTVHost(GenericFolderWatchedHostMixin, CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, ArteTV(), True)
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('artetv')

--- a/IPTVPlayer/hosts/hosthdfilme.py
+++ b/IPTVPlayer/hosts/hosthdfilme.py
@@ -11,6 +11,9 @@ from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
 from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhostmixin import WatchedFlagHostMixin
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks, sidecarFromUrlMeta, decorateResolvedLinkItems
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import extractNum, formatSxxExx, stripLeadingSxxExx
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled, IsMediaNamingNormalized
 
 
 def GetConfigList():
@@ -21,35 +24,12 @@ def gettytul():
     return "https://hdfilme.win/"
 
 
-def _extractNum(rawValue, default=0):
-    """First run of digits in the value as int, else default. Anchored to the first digit
-    group so a trailing '(2019)' or similar in a label cannot leak into the number."""
-    m = re.search(r"\d+", str(rawValue))
-    return int(m.group(0)) if m else default
-
-
-def _formatSxxExx(seasonNum, episodeNum=None):
-    """Build a zero-padded SxxExx tag from already-resolved season/episode numbers (not internal DB ids)."""
-    sNum = _extractNum(seasonNum, 0)
-    if episodeNum is None:
-        return "S%02d" % sNum
-    eNum = _extractNum(episodeNum, 0)
-    return "S%02dE%02d" % (sNum, eNum)
-
-
 def _parseLeadingSxEx(label):
     """Detect a leading 'S1 E1' / 'S01E01' style tag inside a raw episode label; returns (seasonNum, episodeNum) or (None, None)."""
     m = re.match(r"\s*S\s*(\d+)\s*E\s*(\d+)", label, re.IGNORECASE)
     if m:
         return int(m.group(1)), int(m.group(2))
     return None, None
-
-
-def _stripLeadingSeasonEpisodeNumbers(label):
-    """Remove only the leading 'S<digits> E<digits>' numbers from a raw episode label. Whatever
-    separator character the site itself put right after (dash, em-dash, colon, nothing) is left
-    untouched, so we never fight with the site's own formatting."""
-    return re.sub(r"^\s*S\s*\d+\s*E\s*\d+\s*", "", label, flags=re.IGNORECASE)
 
 
 def _trimTrailingDashPart(title):
@@ -198,11 +178,16 @@ class HDFilme(CBaseHostClass):
         episodeMatches = re.findall(r'data-link="([^"]+)"[^>]*?data-label="([^"]+)"', blocksById.get(seasonId, ""))
         for episodeIndex, (link, label) in enumerate(episodeMatches, start=1):
             cleanLabelRaw = self.cleanHtmlStr(label)
+            if not IsMediaNamingNormalized():
+                # normalisation off: keep the site's raw episode label
+                episodeTitle = "%s - %s" % (seriesName, cleanLabelRaw) if seriesName else cleanLabelRaw
+                episodes.append({"type": "video", "url": url, "title": episodeTitle, "icon": icon, "desc": desc, "stream_url": link, "stream_type": "direct", "season_id": seasonId})
+                continue
             embeddedSeason, embeddedEpisode = _parseLeadingSxEx(cleanLabelRaw)
             seasonNumForTag = embeddedSeason if embeddedSeason is not None else seasonNum
             episodeNum = embeddedEpisode if embeddedEpisode is not None else episodeIndex
-            epTag = _formatSxxExx(seasonNumForTag, episodeNum)
-            rest = _stripLeadingSeasonEpisodeNumbers(cleanLabelRaw).strip()
+            epTag = formatSxxExx(seasonNumForTag, episodeNum)
+            rest = stripLeadingSxxExx(cleanLabelRaw).strip()
             if seriesName:
                 episodeTitle = "%s - %s %s" % (seriesName, epTag, rest) if rest else "%s - %s" % (seriesName, epTag)
             else:
@@ -228,7 +213,7 @@ class HDFilme(CBaseHostClass):
             if blockId != "":
                 blocksById[blockId] = block
         for seasonIndex, (seasonId, seasonLabelRaw) in enumerate(seasons, start=1):
-            seasonNumFromLabel = _extractNum(self.cleanHtmlStr(seasonLabelRaw), 0)
+            seasonNumFromLabel = extractNum(self.cleanHtmlStr(seasonLabelRaw), 0)
             seasonNum = seasonNumFromLabel if seasonNumFromLabel > 0 else seasonIndex
             seasonNumsById[seasonId] = seasonNum
             self.cacheSeasons[seasonId] = self._buildEpisodesForSeason(seasonId, seasonNum, seriesName, seriesUrl, icon, desc, blocksById)
@@ -262,7 +247,7 @@ class HDFilme(CBaseHostClass):
         for seasonId, _seasonLabelRaw in seasons:
             seasonNum = seasonNumsById.get(seasonId, 0)
             episodes = self.cacheSeasons.get(seasonId, [])
-            seasonTag = _formatSxxExx(seasonNum)
+            seasonTag = formatSxxExx(seasonNum) if IsMediaNamingNormalized() else (_("Season") + " %d" % extractNum(seasonNum, 0))
             title = "%s - %s" % (seriesName, seasonTag) if seriesName else seasonTag
             params = dict(cItem)
             params.pop("isWatched", None)
@@ -342,6 +327,23 @@ class HDFilme(CBaseHostClass):
         streamUrl = cItem.get("stream_url", "")
         if not streamUrl:
             return linksTab
+
+        sidecarEnabled = IsSidecarEnabled()
+        extraText = ""
+        if sidecarEnabled:
+            try:
+                article = self.getArticleContent(cItem)
+                if article and isinstance(article, list):
+                    articleItem = article[0]
+                    extraText = articleItem.get("text", "") or ""
+                    otherInfo = articleItem.get("other_info", {}) or {}
+                    head = [str(otherInfo[k]) for k in ("released", "duration", "actors") if otherInfo.get(k)]
+                    if head:
+                        extraText = " / ".join(head) + (("\n\n" + extraText) if extraText else "")
+            except Exception:
+                printExc("HDFilme getArticleContent for sidecar failed")
+        sidecar = buildSidecarFromItem(cItem, sidecarEnabled, extraText)
+
         if cItem.get("stream_type") == "movie":
             sts, data = self.getPage(streamUrl, self.defaultParams)
             if not sts:
@@ -354,12 +356,13 @@ class HDFilme(CBaseHostClass):
                 continue
             url = "https:" + url if url.startswith("//") else url
             linksTab.append({"name": self.up.getHostName(url).capitalize(), "url": strwithmeta(url, {"Referer": gettytul()}), "need_resolve": 1})
-        return linksTab
+        return applySidecarToLinks(linksTab, sidecar)
 
     def getVideoLinks(self, videoUrl):
         printDBG("HDFilme.getVideoLinks [%s]" % videoUrl)
         if self.cm.isValidUrl(videoUrl):
-            return self.up.getVideoLinkExt(videoUrl)
+            sidecar = sidecarFromUrlMeta(videoUrl, IsSidecarEnabled())
+            return decorateResolvedLinkItems(self.up.getVideoLinkExt(videoUrl), sidecar)
         return []
 
     def getArticleContent(self, cItem):

--- a/IPTVPlayer/hosts/hostorfon.py
+++ b/IPTVPlayer/hosts/hostorfon.py
@@ -8,6 +8,11 @@
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedfoldermixin import GenericFolderWatchedScraperMixin, GenericFolderWatchedHostMixin
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import normalizeMediathekTitle
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Playlist
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
@@ -30,7 +35,7 @@ def gettytul():
     return 'https://on.orf.at/'
 
 
-class ORFON(CBaseHostClass):
+class ORFON(GenericFolderWatchedScraperMixin, CBaseHostClass):
 
     API = 'https://api-tvthek.orf.at/api/v4.3'
     API_AUTH = 'Basic b3JmX29uX3Y0MzpqRlJzYk5QRmlQU3h1d25MYllEZkNMVU41WU5aMjhtdA=='
@@ -48,6 +53,36 @@ class ORFON(CBaseHostClass):
             'Authorization': self.API_AUTH,
             'Accept': 'application/json',
         }
+
+        self.watchedHelper = IPTVWatchedHelper('orfon')
+        self.wfInitFolderCache()
+
+    ###################################################
+    # watched flag
+    ###################################################
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict) or cItem.get('live'):
+                return ''
+            itemType = cItem.get('type', '')
+            if itemType == 'video':
+                eid = str(cItem.get('ep_id', '') or '').strip()
+                if eid:
+                    return 'video:%s' % eid
+                url = self.wfNormalizeUrlKey(cItem.get('ep_url', '') or cItem.get('url', ''))
+                return 'video:%s' % url if url else ''
+            if itemType in ('audio', 'more', 'marker'):
+                return ''
+            if cItem.get('search_item') or cItem.get('name') == 'history':
+                return ''
+            if cItem.get('category', '') in ('list_start', 'list_az', 'list_dates', 'list_live',
+                                             'search', 'search_next_page', 'search_history'):
+                return ''
+            url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+            return 'folder:%s' % url if url else ''
+        except Exception:
+            printExc()
+        return ''
 
     ###################################################
     def getPage(self, url, params=None, post_data=None):
@@ -170,6 +205,10 @@ class ORFON(CBaseHostClass):
             if self._isVideo(item):
                 eid = item.get('id') or ''
                 params.update({'category': 'play', 'ep_id': eid, 'ep_url': self._abs(selfHref) if selfHref else ''})
+                if not params.get('live'):
+                    profile = self.cleanHtmlStr(((item.get('_embedded') or {}).get('profile') or {}).get('title') or '')
+                    base = '%s - %s' % (profile, title) if profile and profile.lower() not in title.lower() else title
+                    params['title'] = normalizeMediathekTitle(base, date=item.get('date') or item.get('episode_date') or '', sxeHint=title)
                 self.addVideo(params)
             elif episodesHref:
                 params.update({'category': 'list_url', 'url': self._abs(episodesHref)})
@@ -349,6 +388,7 @@ class ORFON(CBaseHostClass):
 
         subTracks = self._subtitle(node) or self._subtitle(data)
         live = bool(cItem.get('live')) or data.get('video_type') == 'live'
+        synopsis = self.cleanHtmlStr(data.get('description') or node.get('description') or data.get('teaser_text') or '')
         bestOnly = config.plugins.iptvplayer.orfon_bestonly.value
 
         hlsList = [s for s in (src.get('hls') or []) if not s.get('is_drm_protected')]
@@ -386,6 +426,8 @@ class ORFON(CBaseHostClass):
             mx = max(res(u) for u in urlTab)
             if mx > 0:
                 urlTab = [u for u in urlTab if res(u) == mx] or urlTab[:1]
+        if not live:
+            urlTab = applySidecarToLinks(urlTab, buildSidecarFromItem(cItem, IsSidecarEnabled(), synopsis))
         return urlTab
 
     ###################################################
@@ -428,7 +470,10 @@ class ORFON(CBaseHostClass):
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
-class IPTVHost(CHostBase):
+class IPTVHost(GenericFolderWatchedHostMixin, CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, ORFON(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('orfon')

--- a/IPTVPlayer/hosts/hostplayrtsiw.py
+++ b/IPTVPlayer/hosts/hostplayrtsiw.py
@@ -8,6 +8,11 @@
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
 from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedfoldermixin import GenericFolderWatchedScraperMixin, GenericFolderWatchedHostMixin
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import normalizeMediathekTitle
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
 from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote
 import re
@@ -28,7 +33,7 @@ def gettytul():
     return 'https://www.srgssr.ch/'
 
 
-class PlayRTSIW(CBaseHostClass):
+class PlayRTSIW(GenericFolderWatchedScraperMixin, CBaseHostClass):
 
     IL = 'https://il.srgssr.ch/integrationlayer/2.0/'
     TOKEN_URL = 'https://tp.srgssr.ch/akahd/token?acl='
@@ -44,6 +49,33 @@ class PlayRTSIW(CBaseHostClass):
         CBaseHostClass.__init__(self, {'history': 'PlayRTSIW', 'cookie': 'srgssr.cookie'})
         self.DEFAULT_ICON_URL = 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/SRG_SSR_2011_logo.svg/1200px-SRG_SSR_2011_logo.svg.png'
         self.HTTP_HEADER = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36', 'Accept': 'application/json'}
+
+        self.watchedHelper = IPTVWatchedHelper('srgssr')
+        self.wfInitFolderCache()
+
+    ###################################################
+    # watched flag
+    ###################################################
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict) or cItem.get('live'):
+                return ''
+            itemType = cItem.get('type', '')
+            if itemType in ('video', 'audio'):
+                urn = str(cItem.get('urn', '') or '').strip()
+                return 'media:%s' % urn if urn else ''
+            if itemType in ('more', 'marker'):
+                return ''
+            if cItem.get('search_item') or cItem.get('name') == 'history':
+                return ''
+            if cItem.get('category', '') in ('list_portal', 'list_radio', 'list_portals',
+                                             'search', 'search_next_page', 'search_history'):
+                return ''
+            url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+            return 'folder:%s' % url if url else ''
+        except Exception:
+            printExc()
+        return ''
 
     ###################################################
     def getPage(self, url, params=None, post_data=None):
@@ -109,6 +141,8 @@ class PlayRTSIW(CBaseHostClass):
                            'icon': self._icon(media.get('imageUrl')), 'desc': '[/br]'.join(descTab)})
             if str(media.get('type') or '').upper() in ('LIVESTREAM', 'SCHEDULED_LIVESTREAM'):
                 params['live'] = True
+            else:
+                params['title'] = normalizeMediathekTitle(params['title'], date=media.get('date') or '', sxeHint=title)
             if str(media.get('mediaType') or '').upper() == 'AUDIO':
                 self.addAudio(params)
             else:
@@ -299,7 +333,7 @@ class PlayRTSIW(CBaseHostClass):
     def getLinksForVideo(self, cItem):
         printDBG("PlayRTSIW.getLinksForVideo [%s]" % cItem.get('urn', ''))
         if cItem.get('direct_url'):
-            return [{'need_resolve': 0, 'name': _('Audio'), 'url': cItem['direct_url']}]
+            return applySidecarToLinks([{'need_resolve': 0, 'name': _('Audio'), 'url': cItem['direct_url']}], buildSidecarFromItem(cItem, IsSidecarEnabled()))
         urn = cItem.get('urn', '')
         if not urn:
             return []
@@ -321,6 +355,7 @@ class PlayRTSIW(CBaseHostClass):
             return []
 
         blockReason = str(chapter.get('blockReason') or '')
+        synopsis = self.cleanHtmlStr(chapter.get('description') or chapter.get('lead') or '')
         resources = chapter.get('resourceList') or []
         if not resources:
             if blockReason:
@@ -377,6 +412,8 @@ class PlayRTSIW(CBaseHostClass):
                 if res.get('url'):
                     urlTab.append({'need_resolve': 0, 'name': ('%s %s' % (res.get('protocol') or '', res.get('quality') or '')).strip(),
                                    'url': self.up.decorateUrl(res['url'], {'iptv_livestream': live})})
+        if not live:
+            urlTab = applySidecarToLinks(urlTab, buildSidecarFromItem(cItem, IsSidecarEnabled(), synopsis))
         return urlTab
 
     ###################################################
@@ -416,10 +453,13 @@ class PlayRTSIW(CBaseHostClass):
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
-class IPTVHost(CHostBase):
+class IPTVHost(GenericFolderWatchedHostMixin, CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, PlayRTSIW(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('srgssr')
 
     def getSearchTypes(self):
         return [('SRF', 'srf'), ('RTS', 'rts'), ('RSI', 'rsi'), ('RTR', 'rtr')]

--- a/IPTVPlayer/hosts/hostserienstreamto.py
+++ b/IPTVPlayer/hosts/hostserienstreamto.py
@@ -14,7 +14,8 @@ from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, sidecarFromUrlMeta, decorateUrl, decorateResolvedLinkItems
 from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
 from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhostmixin import WatchedFlagHostMixin
-from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import formatSxxExx
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled, IsMediaNamingNormalized
 
 
 config.plugins.iptvplayer.serienstreamto_hosts = ConfigSelection(default="http://186.2.175.5/", choices=[("http://186.2.175.5/", "186.2.175.5"), ("https://serienstream.to/", "serienstream.to"), ("https://serienstream.cx/", "serienstream.cx")])  # NOSONAR
@@ -23,7 +24,6 @@ config.plugins.iptvplayer.serienstreamto_login = ConfigText(default="", fixed_si
 config.plugins.iptvplayer.serienstreamto_password = ConfigText(default="", fixed_size=False)
 config.plugins.iptvplayer.serienstreamto_omdb_apikey = ConfigText(default="", fixed_size=False)
 config.plugins.iptvplayer.serienstreamto_mkv = ConfigYesNo(default=True)
-config.plugins.iptvplayer.serienstreamto_legacy_titles = ConfigYesNo(default=False)
 
 
 def GetConfigList():
@@ -34,8 +34,7 @@ def GetConfigList():
                   getConfigListEntry(_("e-mail") + ":", config.plugins.iptvplayer.serienstreamto_login),
                   getConfigListEntry(_("password") + ":", config.plugins.iptvplayer.serienstreamto_password),
                   getConfigListEntry(_("OMDb API Key") + ":", config.plugins.iptvplayer.serienstreamto_omdb_apikey),
-                  getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.serienstreamto_mkv),
-                  getConfigListEntry(_("Use legacy title format") + ":", config.plugins.iptvplayer.serienstreamto_legacy_titles)]
+                  getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.serienstreamto_mkv)]
     optionList.append(getConfigListEntry(_("host") + ":", config.plugins.iptvplayer.serienstreamto_hosts))
     return optionList
 
@@ -71,7 +70,10 @@ class SerienStreamTo(CBaseHostClass):
                      {"category": "list_items", "title": _("All"), "url": self.getFullUrl("serien")}] + self.searchItems()
 
     def _useLegacyTitles(self):
-        return config.plugins.iptvplayer.serienstreamto_legacy_titles.value
+        # the site's raw "Series - Episode N - name" form; the normalised
+        # "Series - SxxExx - name - lang" form is the default. Governed by the
+        # one global switch shared with the mediathek hosts and hdfilme.
+        return not IsMediaNamingNormalized()
 
     def _getWatchedKeyForItem(self, cItem):
         # printDBG("SerienStreamTo._getWatchedKeyForItem")
@@ -356,7 +358,7 @@ class SerienStreamTo(CBaseHostClass):
                 season_num = int(season_num) if str(season_num).isdigit() else 0
                 series_title = cItem.get("title", "").split(" - Staffel")[0].strip()
                 ep_num = int(ep) if ep.isdigit() else 0
-                se_tag = "S%02dE%02d" % (season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
+                se_tag = formatSxxExx(season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
                 lang = language(item)
                 lang_suffix = " - %s" % lang if lang else ""
                 title = "%s - %s - %s%s" % (series_title, se_tag, name, lang_suffix) if se_tag else "%s - %s%s" % (series_title, name, lang_suffix)
@@ -395,7 +397,7 @@ class SerienStreamTo(CBaseHostClass):
                 else:
                     season_num = self.cm.ph.getSearchGroups(se, r'(\d+)')[0]
                     episode_num = self.cm.ph.getSearchGroups(ep, r'(\d+)')[0]
-                    season_ep = "S%sE%s" % (season_num.zfill(2), episode_num.zfill(2)) if season_num and episode_num else "%s %s" % (se, ep)
+                    season_ep = formatSxxExx(season_num, episode_num) if season_num and episode_num else "%s %s" % (se, ep)
                     title = "%s - %s%s" % (name, season_ep, (" - %s" % lang) if lang else "")
                 imdb_lookup_url = re.sub(r'/staffel-\d+/episode-\d+/?$', '/', url)
                 params = dict(cItem)
@@ -693,7 +695,7 @@ class IPTVHost(WatchedFlagHostMixin, CHostBase):
                     season_num = int(season_num) if str(season_num).isdigit() else 0
                     series_title = (seasonItem.get('title', '') or self.host.currItem.get('title', '')).split(" - Staffel")[0].strip()
                     ep_num = int(ep) if ep.isdigit() else 0
-                    se_tag = "S%02dE%02d" % (season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
+                    se_tag = formatSxxExx(season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
                     lang = language(item)
                     lang_suffix = " - %s" % lang if lang else ""
                     title = "%s - %s - %s%s" % (series_title, se_tag, name, lang_suffix) if se_tag else "%s - %s%s" % (series_title, name, lang_suffix)

--- a/IPTVPlayer/hosts/hostzdfmediathek.py
+++ b/IPTVPlayer/hosts/hostzdfmediathek.py
@@ -6,6 +6,11 @@
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
 from Plugins.Extensions.IPTVPlayer.components.ihost import CHostBase, CBaseHostClass
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedfoldermixin import GenericFolderWatchedScraperMixin, GenericFolderWatchedHostMixin
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import normalizeMediathekTitle
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
 from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Playlist
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
 ###################################################
@@ -50,7 +55,7 @@ def gettytul():
     return 'ZDFmediathek'
 
 
-class ZDFmediathek(CBaseHostClass):
+class ZDFmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
     HOST = 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.18) Gecko/20110621 Mandriva Linux/1.9.2.18-0.1mdv2010.2 (2010.2) Firefox/3.6.18'
     HEADER = {'User-Agent': HOST, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'}
     AJAX_HEADER = dict(HEADER)
@@ -99,6 +104,40 @@ class ZDFmediathek(CBaseHostClass):
         # otherwise "+=" mutates the shared class list on every re-instantiation
         # and the search block piles up (4x etc.)
         self.MAIN_CAT_TAB = list(ZDFmediathek.MAIN_CAT_TAB) + self.searchItems()
+
+        self.watchedHelper = IPTVWatchedHelper('zdfmediathek')
+        self.wfInitFolderCache()
+
+    ###################################################
+    # watched flag
+    ###################################################
+    # list_content carries inline 'content', no own url - dict(cItem) leaves the
+    # enclosing cluster's url on it, which would collide with that cluster's key
+    WF_SKIP_CATEGORIES = ('list_start', 'list_live', 'list_content', 'missed_date',
+                          'list_brands_az', 'kinder', 'search', 'search_next_page', 'search_history')
+
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict) or cItem.get('live'):
+                return ''
+            itemType = cItem.get('type', '')
+            if itemType == 'video':
+                vid = str(cItem.get('id', '') or '').strip()
+                if vid:
+                    return 'video:id:%s' % vid
+                url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+                return 'video:%s' % url if url else ''
+            if itemType in ('audio', 'more', 'marker'):
+                return ''
+            if cItem.get('search_item') or cItem.get('name') == 'history':
+                return ''
+            if cItem.get('category', '') in self.WF_SKIP_CATEGORIES:
+                return ''
+            url = self.wfNormalizeUrlKey(cItem.get('url', ''))
+            return 'folder:%s' % url if url else ''
+        except Exception:
+            printExc()
+        return ''
 
     def getPage(self, url, params={}, post_data=None):
         HTTP_HEADER = dict(self.HEADER)
@@ -256,6 +295,12 @@ class ZDFmediathek(CBaseHostClass):
                 params = {'title': title, 'url': self.getFullUrl(item.get('url', '')), 'desc': ' | '.join(descTab), 'icon': self.getIconUrl(icon), 'id': item.get('id', ''), 'sharing_url': item.get('sharingUrl', ''), 'good_for_fav': True}
                 if not params['url'] and not params['id']:
                     return
+                if item['type'] == 'livevideo':
+                    params['live'] = True
+                else:
+                    params['title'] = normalizeMediathekTitle(
+                        title, date=item.get('editorialDate') or item.get('airtimeBegin') or item.get('onlineDate') or '',
+                        sxeHint='%s %s' % (self.cleanHtmlStr(item.get('headline', '') or ''), title))
                 self.addVideo(params)
         except Exception:
             printExc()
@@ -372,6 +417,7 @@ class ZDFmediathek(CBaseHostClass):
             urlTab = []
             tmpUrlTab = []
             data = json_loads(data)['document']
+            synopsis = self.cleanHtmlStr(data.get('beschreibung') or data.get('leadParagraph') or '')
             try:
                 for item in data['captions']:
                     if 'vtt' in item['format'] and self.cm.isValidUrl(item['uri']):
@@ -478,6 +524,8 @@ class ZDFmediathek(CBaseHostClass):
                     urlTab.append({'need_resolve': 0, 'name': name, 'url': self.up.decorateUrl(url, decorateParams)})
                     if onelinkmode:
                         break
+            if not isLive:
+                urlTab = applySidecarToLinks(urlTab, buildSidecarFromItem(cItem, IsSidecarEnabled(), synopsis))
             printDBG(tmpUrlTab)
         except Exception:
             printExc()
@@ -526,7 +574,10 @@ class ZDFmediathek(CBaseHostClass):
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
-class IPTVHost(CHostBase):
+class IPTVHost(GenericFolderWatchedHostMixin, CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, ZDFmediathek(), True)
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('zdfmediathek')

--- a/IPTVPlayer/libs/urlmetahelper.py
+++ b/IPTVPlayer/libs/urlmetahelper.py
@@ -6,6 +6,8 @@
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 
+import re
+
 ###################################################
 # FOREIGN import
 ###################################################
@@ -128,6 +130,50 @@ def sidecarFromUrlMeta(url, cfgEnabled=True):
 
 def sidecarFromMeta(url, cfgEnabled=True):
     return sidecarFromUrlMeta(url, cfgEnabled)
+
+
+def _normSidecarText(value):
+    try:
+        value = str(value or "").replace("\r", "\n")
+        return re.sub(r"\n{3,}", "\n\n", value).strip()
+    except Exception:
+        printExc()
+        return ""
+
+
+def buildSidecarFromItem(cItem, enabled=True, extraText=""):
+    # convenience for hosts: assemble a sidecar straight from a list item's own
+    # metadata - an optional richer text first (e.g. a real synopsis the host
+    # already fetched), then the item's [/br]-joined desc, plus its icon as the
+    # poster. Whether it is actually written is still governed by `enabled`.
+    try:
+        cItem = cItem or {}
+        head = _normSidecarText(extraText)
+        body = _normSidecarText(str(cItem.get("txt", "") or cItem.get("desc", "") or "").replace("[/br]", "\n"))
+        if body and body not in head:
+            txt = (head + "\n\n" + body).strip() if head else body
+        else:
+            txt = head
+        return buildSidecar(enabled, txt, str(cItem.get("icon", "") or ""))
+    except Exception:
+        printExc()
+        return buildSidecar(False, "", "")
+
+
+def applySidecarToLinks(links, sidecar):
+    # decorate every link's url meta with the sidecar in place; safe no-op when
+    # the sidecar is missing / disabled or there are no links
+    try:
+        if not links or not isinstance(sidecar, dict) or not sidecar.get("enabled"):
+            return links
+        for item in links:
+            try:
+                item["url"] = decorateUrl(item["url"], sidecar=sidecar)
+            except Exception:
+                printExc()
+    except Exception:
+        printExc()
+    return links
 
 
 def decorateUrl(url, referer=None, sidecar=None, mkvEnabled=False, extraMeta=None):

--- a/IPTVPlayer/tools/iptvnaming.py
+++ b/IPTVPlayer/tools/iptvnaming.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# Shared media-server friendly title / download-name normalisation.
+#
+# Used by every host that emits normalised item titles - the mediathek hosts
+# (ARD/ZDF/ARTE/ORF/SRG), serienstream.to and hdfilme. All of them honour the one
+# global switch config.plugins.iptvplayer.normalize_media_names
+# (IsMediaNamingNormalized); the download filename is derived from the item
+# title, so normalising the title normalises the file name too.
+#
+# The sidecar .txt/.jpg helpers are producer-side too but live with the rest of
+# that code in libs/urlmetahelper.py (buildSidecarFromItem / applySidecarToLinks);
+# the consumer side is iptvdm/downloaderhelpers.py.
+###################################################
+# LOCAL import
+###################################################
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printExc
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsMediaNamingNormalized
+###################################################
+import re
+
+
+###################################################
+# small SxxExx primitives (shared by all hosts)
+###################################################
+def extractNum(rawValue, default=0):
+    # first run of digits in the value as int, else default
+    try:
+        m = re.search(r'\d+', str(rawValue))
+        return int(m.group(0)) if m else default
+    except Exception:
+        return default
+
+
+def formatSxxExx(seasonNum, episodeNum=None):
+    # zero-padded "S02" / "S02E05" from already-resolved numbers
+    sNum = extractNum(seasonNum, 0)
+    if episodeNum is None:
+        return 'S%02d' % sNum
+    return 'S%02dE%02d' % (sNum, extractNum(episodeNum, 0))
+
+
+def parseSxxExx(text):
+    # 'S02E05' / 'S2 E5' / 'Staffel 2, Folge 5' / '2. Staffel Folge 5' -> ('2','5'); ('','') if none
+    if not text:
+        return '', ''
+    try:
+        m = re.search(r'S\s*0*(\d+)\s*[ .:/x_-]*\s*E\s*0*(\d+)', text, re.I)
+        if m:
+            return m.group(1), m.group(2)
+        s = re.search(r'Staffel\s*0*(\d+)', text, re.I)
+        e = re.search(r'(?:Folge|Episode)\s*0*(\d+)', text, re.I)
+        if s and e:
+            return s.group(1), e.group(1)
+    except Exception:
+        printExc()
+    return '', ''
+
+
+def stripLeadingSxxExx(label):
+    # remove only a leading 'S<d> E<d>' run, keeping whatever separator the site
+    # put after it untouched
+    try:
+        return re.sub(r'^\s*S\s*\d+\s*E\s*\d+\s*', '', label or '', flags=re.I)
+    except Exception:
+        printExc()
+    return label or ''
+
+
+def _pad2(num):
+    n = extractNum(num, 0)
+    return '%02d' % n if n > 0 else ''
+
+
+def _hasSxE(title):
+    return bool(re.search(r'S\d{1,3}E\d{1,3}', title.replace(' ', ''), re.I))
+
+
+def _cleanText(value):
+    try:
+        value = str(value or '').replace('\r', '\n')
+        return re.sub(r'\n{3,}', '\n\n', value).strip()
+    except Exception:
+        printExc()
+    return ''
+
+
+def _appendLang(title, lang):
+    lang = str(lang or '').strip()
+    if lang and lang.lower() not in title.lower():
+        return '%s - %s' % (title, lang)
+    return title
+
+
+###################################################
+# mediathek-style "augment the existing label" normaliser
+###################################################
+def normalizeMediathekTitle(classicTitle, date='', year='', sxeHint='', isMovie=False, lang=''):
+    # Augments the host's already-decent "Show - Episode" label instead of
+    # rebuilding it: drops a trailing "| ..." meta tail, inserts SxxExx after the
+    # show when season/episode are known, otherwise appends (Year) for a movie
+    # or (YYYY-MM-DD) for a dated episode. Returns classicTitle unchanged when
+    # normalisation is off or nothing can be added.
+    try:
+        if not IsMediaNamingNormalized():
+            return classicTitle
+        title = _cleanText(classicTitle).replace('\n', ' ')
+        # drop only a trailing "| ..." segment that is clearly a mediathek meta
+        # tail, never a real subtitle that happens to use a pipe
+        tail = title.rsplit('|', 1)[-1] if '|' in title else ''
+        if tail and re.search(r'verf[uü]gbar|Video|UT\b|H[oö]rfassung|Audiodeskription|\bmin\b|\d{1,2}\.\d{1,2}\.\d{2,4}', tail, re.I):
+            title = title.rsplit('|', 1)[0].strip() or classicTitle
+        title = re.sub(r'\s{2,}', ' ', title)
+
+        season, episode = parseSxxExx(sxeHint)
+        if not (season and episode):
+            season, episode = parseSxxExx(title)
+        if season and episode and not _hasSxE(title):
+            tag = 'S%sE%s' % (_pad2(season), _pad2(episode))
+            if tag:
+                if ' - ' in title:
+                    show, rest = title.split(' - ', 1)
+                    title = '%s - %s - %s' % (show.strip(), tag, rest.strip())
+                else:
+                    title = '%s - %s' % (title, tag)
+                return _appendLang(title, lang)
+
+        d = str(date)[:10] if date and len(str(date)) >= 10 and str(date)[4] == '-' else ''
+        y = str(year).strip() if year else (d[:4] if d else '')
+        if isMovie and y and not _hasSxE(title):
+            if ('(%s)' % y) not in title:
+                title = '%s (%s)' % (title.rstrip(), y)
+        elif d and not _hasSxE(title):
+            if d not in title and d.replace('-', '.') not in title and d[:4] not in title.split('(')[-1]:
+                title = '%s (%s)' % (title, d)
+        return _appendLang(title, lang)
+    except Exception:
+        printExc()
+    return classicTitle

--- a/IPTVPlayer/tools/iptvwatchedfoldermixin.py
+++ b/IPTVPlayer/tools/iptvwatchedfoldermixin.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Shared generic "watched flag" wiring for the recursive folder-style hosts
+# (ARD / ZDF / ARTE / ORF / SRG mediatheken).
+#
+# Unlike filmpalast / serienstream these hosts have NO explicit
+# series/season/episode data model - a "show" is just a folder whose episodes are
+# fetched through the same generic listing code as everything else. So episodes
+# are marked normally (watched / started / MENU toggle via WatchedFlagHostMixin)
+# and a folder's dot/checkmark is derived by walking a breadcrumb chain of folder
+# keys that is accumulated while the user browses: every addDir()/addVideo()/
+# addAudio() records parent<-child, and when an episode's state changes the chain
+# is recomputed upwards (episode -> season folder -> show folder -> ...), as far
+# as it is known in the current session.
+###################################################
+# LOCAL import
+###################################################
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printExc
+from Plugins.Extensions.IPTVPlayer.components.ihost import CBaseHostClass, RetHost
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhostmixin import WatchedFlagHostMixin
+###################################################
+
+# query-string params that only page/slice a listing - they must not make the
+# same logical folder look like two different folders
+_WF_VOLATILE_QS = ('page', 'pageNumber', 'pageNo', 'pageSize', 'offset', 'limit',
+                   'loadSize', 'size', 'vodPageNumber', 'showPageNumber', 'maxLength',
+                   'embedded')
+
+
+class GenericFolderWatchedScraperMixin(object):
+    # host scraper side - mix in BEFORE CBaseHostClass.
+    # Requires the including class to provide:
+    #   self.watchedHelper           (IPTVWatchedHelper instance)
+    #   self.wfInitFolderCache()     called from __init__
+    #   _getWatchedKeyForItem(cItem) -> '' | 'video:<stable-id>' | 'folder:<stable-id>'
+
+    def wfInitFolderCache(self):
+        self.wfFolderChildren = {}
+        self.wfFolderParent = {}
+
+    @staticmethod
+    def wfNormalizeUrlKey(url):
+        # drop volatile pagination params so page 2+ of a folder keys the same as page 1
+        url = str(url or '').strip()
+        if url == '':
+            return ''
+        try:
+            base, sep, qs = url.partition('?')
+            if sep:
+                kept = [p for p in qs.split('&') if p and p.split('=', 1)[0] not in _WF_VOLATILE_QS]
+                url = base + ('?' + '&'.join(kept) if kept else '')
+        except Exception:
+            printExc()
+        return url
+
+    def wfRegister(self, params):
+        # links the folder tree (parent <- child) and stamps parent_key on the
+        # child for later propagation; a no-op for items without a watched key
+        # (nav tabs, "Next page", live streams, search, ...).
+        # MUST run after CBaseHostClass.addX() so params['type'] is already set.
+        try:
+            if not isinstance(params, dict) or getattr(self, 'watchedHelper', None) is None:
+                return params
+            childKey = self._getWatchedKeyForItem(params)
+            if childKey == '':
+                return params
+            parentKey = self._getWatchedKeyForItem(getattr(self, 'currItem', {}) or {})
+            params['parent_key'] = parentKey
+            if parentKey != '' and parentKey != childKey:
+                children = self.wfFolderChildren.setdefault(parentKey, [])
+                if childKey not in children:
+                    children.append(childKey)
+                self.wfFolderParent[childKey] = parentKey
+        except Exception:
+            printExc()
+        return params
+
+    def addDir(self, params):
+        CBaseHostClass.addDir(self, params)
+        self.wfRegister(params)
+
+    def addVideo(self, params):
+        CBaseHostClass.addVideo(self, params)
+        self.wfRegister(params)
+
+    def addAudio(self, params):
+        CBaseHostClass.addAudio(self, params)
+        self.wfRegister(params)
+
+    def _propagateEpisodeWatchedState(self, item):
+        # called by WatchedFlagHostMixin on play start / completion and by
+        # GenericFolderWatchedHostMixin.performCustomAction on a MENU toggle
+        try:
+            if not isinstance(item, dict) or getattr(self, 'watchedHelper', None) is None:
+                return
+            key = self._getWatchedKeyForItem(item)
+            startKey = self.wfFolderParent.get(key, '') or str(item.get('parent_key', '') or '')
+            if startKey != '':
+                self.watchedHelper.propagateFolderChain(startKey, self.wfFolderChildren, self.wfFolderParent)
+        except Exception:
+            printExc()
+
+
+class GenericFolderWatchedHostMixin(WatchedFlagHostMixin):
+    # IPTVHost side - mix in BEFORE CHostBase.
+    # Requires __init__ to set self.cachedRet, self.refreshAfterWatchedFlagChange
+    # and self.watchedHelper (same IPTVWatchedHelper host name as the scraper).
+
+    def performCustomAction(self, privateData):
+        ret = self.watchedHelper.performCustomAction(privateData)
+        if ret.status == RetHost.OK:
+            self.refreshAfterWatchedFlagChange = True
+            try:
+                idx = privateData.get('item_index', -1)
+                if 0 <= idx < len(self.host.currList):
+                    self.host._propagateEpisodeWatchedState(self.host.currList[idx])
+            except Exception:
+                printExc()
+        return ret

--- a/IPTVPlayer/tools/iptvwatchedhelper.py
+++ b/IPTVPlayer/tools/iptvwatchedhelper.py
@@ -620,3 +620,60 @@ class IPTVWatchedHelper(object):
         except Exception:
             printExc()
         self.dumpDebugCalls()
+
+    ###################################################
+    # generic folder-tree propagation (by key, no item dicts / no data model)
+    #
+    # Used by the recursive folder-style hosts (ARD/ZDF/ARTE/ORF/SRG mediatheken)
+    # that have no explicit series/season/episode structure: a plain episode gets
+    # marked as usual and its enclosing folders' dot/checkmark is then recomputed
+    # by walking a breadcrumb chain of folder keys the host accumulates while the
+    # user browses (in-memory, per session - see iptvwatchedfoldermixin.py).
+    ###################################################
+    def recomputeKeyState(self, parentKey, childKeys):
+        # set parentKey's marker purely from its children's current marker state:
+        # every child watched -> watched, some progress -> started, nothing -> cleared
+        self._dbgCall('recomputeKeyState')
+        try:
+            if not self.isMarkingAllowed():
+                return False
+            parentKey = self._normalizeKey(parentKey)
+            normChildKeys = []
+            for childKey in childKeys or []:
+                childKey = self._normalizeKey(childKey)
+                if childKey != '':
+                    normChildKeys.append(childKey)
+            if parentKey == '' or len(normChildKeys) == 0:
+                return False
+            states = [self.getWatchedState(childKey) for childKey in normChildKeys]
+            scratch = {}
+            if all(state == 'watched' for state in states):
+                return self.markItemWatched(scratch, parentKey)
+            if any(state != 'none' for state in states):
+                return self._writeStartedMarker(scratch, parentKey)
+            return self.unmarkItemWatched(scratch, parentKey)
+        except Exception:
+            printExc()
+        return False
+
+    def propagateFolderChain(self, startKey, folderChildren, folderParent, maxDepth=16):
+        # walk a chain of folder keys upwards (child -> parent -> ...), recomputing
+        # each level from its known children; both maps are usually partial (only
+        # what has been browsed this session) - a missing link just stops the walk
+        self._dbgCall('propagateFolderChain')
+        try:
+            if not self.isMarkingAllowed():
+                return
+            key = self._normalizeKey(startKey)
+            seen = set()
+            depth = 0
+            while key != '' and key not in seen and depth < maxDepth:
+                seen.add(key)
+                depth += 1
+                childKeys = folderChildren.get(key)
+                if childKeys:
+                    self.recomputeKeyState(key, list(childKeys))
+                key = self._normalizeKey(folderParent.get(key, ''))
+        except Exception:
+            printExc()
+        self.dumpDebugCalls()

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.01.01"
+IPTV_VERSION = "2026.09.02.01"


### PR DESCRIPTION
## Watched / playback status for ARD, ZDF, ARTE, ORF ON, SRG SSR

The "mark as watched" / "playback started" feature (already in FilmPalast, serienstream.to, YouTube) now works in all five mediathek hosts:

- MENU key on an episode -> Set watched / Unset watched.
- Starting playback marks the episode started (dot); crossing ~95 % marks it watched (check).
- Folder propagation: the dot/check moves up the folder chain - episode ->
  season folder -> show folder - as far as the chain is known in the current browsing session (these APIs have no persistent series/season/episode model, so it is in-memory per session). Top-level navigation rows are excluded.
- Uses the existing global options "Allow watched flag to be set" and the viewed/started colors.
- New shared code: tools/iptvwatchedfoldermixin.py, plus recomputeKeyState() / propagateFolderChain() in tools/iptvwatchedhelper.py.

## Sidecar .txt / .jpg

- A .txt (synopsis + metadata) and a .jpg (poster) are now written next to downloads / recordings for ARD, ZDF, ARTE, ORF, SRG and hdfilme - the same mechanism FilmPalast/serienstream already use.
- The mediathek hosts build the text from the detail/player response they already fetch (full synopsis) plus the item description and icon.
- Controlled by the existing global option "Create sidecar files (.txt/.jpg)".
- New producer helpers buildSidecarFromItem() / applySidecarToLinks() in libs/urlmetahelper.py (next to the existing sidecar code, not in the download-manager layer).

## One global name / filename normalization switch

- New global option "Normalize item / file names (Show - SxxExx - Title)" (normalize_media_names, on by default).
- Media-server friendly titles - and, since the download filename is derived from the title, normalized filenames too:
  - Show - S01E05 - Episode Title  when season/episode are known
  - Title (Year)  for movies
  - Show - Episode Title (2026-09-02)  for dated episodes
  - trailing "| available until ..." clutter removed
- Defensive: it augments the existing label and falls back to the original title on any doubt.
- Replaces serienstream.to's own "Use legacy title format" option (removed). hdfilme now honours the switch too (previously always on).
- tools/iptvmediathekmeta.py -> tools/iptvnaming.py; shared primitives extractNum / formatSxxExx / parseSxxExx / stripLeadingSxxExx are now used by hdfilme, serienstream and the mediathek hosts.

-------------------------------------------------------------------------------

## Wiedergabe-Status fuer ARD, ZDF, ARTE, ORF ON, SRG SSR

Die "als gesehen markieren" / "Wiedergabe gestartet"-Funktion (bisher nur FilmPalast, serienstream.to, YouTube) gibt es jetzt in allen fuenf Mediathek-Hosts:

- MENU-Taste auf einer Episode -> Gesehen setzen / Gesehen entfernen.
- Wiedergabestart markiert die Episode als gestartet (Punkt); ab ca. 95 % als gesehen (Haken).
- Ordner-Propagation: Punkt/Haken wandert die Ordner-Kette hoch - Episode ->
  Staffel-Ordner -> Sendungs-Ordner - so weit die Kette in der laufenden Sitzung bekannt ist (diese APIs haben kein festes Serie/Staffel/Episode- Modell, daher nur im Speicher pro Sitzung). Nav-Eintraege der obersten Ebene sind ausgenommen.
- Nutzt die vorhandenen globalen Optionen "Gesehen-Markierung erlauben" und die Farben fuer gesehen/gestartet.
- Neuer geteilter Code: tools/iptvwatchedfoldermixin.py sowie recomputeKeyState() / propagateFolderChain() in tools/iptvwatchedhelper.py.

## Sidecar .txt / .jpg

- Neben Downloads / Aufnahmen werden jetzt eine .txt (Inhaltsangabe + Metadaten) und eine .jpg (Poster) abgelegt - fuer ARD, ZDF, ARTE, ORF, SRG und hdfilme - gleiche Mechanik wie bei FilmPalast/serienstream.
- Die Mediathek-Hosts bauen den Text aus der ohnehin geholten Detail-/Player- Antwort (volle Synopsis) plus Beschreibung und Icon.
- Gesteuert ueber die vorhandene globale Option "Sidecar-Dateien erstellen (.txt/.jpg)".
- Neue Producer-Helfer buildSidecarFromItem() / applySidecarToLinks() in libs/urlmetahelper.py (zum bestehenden Sidecar-Code, nicht in die Download-Manager-Schicht).

## Ein globaler Schalter fuer Namens-/Dateinamen-Normalisierung

- Neue globale Option "Namen von Eintraegen/Dateien normalisieren (Show - SxxExx - Titel)" (normalize_media_names, standardmaessig an).
- Media-Server-taugliche Titel - und da der Download-Dateiname aus dem Titel abgeleitet wird, auch normalisierte Dateinamen:
  - Show - S01E05 - Episodentitel  wenn Staffel/Folge bekannt
  - Titel (Jahr)  bei Filmen
  - Show - Episodentitel (2026-09-02)  bei datierten Folgen
  - "| verfuegbar bis ..."-Anhang wird entfernt
- Defensiv: erweitert nur das bestehende Label und faellt im Zweifel auf den Originaltitel zurueck.
- Ersetzt die eigene Option "Altes Titelformat verwenden" von serienstream.to (entfernt). hdfilme beachtet den Schalter jetzt ebenfalls (vorher immer an).
- tools/iptvmediathekmeta.py -> tools/iptvnaming.py; geteilte Primitiven extractNum / formatSxxExx / parseSxxExx / stripLeadingSxxExx werden nun von hdfilme, serienstream und den Mediathek-Hosts genutzt.