### PR TITLE
Hoster updates 2026-09: filmpalast / kinoger / kinoking / cine.to / h…

### DIFF
--- a/IPTVPlayer/hosts/hostcineto.py
+++ b/IPTVPlayer/hosts/hostcineto.py
@@ -25,9 +25,9 @@ import re
 ###################################################
 config.plugins.iptvplayer.api_key_9kweu = ConfigText(default="", fixed_size=False)
 config.plugins.iptvplayer.api_key_2captcha = ConfigText(default="", fixed_size=False)
-config.plugins.iptvplayer.cineto_bypassrecaptcha = ConfigSelection(default="", choices=[("", _("None")),
-                                                                                          ("9kw.eu", "https://9kw.eu/"),
-                                                                                          ("2captcha.com", "https://2captcha.com/")])
+config.plugins.iptvplayer.cineto_bypassrecaptcha = ConfigSelection(default="mye2i", choices=[("mye2i", "MyE2i (solve on your phone/PC)"),
+                                                                                            ("9kw.eu", "https://9kw.eu/"),
+                                                                                            ("2captcha.com", "https://2captcha.com/")])
 
 
 def GetConfigList():
@@ -263,7 +263,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
             descTab = []
             tmp = data.get('year', '')
             if tmp != '':
-                descTab.append(tmp)
+                descTab.append(str(tmp))
 
             tmp = data.get('duration', '')
             if tmp != '':
@@ -296,7 +296,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
                 lang = langsDict.get(langId, langId)
                 langName = lang
                 trailerUrl = data.get('trailer_%s' % lang, '')
-                desc = ' | '.join(descTab) + '[/br]' + data.get('plot_%s' % lang, '')
+                desc = ' | '.join(str(x) for x in descTab) + '[/br]' + str(data.get('plot_%s' % lang, ''))
                 baseTitle = data['title']
 
                 if trailerUrl != '':
@@ -350,7 +350,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
                 quality = qualityMap.get(quality, quality)
                 for idx in range(1, len(links), 1):
                     name = '[%s] %s' % (quality, hosting)
-                    url = self.getFullUrl('/out/' + links[idx])
+                    url = self.getFullUrl('/out/' + str(links[idx]))
                     retTab.append({'name': name, 'url': url, 'need_resolve': 1})
         except Exception:
             printExc()
@@ -386,7 +386,9 @@ class CineTO(CBaseHostClass, CaptchaHelper):
                 else:
                     sitekey = self.cm.ph.getSearchGroups(data, r'''gcaptchaSetup\s*?\(\s*?['"]([^'^"]+?)['"]''')[0]
                     if sitekey != '':
-                        token, errorMsgTab = self.processCaptcha(sitekey, self.cm.meta['url'], bypassCaptchaService=config.plugins.iptvplayer.cineto_bypassrecaptcha.value)
+                        # cine.to's reCAPTCHA v2 can't be solved by CaptchaHelper's
+                        # internal fallback, so a bypass service is mandatory -> MyE2i
+                        token, errorMsgTab = self.processCaptcha(sitekey, self.cm.meta['url'], bypassCaptchaService=config.plugins.iptvplayer.cineto_bypassrecaptcha.value or 'mye2i')
 
                         if token != '':
                             params = MergeDicts(self.defaultParams, {'max_data_size': 0})

--- a/IPTVPlayer/hosts/hosthdfilmetv.py
+++ b/IPTVPlayer/hosts/hosthdfilmetv.py
@@ -97,6 +97,17 @@ class HDFilmeTV(CBaseHostClass):
             url = "https:" + url if url.startswith("//") else url
             if "/vod/" in url:
                 continue
+            if "meinecloud.click/movie/" in url:
+                # meinecloud is a mirror-list page, not a hoster - expand it to the
+                # real hoster embeds it links (voe / dr0pstream / mixdrop / ...)
+                mts, mdata = self.getPage(url)
+                if mts:
+                    for sub in re.findall(r'data-link="([^"]+)"', mdata):
+                        sub = "https:" + sub if sub.startswith("//") else sub
+                        if "meinecloud" in sub or "/vod/" in sub or not self.cm.isValidUrl(sub):
+                            continue
+                        urltab.append({"name": self.up.getHostName(sub).capitalize(), "url": strwithmeta(sub, {"Referer": "https://meinecloud.click/"}), "need_resolve": 1})
+                continue
             title = self.up.getHostName(url).capitalize()
             if "youtube" in url:
                 title = "Trailer"

--- a/IPTVPlayer/hosts/hostkinoking.py
+++ b/IPTVPlayer/hosts/hostkinoking.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 04.12.2025 - Mr.X
+# Last Modified: 02.09.2026 - rewrite for the redesigned kinoking.cc
+#   (Tailwind "fav-data-source" cards; movie.php server picker via ?id=..&link=<key>
+#    -> per-server <iframe> embed; series.php?id=..&season=.. -> inline
+#    allEpisodesData JSON with video_links) + watched flag / sidecar / name norm.
 import json
 import re
 
@@ -8,6 +11,11 @@ from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT
 from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote_plus
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedfoldermixin import GenericFolderWatchedScraperMixin, GenericFolderWatchedHostMixin
+from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import formatSxxExx
+from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromItem, applySidecarToLinks, sidecarFromUrlMeta, decorateResolvedLinkItems
+from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled, IsMediaNamingNormalized
 
 
 def GetConfigList():
@@ -15,16 +23,50 @@ def GetConfigList():
 
 
 def gettytul():
-    return "https://KinoKing.cc/"
+    return "https://kinoking.cc/"
 
 
-class KinoKing(CBaseHostClass):
+class KinoKing(GenericFolderWatchedScraperMixin, CBaseHostClass):
     def __init__(self):
         CBaseHostClass.__init__(self, {"history": "KinoKing", "cookie": "KinoKing.cookie"})
         self.HEADER = self.cm.getDefaultHeader()
         self.defaultParams = {"header": self.HEADER, "max_data_size": 1024 * 1024, "use_cookie": True, "load_cookie": True, "save_cookie": True, "cookiefile": self.COOKIE_FILE}
         self.MAIN_URL = gettytul()
-        self.MENU = [{"category": "list_items", "title": _("Movies"), "url": self.getFullUrl("index.php?genre=current-movies&filter=movies&view=grid&page=")}, {"category": "list_items", "title": _("Series"), "url": self.getFullUrl("index.php?genre=recently-added&filter=series&view=grid&page=")}] + self.searchItems()
+        self.MENU = [{"category": "list_items", "title": _("Movies"), "url": self.getFullUrl("index.php?genre=current-movies&filter=movies&view=grid&page=")},
+                     {"category": "list_items", "title": _("Series"), "url": self.getFullUrl("index.php?genre=recently-added&filter=series&view=grid&page=")}] + self.searchItems()
+
+        self.watchedHelper = IPTVWatchedHelper("kinoking")
+        self.wfInitFolderCache()
+
+    ###################################################
+    # watched flag
+    ###################################################
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict):
+                return ""
+            category = cItem.get("category", "")
+            if cItem.get("type", "") in ("video", "audio"):
+                if category == "episode":
+                    sid = str(cItem.get("s_id", "") or "").strip()
+                    season = str(cItem.get("season", "") or "").strip()
+                    epnum = str(cItem.get("ep_num", "") or "").strip()
+                    if sid and epnum:
+                        return "episode:%s|%s|%s" % (sid, season, epnum)
+                    vl = str(cItem.get("video_links", "") or "").strip()
+                    return "episode:%s" % vl if vl else ""
+                url = str(cItem.get("url", "") or "").strip()
+                return "video:%s" % url if url else ""
+            if category == "kk_series":
+                url = str(cItem.get("url", "") or "").strip()
+                return "series:%s" % url if url else ""
+            if category == "kk_season":
+                url = str(cItem.get("url", "") or "").strip()
+                return "season:%s" % url if url else ""
+            return ""
+        except Exception:
+            printExc()
+        return ""
 
     def getPage(self, baseUrl, addParams=None, post_data=None):
         if addParams is None:
@@ -32,116 +74,198 @@ class KinoKing(CBaseHostClass):
         addParams["cloudflare_params"] = {"cookie_file": self.COOKIE_FILE, "User-Agent": self.HEADER.get("User-Agent")}
         return self.cm.getPageCFProtection(baseUrl, addParams, post_data)
 
-    def getFullIconUrl(self, url):
-        url = self.getFullUrl(url)
-        if url == "":
-            return ""
-        cookieHeader = self.cm.getCookieHeader(self.COOKIE_FILE)
-        return strwithmeta(url, {"Cookie": cookieHeader, "User-Agent": self.HEADER.get("User-Agent")})
-
     def listItems(self, cItem):
         printDBG("KinoKing.listItems |%s|" % cItem)
         url = cItem["url"]
         page = cItem.get("page", 1)
-        sts, data = self.getPage(url if "?search" in url else url + str(page))
+        isSearch = "search=" in url
+        sts, data = self.getPage(url if isSearch else url + str(page))
         if not sts:
             return
-        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="content-card', "</div></div>")
-        for item in data:
-            icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(item, r'src="([^"]+)')[0])
-            title = self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, 'title">([^<]+)')[0])
-            url = self.cm.ph.getSearchGroups(item, r"playMovie[^>](\d+)")[0] or self.cm.ph.getSearchGroups(item, r"""playContent[^>]\d+,\s*'[^']+',\s*(\d+)""")[0]
-            if url:
-                url = "%smovie.php?id=%s" % (gettytul(), url) if "playMovie" in item else "%sseries.php?id=%s" % (gettytul(), url)
+        normalize = IsMediaNamingNormalized()
+        cards = re.findall(r'<div class="[^"]*fav-data-source[^"]*"([^>]+)>', data)
+        cnt = 0
+        for attrs in cards:
+            cid = self.cm.ph.getSearchGroups(attrs, r'data-id="(\d+)"')[0]
+            ctype = self.cm.ph.getSearchGroups(attrs, r'data-type="([^"]+)"')[0]
+            if cid == "" or ctype == "":
+                continue
+            title = self.cleanHtmlStr(self.cm.ph.getSearchGroups(attrs, r'data-title="([^"]*)"')[0])
+            icon = self.cm.ph.getSearchGroups(attrs, r'data-img="([^"]*)"')[0]
+            quality = self.cm.ph.getSearchGroups(attrs, r'data-quality="([^"]*)"')[0]
+            cnt += 1
             params = dict(cItem)
-            params.update({"good_for_fav": True, "category": "video", "title": title, "url": url, "icon": icon})
-            if "series" in url:
-                params.update({"category": "list_seasons"})
+            params.pop("page", None)
+            if ctype == "series":
+                params.update({"good_for_fav": True, "category": "kk_series", "title": title, "s_id": cid,
+                               "url": "%sseries.php?id=%s" % (self.MAIN_URL, cid), "icon": icon, "desc": ""})
                 self.addDir(params)
             else:
+                dispTitle = title if (normalize or not quality) else "%s [%s]" % (title, quality)
+                params.update({"good_for_fav": True, "category": "movie", "title": dispTitle, "s_title": title,
+                               "url": "%smovie.php?id=%s" % (self.MAIN_URL, cid), "icon": icon, "desc": ""})
                 self.addVideo(params)
-        if "?search" not in url:
+        if not isSearch and cnt >= 24:
             params = dict(cItem)
             params.update({"good_for_fav": False, "title": _("Next page"), "page": page + 1})
             self.addDir(params)
 
-    def Seasons(self, cItem):
-        printDBG("KinoKing.Seasons")
-        url = cItem["url"]
-        sts, data = self.getPage(url)
+    def listSeasons(self, cItem):
+        printDBG("KinoKing.listSeasons")
+        sts, data = self.getPage(cItem["url"])
         if not sts:
             return
-        desc = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, '<meta name="description" content="([^"]+)')[0])
-        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="season', "content-card")[0]
-        data = re.compile(r'href="([^"]+).*?Staffel\s*(\d+)', re.DOTALL).findall(data)
-        for url, title in data:
-            title = cItem["title"] + " - Season " + title
-            url = self.getFullUrl("series.php" + url)
+        desc = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, r'<meta name="description" content="([^"]+)')[0])
+        seasons = []
+        for snum in re.findall(r'[?&]season=(\d+)', data):
+            if snum not in seasons:
+                seasons.append(snum)
+        if not seasons:
+            seasons = ["1"]
+        for snum in seasons:
             params = dict(cItem)
-            params.update({"good_for_fav": True, "category": "list_episodes", "title": title, "url": url, "desc": desc})
+            params.update({"good_for_fav": True, "category": "kk_season", "title": "%s - %s %s" % (cItem["title"], _("Season"), snum),
+                           "s_title": cItem["title"], "season": snum, "url": "%s&season=%s" % (cItem["url"], snum), "desc": desc})
             self.addDir(params)
 
-    def Episodes(self, cItem):
-        printDBG("KinoKing.Episodes")
-        url = cItem["url"]
-        sts, data = self.getPage(url)
+    def listEpisodes(self, cItem):
+        printDBG("KinoKing.listEpisodes")
+        sts, data = self.getPage(cItem["url"])
         if not sts:
             return
-        data = re.compile(r"""onclick="playEpisode[^>](\d+),\s*'([^']+)""", re.DOTALL).findall(data)
-
-        for url, title in data:
-            title = cItem["title"] + " - " + title
-            url = gettytul() + "api/episode-navigation.php?episode_id=" + url
-            self.getFullUrl("series.php" + url)
+        m = re.search(r'allEpisodesData\s*=\s*(\[.*?\])\s*;', data, re.DOTALL)
+        if not m:
+            return
+        try:
+            episodes = json.loads(m.group(1))
+        except Exception:
+            printExc()
+            return
+        normalize = IsMediaNamingNormalized()
+        sTitle = cItem.get("s_title", cItem["title"])
+        wantSeason = str(cItem.get("season", "") or "").strip()
+        for ep in episodes:
+            if wantSeason and str(ep.get("season_number", "")).strip() != wantSeason:
+                continue
+            if not ep.get("video_links"):
+                continue
+            epName = self.cleanHtmlStr(ep.get("name", "") or "")
+            tag = ""
+            if normalize and ep.get("season_number") and ep.get("episode_number"):
+                tag = formatSxxExx(ep["season_number"], ep["episode_number"])
+            if tag and epName:
+                title = "%s - %s - %s" % (sTitle, tag, epName)
+            elif tag:
+                title = "%s - %s" % (sTitle, tag)
+            elif epName:
+                title = "%s - %s" % (sTitle, epName)
+            else:
+                title = sTitle
             params = dict(cItem)
-            params.update({"good_for_fav": True, "title": title, "url": url, "desc": url})
+            params.update({"good_for_fav": True, "category": "episode", "title": title, "url": "",
+                           "s_id": cItem.get("s_id", ""), "ep_num": ep.get("episode_number", ""),
+                           "video_links": ep.get("video_links"), "desc": self.cleanHtmlStr(ep.get("overview", "") or "")})
             self.addVideo(params)
 
     def listSearchResult(self, cItem, searchPattern, searchType):
-        printDBG("KinoKing.listSearchResult cItem[%s], searchPattern[%s] searchType[%s]" % (cItem, searchPattern, searchType))
+        printDBG("KinoKing.listSearchResult [%s]" % searchPattern)
         cItem = dict(cItem)
         cItem["url"] = self.getFullUrl("index.php?search=%s" % urllib_quote_plus(searchPattern))
         self.listItems(cItem)
 
+    def _appendHosterLinks(self, urltab, raw, referer):
+        for url in raw:
+            url = url.strip()
+            if url == "":
+                continue
+            url = "https:" + url if url.startswith("//") else url
+            if not self.cm.isValidUrl(url):
+                continue
+            urltab.append({"name": self.up.getHostName(url).capitalize(), "url": strwithmeta(url, {"Referer": referer}), "need_resolve": 1})
+
     def getLinksForVideo(self, cItem):
         printDBG("KinoKing.getLinksForVideo [%s]" % cItem)
         urltab = []
-        link = cItem["url"]
-        sts, data = self.getPage(link, self.defaultParams)
-        if not sts:
-            return []
-        if "episode_id" in link:
-            data = json.loads(data)
-            url = data.get("links")[0]
+        sidecarTxt = cItem.get("desc", "")
+
+        videoLinks = cItem.get("video_links")
+        if videoLinks:
+            # series episode - video_links is a hoster url (or a json list / separated list)
+            raw = []
+            try:
+                parsed = json.loads(videoLinks)
+                raw = parsed if isinstance(parsed, list) else [str(parsed)]
+            except Exception:
+                raw = re.split(r"[\s,;|]+", str(videoLinks))
+            self._appendHosterLinks(urltab, raw, self.MAIN_URL)
         else:
-            data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="movie-container">', " </div>")[0]
-            url = self.cm.ph.getSearchGroups(data, 'src="([^"]+)')[0]
-        if url:
-            urltab.append({"name": self.up.getHostName(url).capitalize(), "url": strwithmeta("https:" + url if url.startswith("//") else url, {"Referer": gettytul()}), "need_resolve": 1})
-        return urltab
+            # movie - movie.php renders a server picker; each "?id=<id>&link=<key>"
+            # variant swaps the player <iframe> to a different mirror. Collect them all.
+            sts, data = self.getPage(cItem["url"], self.defaultParams)
+            if not sts:
+                return []
+            if not sidecarTxt:
+                sidecarTxt = self.cleanHtmlStr(self.cm.ph.getSearchGroups(data, r'<meta name="description" content="([^"]+)')[0])
+
+            pages = [data]
+            seenQs = set()
+            for qs in re.findall(r'href="\?(id=\d+&(?:amp;)?link=[^"#]+)"', data):
+                qs = qs.replace("&amp;", "&")
+                if qs in seenQs:
+                    continue
+                seenQs.add(qs)
+                if len(seenQs) > 10:
+                    break
+                sts2, data2 = self.getPage("%smovie.php?%s" % (self.MAIN_URL, qs), self.defaultParams)
+                if sts2 and data2:
+                    pages.append(data2)
+
+            embeds = []
+            for pg in pages:
+                for frame in re.findall(r'<iframe[^>]+src="([^"]+)"', pg):
+                    frame = frame.replace("&amp;", "&")
+                    frame = "https:" + frame if frame.startswith("//") else frame
+                    if frame not in embeds and self.cm.isValidUrl(frame):
+                        embeds.append(frame)
+
+            for frame in embeds:
+                if "meinecloud.click" in frame and "/movie/" in frame:
+                    mts, mdata = self.cm.getPage(frame, {"header": self.HEADER})
+                    if mts and mdata:
+                        subs = []
+                        for sub in re.findall(r'data-link="([^"]+)"', mdata):
+                            if "meinecloud" in sub or "/vod/" in sub:
+                                continue
+                            subs.append(sub)
+                        self._appendHosterLinks(urltab, subs, "https://meinecloud.click/")
+                elif re.search(r'(?:vidsync|cinesrc)\.', frame):
+                    printDBG("KinoKing: aggregator embed uebersprungen [%s]" % frame)
+                else:
+                    self._appendHosterLinks(urltab, [frame], self.MAIN_URL)
+
+        return applySidecarToLinks(urltab, buildSidecarFromItem(cItem, IsSidecarEnabled(), sidecarTxt))
 
     def getVideoLinks(self, videoUrl):
         printDBG("KinoKing.getVideoLinks [%s]" % videoUrl)
         if self.cm.isValidUrl(videoUrl):
-            return self.up.getVideoLinkExt(videoUrl)
+            sidecar = sidecarFromUrlMeta(videoUrl, IsSidecarEnabled())
+            return decorateResolvedLinkItems(self.up.getVideoLinkExt(videoUrl), sidecar)
         return []
 
     def handleService(self, index, refresh=0, searchPattern="", searchType=""):
         CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
         name = self.currItem.get("name", "")
         category = self.currItem.get("category", "")
-        printDBG("handleService start\nhandleService: name[%s], category[%s] " % (name, category))
+        printDBG("KinoKing.handleService name[%s] category[%s]" % (name, category))
         self.currList = []
         if name is None:
             self.listsTab(self.MENU, {"name": "category"})
         elif category == "list_items":
             self.listItems(self.currItem)
-        elif category == "list_seasons":
-            self.Seasons(self.currItem)
-        elif category == "list_episodes":
-            self.Episodes(self.currItem)
-        elif category == "list_value":
-            self.listValue(self.currItem)
+        elif category == "kk_series":
+            self.listSeasons(self.currItem)
+        elif category == "kk_season":
+            self.listEpisodes(self.currItem)
         elif category in ["search", "search_next_page"]:
             cItem = dict(self.currItem)
             cItem.update({"search_item": False, "name": "category"})
@@ -153,6 +277,9 @@ class KinoKing(CBaseHostClass):
         CBaseHostClass.endHandleService(self, index, refresh)
 
 
-class IPTVHost(CHostBase):
+class IPTVHost(GenericFolderWatchedHostMixin, CHostBase):
     def __init__(self):
         CHostBase.__init__(self, KinoKing(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper("kinoking")

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from ast import literal_eval
 import base64
 from binascii import hexlify, unhexlify
 import codecs
 from hashlib import sha256
-from random import choice as random_choice, uniform
+from random import choice as random_choice, randint, uniform
 import re
 import string
 import struct
@@ -19,6 +20,7 @@ from Plugins.Extensions.IPTVPlayer.libs import ph, pyaes
 from Plugins.Extensions.IPTVPlayer.libs.aesgcm import python_aesgcm
 from Plugins.Extensions.IPTVPlayer.libs.crypto.cipher.aes_cbc import AES_CBC
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads, dumps as json_dumps
+from Plugins.Extensions.IPTVPlayer.libs.ecdsa import NIST256p as ECDSA_NIST256p, SigningKey as ECDSA_SigningKey
 from Plugins.Extensions.IPTVPlayer.libs.jsunpack import get_packed_data
 from Plugins.Extensions.IPTVPlayer.libs.pCommon import common
 from Plugins.Extensions.IPTVPlayer.libs.recaptcha_v2 import UnCaptchaReCaptcha
@@ -238,6 +240,7 @@ class urlparser:
             "bysevepoin.com": self.pp.parserBYSE,
             "bysewihe.com": self.pp.parserBYSE,
             "bysezejataos.com": self.pp.parserBYSE,
+            "bysezoxexe.com": self.pp.parserBYSE,
             # c
             "c1z39.com": self.pp.parserBYSE,
             "cavanhabg.com": self.pp.parserJWPLAYER,
@@ -245,6 +248,7 @@ class urlparser:
             "cdn1.site": self.pp.parserJWPLAYER,
             "cdnwish.com": self.pp.parserJWPLAYER,
             "chuckle-tube.com": self.pp.parserVOESX,
+            "cinegrab.com": self.pp.parserBYSE,
             "cloud.mail.ru": self.pp.parserCOUDMAILRU,
             "coflix.upn.one": self.pp.parserSBS,
             "coverapi.store": self.pp.parserCOVERAPI,
@@ -289,6 +293,7 @@ class urlparser:
             "doply.net": self.pp.parserDOOD,
             "dpstream.fyi": self.pp.parserJWPLAYER,
             "dr0pstream.com": self.pp.parserJWPLAYER,
+            "drakkar.st": self.pp.parserDRAKKAR,
             "dropload.co": self.pp.parserJWPLAYER,
             "dropload.io": self.pp.parserJWPLAYER,
             "dropload.pro": self.pp.parserJWPLAYER,
@@ -328,12 +333,14 @@ class urlparser:
             "fileone.tv": self.pp.parserFILEONETV,
             "file-upload.org": self.pp.parserJWPLAYER,
             "filma365.strp2p.site": self.pp.parserSBS,
+            "firestream.to": self.pp.parserFIRESTREAM,
             "flaswish.com": self.pp.parserJWPLAYER,
             "flyfile.app": self.pp.parserFLYFILE,
             "forafile.com": self.pp.parserJWPLAYER,
             "freedisc.pl": self.pp.parserFREEDISC,
             "fsdcmo.sbs": self.pp.parserJWPLAYER,
             "fsst.online": self.pp.parserSST,
+            "furher.in": self.pp.parserBYSE,
             # g
             "ghbrisk.com": self.pp.parserJWPLAYER,
             "goodstream.one": self.pp.parserJWPLAYER,
@@ -362,10 +369,12 @@ class urlparser:
             "jodwish.com": self.pp.parserJWPLAYER,
             "justupload.io": self.pp.parserJWPLAYER,
             # k
+            "kerapoxy.cc": self.pp.parserBYSE,
             "kinoger.be": self.pp.parserJWPLAYER,
             "kinoger.embed4me.vip": self.pp.parserSBS,
             "kinoger.seekplays.pro": self.pp.parserSBS,
             "kinoger.p2pplay.pro": self.pp.parserSBS,
+            "kinoger.pw": self.pp.parserSTREAMUP,
             "kinoger.re": self.pp.parserSBS,
             "kinoger.ru": self.pp.parserVOESX,
             "kravaxxa.com": self.pp.parserJWPLAYER,
@@ -415,6 +424,7 @@ class urlparser:
             "moflix-stream.link": self.pp.parserBYSE,
             "moflix.rpmplay.xyz": self.pp.parserSBS,
             "moflix.upns.xyz": self.pp.parserSBS,
+            "moonmov.pro": self.pp.parserBYSE,
             "movearnpre.com": self.pp.parserJWPLAYER,
             "moviesapi.club": self.pp.parserVIDSRC,
             "moviesapi.to": self.pp.parserVIDSRC,
@@ -430,11 +440,13 @@ class urlparser:
             "obeywish.com": self.pp.parserJWPLAYER,
             "odnoklassniki.ru": self.pp.parserOKRU,
             "odysee.com": self.pp.parserJWPLAYER,
+            "odysseusa.cc": self.pp.parserSTREAMUP,
             "ok.ru": self.pp.parserOKRU,
             # p
             "peytonepre.com": self.pp.parserJWPLAYER,
             "player.upn.one": self.pp.parserSBS,
             "playerwish.com": self.pp.parserJWPLAYER,
+            "playmate.to": self.pp.parserPLAYMATE,
             "playmogo.com": self.pp.parserDOOD,
             "polsatsport.pl": self.pp.parserJWPLAYER,
             "poophq.com": self.pp.parserVEEV,
@@ -448,12 +460,14 @@ class urlparser:
             # s
             "s3taku.pro": self.pp.parserJWPLAYER,
             "savefiles.com": self.pp.parserJWPLAYER,
+            "sb1254w9megshle.org": self.pp.parserBYSE,
             "scloud.online": self.pp.parserSTREAMTAPE,
             "sendvid.com": self.pp.parserJWPLAYER,
             "sfastwish.com": self.pp.parserJWPLAYER,
             "sharevideo.pl": self.pp.parserSHAREVIDEO,
             "shavetape.cash": self.pp.parserSTREAMTAPE,
             "shiid4u.upn.one": self.pp.parserSBS,
+            "smdfs40r.skin": self.pp.parserBYSE,
             "smoothpre.com": self.pp.parserJWPLAYER,
             "soundcloud.com": self.pp.parserSOUNDCLOUDCOM,
             "sportsonline.si": self.pp.parserJWPLAYER,
@@ -468,6 +482,7 @@ class urlparser:
             "streamhihi.com": self.pp.parserJWPLAYER,
             "streamhls.to": self.pp.parserJWPLAYER,
             "streamlyplayer.online": self.pp.parserBYSE,
+            "streamlyplayero.online": self.pp.parserBYSE,
             "streamix.so": self.pp.parserSTREAMUP,
             "streamnoads.com": self.pp.parserSTREAMTAPE,
             "streamruby.com": self.pp.parserJWPLAYER,
@@ -563,6 +578,7 @@ class urlparser:
             "vidsrc-me.su": self.pp.parserVIDSRC,
             "vidsrcme.ru": self.pp.parserVIDSRC,
             "vidsrcme.su": self.pp.parserVIDSRC,
+            "vixeo.io": self.pp.parserVIXEO,
             "vixsrc.to": self.pp.parserVIXSRC,
             "vsrc.su": self.pp.parserVIDSRC,
             "vsembed.ru": self.pp.parserVIDSRC,
@@ -600,7 +616,7 @@ class urlparser:
             "youtube-nocookie.com": self.pp.parserYOUTUBE,
             "youtube.com": self.pp.parserYOUTUBE,
             # z
-            "z1ekv717.fun": self.pp.parserJWPLAYER
+            "z1ekv717.fun": self.pp.parserBYSE
         }
 
     @staticmethod
@@ -1899,10 +1915,11 @@ class pageParser(CaptchaHelper):
         printDBG("parserDOOD baseUrl [%s]" % baseUrl)
         HTTP_HEADER = self.cm.getDefaultHeader()
         urlParams = {"header": HTTP_HEADER}
-        urls = ["all3do.com", "d0000d.com", "d000d.com", "d0o0d.com", "d-s.io", "do0od.com", "dooodster.com", "doodstream.com", "doply.net", "dooood.com", "do7go.com", "ds2play.com", "ds2video.com", "dood.cx", "dood.la", "dood.li", "dood.pm", "dood.re", "dood.sh", "dood.so", "dood.stream", "dood.to", "dood.watch", "dood.work", "dood.wf", "dood.ws", "dood.yt", "doods.pro", "doodcdn.io", "vide0.net", "vidply.com", "vvide0.com"]
+        urls = ["all3do.com", "d0000d.com", "d000d.com", "d0o0d.com", "d-s.io", "do0od.com", "dooodster.com", "doodstream.com", "doply.net", "dooood.com", "do7go.com", "ds2play.com", "ds2video.com", "dood.cx", "dood.la", "dood.li", "dood.pm", "dood.re", "dood.sh", "dood.so", "dood.stream", "dood.to", "dood.watch", "dood.work", "dood.wf", "dood.ws", "dood.yt", "doods.pro", "doodcdn.io", "vide0.net", "vidply.com", "vvide0.com", "playmogo.com"]
         for url in urls:
             if url in baseUrl:
                 baseUrl = baseUrl.replace(url, "dsvplay.com")
+        baseUrl = baseUrl.replace("/w/", "/e/")  # watch page -> embed page
         host = "https://%s" % urlparser.getDomain(baseUrl, True)
         if "/d/" in baseUrl:
             sts, data = self.cm.getPage(baseUrl, urlParams)
@@ -1962,28 +1979,30 @@ class pageParser(CaptchaHelper):
                 urltabs.append(params)
         return urltabs
 
-    def parserSST(self, url):  # update 050626
+    def parserSST(self, url):  # update 020926
         printDBG("parserSST baseUrl[%s]" % url)
-        host = urlparser.getDomain(url, False)
         HTTP_HEADER = self.cm.getDefaultHeader()
-        sts, data = self.cm.getPage(url, {"header": HTTP_HEADER})
+        sts, data = self.cm.getPage(url, {"header": HTTP_HEADER, "with_metadata": True})
         if not sts:
             return []
+        host = urlparser.getDomain(getattr(data, "meta", {}).get("url", url), False)  # fsst.online -> incvideo1.online after redirect
+        meta = {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1]}
         urltab = []
-        urls = re.findall(r'<source[^>]*src="([^"]+)"[^>]*label="([^"]+)"', data)
-        if urls:
-            for url, q in urls:
-                url = urlparser.decorateUrl(url, {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1]})
-                urltab.append({"name": q, "url": url})
-        else:
-            url = re.search('file:"([^"]+)', data)
-            if url:
-                url = url.group(1)
-                if "[" in url:
-                    urls = re.findall(r"\[(\d+p)\](https?://[^\s,]+)", url)
-                    urltab.extend({"name": quality, "url": url} for quality, url in urls)
-            else:
-                urltab.append({"name": "360p", "url": url})
+        srcList = re.findall(r'<source[^>]*src="([^"]+)"[^>]*label="([^"]+)"', data)
+        if srcList:
+            for surl, q in srcList:
+                urltab.append({"name": q, "url": urlparser.decorateUrl(surl, dict(meta))})
+            return urltab
+        m = re.search(r'file\s*:\s*"([^"]+)"', data)
+        if not m:
+            return []
+        fileUrl = m.group(1)
+        if "[" in fileUrl:  # Playerjs multi-quality: [360p]url,[720p]url
+            for quality, qurl in re.findall(r"\[(\d+p)\](https?://[^\s,\]]+)", fileUrl):
+                urltab.append({"name": quality, "url": urlparser.decorateUrl(qurl, dict(meta))})
+        elif self.cm.isValidUrl(fileUrl):
+            q = self.cm.ph.getSearchGroups(data, r'default_quality\s*:\s*"([^"]+)')[0] or "MP4"
+            urltab.append({"name": q, "url": urlparser.decorateUrl(fileUrl, dict(meta))})
         return urltab
 
     def parserSBS(self, baseUrl):  # update 020126
@@ -2220,6 +2239,79 @@ class pageParser(CaptchaHelper):
                 urltab.append({"name": "MP4", "url": url})
         return urltab
 
+    def parserFIRESTREAM(self, baseUrl):  # add 020926 - firestream.to (filmpalast/kinoger "Firestream HD")
+        printDBG("parserFIRESTREAM baseUrl[%s]" % baseUrl)
+        urltab = []
+        host = urlparser.getDomain(baseUrl, False)
+        mid = self.cm.ph.getSearchGroups(baseUrl, r"/(?:e|v)/([0-9A-Za-z_-]+)")[0]
+        if mid == "":
+            return []
+        HTTP_HEADER = self.cm.getDefaultHeader()
+        embedUrl = "%se/%s" % (host, mid)
+        HTTP_HEADER["Referer"] = embedUrl
+        sts, data = self.cm.getPage(embedUrl, {"header": HTTP_HEADER})
+        if not sts:
+            return []
+        blob = self.cm.ph.getSearchGroups(data, r'id="token-blob"[^>]*>([^<]+)')[0].strip()
+        if blob == "":
+            return []
+        postHeader = dict(HTTP_HEADER)
+        postHeader.update({"Referer": embedUrl, "Origin": host[:-1], "Content-Type": "application/json"})
+        sts, data = self.cm.getPage("%sapi/videos/%s/resolve" % (host, mid), {"header": postHeader, "raw_post_data": True}, json_dumps({"blob": blob}))
+        if not sts:
+            return []
+        try:
+            data = json_loads(data)
+        except Exception:
+            printExc()
+            return []
+        for key, name in (("signedVideoUrl", "HD"), ("signedVideoSdUrl", "SD")):
+            url = data.get(key)
+            if not url:
+                continue
+            url = urlparser.decorateUrl(url, {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1]})
+            if ".m3u8" in url:
+                urltab.extend(getDirectM3U8Playlist(url))
+            else:
+                urltab.append({"name": name, "url": url})
+        return urltab
+
+    def parserPLAYMATE(self, baseUrl):  # add 020926 - playmate.to (filmpalast "Playmate HD")
+        printDBG("parserPLAYMATE baseUrl[%s]" % baseUrl)
+        urltab = []
+        subTracks = []
+        host = urlparser.getDomain(baseUrl, False)
+        mid = self.cm.ph.getSearchGroups(baseUrl, r"/(?:watch|embed|e|v)/([0-9A-Za-z]+)")[0]
+        if mid == "":
+            return []
+        HTTP_HEADER = self.cm.getDefaultHeader()
+        HTTP_HEADER.update({"Referer": "%sembed/%s" % (host, mid), "Origin": host[:-1], "Content-Type": "application/json"})
+        sts, data = self.cm.getPage("%sapi/s" % host, {"header": HTTP_HEADER, "raw_post_data": True}, json_dumps({"c": mid, "d": "web"}))
+        if not sts:
+            return []
+        try:
+            data = json_loads(data)
+        except Exception:
+            printExc()
+            return []
+        for sub in (data.get("kx") or []):
+            surl = sub.get("sf") or sub.get("file") or ""
+            if surl:
+                subTracks.append({"title": "", "url": "https:" + surl if surl.startswith("//") else surl, "lang": sub.get("sl") or sub.get("label") or ""})
+        url = data.get("sx")
+        if not url:
+            return []
+        meta = {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1], "external_sub_tracks": subTracks}
+        if ".m3u8" in url or "/hls/" in url or url.split("?")[0].endswith(".txt"):
+            # playmate's HLS master/variant playlists use a .txt extension AND the
+            # segments are disguised as .css/.js/.woff (anti-adblock). exteplayer3
+            # chokes on that; hlsdl handles it -> needs "[HLS/M3U8] buffering" enabled.
+            meta["iptv_proto"] = "m3u8"
+            urltab.append({"name": "HLS", "url": urlparser.decorateUrl(url, meta)})
+        else:
+            urltab.append({"name": "MP4", "url": urlparser.decorateUrl(url, meta)})
+        return urltab
+
     def parserSHAREVIDEO(self, url):  # add 160925
         printDBG("parserSHAREVIDEO baseUrl[%s]" % url)
         HTTP_HEADER = self.cm.getDefaultHeader()
@@ -2234,7 +2326,9 @@ class pageParser(CaptchaHelper):
             urltab.extend(getDirectM3U8Playlist(url))
         return urltab
 
-    def parserBYSE(self, baseUrl):  # fix 300526
+    def parserBYSE(self, baseUrl):  # fix 240826 - captcha/proof-of-work challenge support
+        UA = "Mozilla/5.0 (Linux; Android 10; TX6s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36"
+
         def fp(x, y, z):  # thx Gujal00
             v_id = hexlify(urandom(x)).decode()
             d_id = hexlify(urandom(x)).decode()
@@ -2261,43 +2355,337 @@ class pageParser(CaptchaHelper):
             t = list(map(ft, e))
             return b"".join(t)
 
+        def fh(v):
+            return b64urlencode(sha256(str(v).encode("ascii")).digest(), strip=True)
+
+        def wn(challenge):
+            sk = ECDSA_SigningKey.generate(curve=ECDSA_NIST256p, hashfunc=sha256)
+            vk = sk.verifying_key.to_string()
+            nonce = str(challenge.get("nonce") or "")
+            signature = sk.sign(nonce.encode(), hashfunc=sha256)
+            pub = {"crv": "P-256", "ext": True, "key_ops": ["verify"], "kty": "EC", "x": b64urlencode(vk[:32], strip=True), "y": b64urlencode(vk[32:], strip=True)}
+            r = uniform(0, 1)
+            return {
+                "viewer_id": "", "device_id": "", "challenge_id": challenge.get("challenge_id", ""), "nonce": nonce,
+                "signature": b64urlencode(signature, strip=True), "public_key": pub,
+                "client": {
+                    "user_agent": UA, "architecture": "arm", "bitness": "32", "platform": "Android", "platform_version": "10.0.0",
+                    "model": "TX6s", "ua_full_version": "137.0.7337.0",
+                    "brand_full_versions": [{"brand": "Chromium", "version": "137.0.7337.0"}],
+                    "pixel_ratio": 1, "screen_width": 1280, "screen_height": 720, "color_depth": 24,
+                    "languages": ["en-US"], "timezone": "America/New_York", "hardware_concurrency": 4, "device_memory": 2,
+                    "touch_points": 1, "webgl_vendor": "Google Inc. (ARM)", "webgl_renderer": "ANGLE (ARM, Mali-G31 MP2, OpenGL ES 3.2)",
+                    "canvas_hash": fh(r), "audio_hash": fh(r + 1), "webgl_params_hash": fh(r + 2), "fonts_hash": fh(r + 3), "codecs_hash": fh(r + 4),
+                    "media_devices": "ai1ao1vi4", "pointer_type": "coarse",
+                    "extra": {"vendor": "Google Inc.", "appVersion": UA[len("Mozilla/"):]},
+                },
+                "storage": {}, "attributes": {"entropy": "high"},
+            }
+
+        def rotl32(t, e):
+            m = 0xFFFFFFFF
+            return ((t << e) | (t >> (32 - e))) & m
+
+        def ye(t):
+            m = 0xFFFFFFFF
+            t[0] = (t[0] + t[1]) & m
+            t[3] = rotl32(t[3] ^ t[0], 16)
+            t[2] = (t[2] + t[3]) & m
+            t[1] = rotl32(t[1] ^ t[2], 12)
+            t[0] = (t[0] + t[1]) & m
+            t[3] = rotl32(t[3] ^ t[0], 8)
+            t[2] = (t[2] + t[3]) & m
+            t[1] = rotl32(t[1] ^ t[2], 7)
+
+        def gr(t):
+            m = 0xFFFFFFFF
+            e = [1779033703, 3144134277, 1013904242, 2773480762]
+            be, lt, dr, lr, hr = 512, 511, 2, 2654435761, 2246822519
+            for i in t:
+                e[0] = (e[0] + i) & m
+                e[0] = rotl32(e[0], 7)
+                ye(e)
+            for _i in range(8):
+                ye(e)
+            r = [0] * be
+            for i in range(be):
+                ye(e)
+                r[i] = (e[0] ^ e[2]) & m
+            for _i in range(dr):
+                for s in range(be):
+                    a = r[s] & lt
+                    c = (r[s] + r[a]) & m
+                    c = rotl32(c, 13)
+                    c = (c ^ ((r[(s + 1) & lt] * lr) & m)) & m
+                    r[s] = c
+                    e[0] = (e[0] ^ c) & m
+                    ye(e)
+            n = [0] * 8
+            o = be // 8
+            for i in range(8):
+                ye(e)
+                s = e[0]
+                a = i * o
+                for c in range(o):
+                    d = r[a + c]
+                    s = (s + d) & m
+                    s = rotl32(s, 5)
+                    s = (s ^ ((d * hr) & m)) & m
+                n[i] = (s ^ e[2]) & m
+            return n
+
+        def wr(t):
+            e = 0
+            for n in t:
+                if n == 0:
+                    e += 32
+                    continue
+                return e + (32 - n.bit_length())
+            return e
+
+        def er(t, e, timeout=20.0):
+            if e <= 0:
+                return "0"
+            start = time.time()
+            s = 0
+            t = t + ":"
+            while True:
+                for _i in range(1024):
+                    d = gr((t + str(s)).encode("ascii"))
+                    if wr(d) >= e:
+                        return str(s)
+                    s += 1
+                if time.time() - start > timeout:
+                    return None
+
+        def statusCode(data, sts):
+            try:
+                code = getattr(data, "meta", {}).get("status_code")
+                if code:
+                    return code
+            except Exception:
+                pass
+            return 200 if sts else 0
+
+        def tryJson(data):
+            try:
+                return json_loads(data)
+            except Exception:
+                return None
+
         baseUrl = baseUrl.replace("/d/", "/e/")
         printDBG("parserBYSE baseUrl[%s]" % baseUrl)
         urltab = []
-        HTTP_HEADER = self.cm.getDefaultHeader()
-        HTTP_HEADER["Referer"] = baseUrl
-        HTTP_HEADER["X-Embed-Parent"] = baseUrl
-        host = urlparser.getDomain(baseUrl.replace("boosteradx.online", "streamlyplayer.online"), False)
+        for redirectDomain in ["boosteradx.online", "byse.sx", "streamlyplayer.online"]:
+            baseUrl = baseUrl.replace(redirectDomain, "streamlyplayero.online")
+        ref = urlparser.getDomain(baseUrl, False)
         mid = re.search(r"/(?:e|d|download)/([0-9a-zA-Z]+)", baseUrl).group(1)
-        sts, data = self.cm.getPage("%sapi/videos/%s/embed/details" % (host, mid), {"header": HTTP_HEADER})
+        HTTP_HEADER = self.cm.getDefaultHeader()
+        HTTP_HEADER["User-Agent"] = UA
+        HTTP_HEADER["Referer"] = ref
+        HTTP_HEADER["Origin"] = ref[:-1]
+
+        embed = ""
+        detailsUrl = "%sapi/videos/%s/details" % (ref, mid)
+        sts, data = self.cm.getPage(detailsUrl, {"header": dict(HTTP_HEADER)})
+        details = tryJson(data) if sts else None
+        if details is None or statusCode(data, sts) == 404:
+            embed = "embed/"
+            detailsUrl = "%sapi/videos/%s/%sdetails" % (ref, mid, embed)
+            sts, data = self.cm.getPage(detailsUrl, {"header": dict(HTTP_HEADER)})
+            if not sts:
+                return []
+            details = tryJson(data)
+            if details is None:
+                return []
+
+        embedUrl = details.get("embed_frame_url")
+        if embedUrl:
+            ref = urlparser.getDomain(embedUrl, False)
+            HTTP_HEADER["X-Embed-Parent"] = baseUrl
+            HTTP_HEADER["Referer"] = ref
+            HTTP_HEADER["Origin"] = ref[:-1]
+
+        settingsUrl = "%sapi/videos/%s/%ssettings" % (ref, mid, embed)
+        sts, data = self.cm.getPage(settingsUrl, {"header": dict(HTTP_HEADER)})
+        settings = tryJson(data) if sts else None
+        if settings is None:
+            settings = {}
+
+        if settings.get("captcha_required"):
+            challengeUrl = "%sapi/videos/access/challenge" % ref
+            sts, data = self.cm.getPage(challengeUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, "")
+            challenge = tryJson(data) if sts else None
+            if challenge is None:
+                return []
+
+            attestUrl = "%sapi/videos/access/attest" % ref
+            sts, data = self.cm.getPage(attestUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps(wn(challenge)))
+            attest = tryJson(data) if sts else None
+            if attest is None:
+                return []
+            fingerprint = {"token": attest.get("token"), "viewer_id": attest.get("viewer_id"), "device_id": attest.get("device_id"), "confidence": attest.get("confidence")}
+
+            captchaUrl = "%sapi/videos/%s/%scaptcha" % (ref, mid, embed)
+            sts, data = self.cm.getPage(captchaUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps({"fingerprint": fingerprint}))
+            captcha = tryJson(data) if sts else None
+            if captcha is None:
+                return []
+            solution = er(captcha.get("pow_nonce", ""), captcha.get("pow_difficulty", 0), timeout=45.0)
+            if solution is None:
+                return []
+
+            verifyUrl = "%sapi/videos/%s/%scaptcha/verify" % (ref, mid, embed)
+            verifyPost = {"pow_token": captcha.get("pow_token"), "solution": solution, "fingerprint": fingerprint}
+            sts, data = self.cm.getPage(verifyUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps(verifyPost))
+            verify = tryJson(data) if sts else None
+            if verify is None:
+                return []
+            HTTP_HEADER["X-Captcha-Token"] = verify.get("token", "")
+
+            playbackUrl = "%sapi/videos/%s/%splayback" % (ref, mid, embed)
+            sts, data = self.cm.getPage(playbackUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps({"fingerprint": fingerprint}))
+        else:
+            playbackUrl = "%sapi/videos/%s/%splayback" % (ref, mid, embed)
+            sts, data = self.cm.getPage(playbackUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True}, json_dumps(fp(16, 0.83, 0.94)))
         if not sts:
             return []
-        data = json_loads(data)
-        code = data.get("code")
-        baseUrl = data.get("embed_frame_url", baseUrl)
-        HTTP_HEADER["Referer"] = baseUrl
-        host = urlparser.getDomain(baseUrl, False)
-        HTTP_HEADER["Origin"] = host[:-1]
-        sts, data = self.cm.getPage("%sapi/videos/%s/embed/playback" % (host, code), {"header": HTTP_HEADER, "raw_post_data": True}, json_dumps(fp(16, 0.6, 0.9)))
-        if not sts:
+
+        html = tryJson(data)
+        if html is None:
             return []
-        html = json_loads(data)
-        pd = html.get("playback")
-        if pd:
-            iv = ft(pd.get("iv"))
-            key = xn(pd.get("key_parts"), pd.get("version"))
-            pl = ft(pd.get("payload"))
-            cipher = python_aesgcm.new(key)
-            ct = cipher.open(iv, pl)
-            html = json_loads(ct.decode("latin-1"))
         sources = html.get("sources")
+        if not sources:
+            pd = html.get("playback")
+            if pd:
+                iv = ft(pd.get("iv"))
+                key = xn(pd.get("key_parts"), pd.get("version"))
+                pl = ft(pd.get("payload"))
+                cipher = python_aesgcm.new(key)
+                ct = cipher.open(iv, pl)
+                html = json_loads(ct.decode("latin-1"))
+                sources = html.get("sources")
         if sources:
             for x in sources:
-                url = urlparser.decorateUrl(x.get("url"), {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1]})
+                url = urlparser.decorateUrl(x.get("url"), {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": ref, "Origin": ref[:-1]})
                 if ".m3u8" in url:
                     urltab.extend(getDirectM3U8Playlist(url, sortWithMaxBitrate=99999999))
                 else:
                     urltab.append({"name": x.get("label", ""), "url": url})
+        return urltab
+
+    def parserDRAKKAR(self, baseUrl):  # add 250826
+        def xd(enc, key):
+            r = []
+            for i in range(len(enc)):
+                if isinstance(enc[i], int):
+                    r.append(chr(enc[i] ^ key[i % len(key)]))
+                else:
+                    r.append(format(int(enc[i], 16) ^ int(key[i % len(key)], 16), "x"))
+            return "".join(r)
+
+        def wc(seed, ch):
+            return sha256((seed + ch).encode("utf-8")).hexdigest()[:16]
+
+        def stdB64Decode(s):
+            s = s + "=" * (-len(s) % 4)
+            return base64.b64decode(s)
+
+        def aesCbcDecrypt(cipherBytes, ivHex, key):
+            try:
+                decrypter = pyaes.Decrypter(pyaes.AESModeOfOperationCBC(key, unhexlify(ivHex)))
+                decrypted = decrypter.feed(cipherBytes)
+                decrypted += decrypter.feed()
+                return decrypted.decode()
+            except Exception:
+                return None
+
+        printDBG("parserDRAKKAR baseUrl[%s]" % baseUrl)
+        urltab = []
+        HTTP_HEADER = self.cm.getDefaultHeader()
+        sts, html = self.cm.getPage(baseUrl, {"header": dict(HTTP_HEADER)})
+        if not sts:
+            return []
+        m = re.search(r"\(function\(\){\s*(var.+?)\s*var\s*_cr.+?_ept\s*=\s*'([^']+).+?_ws\s*=\s*'([^']+)", html, re.DOTALL)
+        if not m:
+            return []
+        varsBlock, ept, ws = m.group(1), m.group(2), m.group(3)
+        if "fromCharCode" in varsBlock:
+            s = re.findall(r"=\s*(\[[^;]+)", varsBlock)
+            if not s:
+                return []
+            if len(s) == 2:
+                cr = xd(literal_eval(s[0]), literal_eval(s[1]))
+            else:
+                t = int(varsBlock[:-2].split("]")[-1])
+                cr = "".join([chr(i + t) for i in literal_eval(s[0])])
+        else:
+            s = re.findall(r"=((?:atob\()?'[^']+)", varsBlock)
+            if len(s) < 2:
+                return []
+            if "atob(" in s[0]:
+                cr = stdB64Decode(s[0].split("'")[-1]).decode("latin-1") + stdB64Decode(s[1].split("'")[-1]).decode("latin-1")
+            else:
+                cr = s[0].split("'")[-1][::-1] + s[1].split("'")[-1][::-1]
+
+        ts = int(time.time() * 1000)
+        time.sleep(1.5)
+        ref = urlparser.getDomain(baseUrl, False)
+        postData = {
+            "cr": cr,
+            "pt": xd(ept, cr),
+            "wc": wc(ws, cr),
+            "_ts2": int(time.time() * 1000) - randint(100, 500),
+            "bs": {"ts": ts, "sw": 1280, "sh": 720, "plt": "", "tz": 240, "lang": "en-US", "pl": "", "ct": 4, "dm": 24, "td": 0, "cv": 1, "wg": 1},
+        }
+        HTTP_HEADER["Referer"] = ref
+        HTTP_HEADER["Origin"] = ref[:-1]
+        streamUrl = baseUrl.split("?")[0].rstrip("/") + "/stream"
+        sts, data = self.cm.getPage(streamUrl, {"header": HTTP_HEADER, "raw_post_data": True}, json_dumps(postData))
+        if not sts:
+            return []
+        try:
+            res = json_loads(data)
+        except Exception:
+            return []
+        if not (res.get("s") and res.get("d") and res.get("x")):
+            return []
+        key = sha256((str(res.get("p1", "")) + str(res.get("p2", "")) + str(res.get("p3", "")) + str(res.get("p4", "")) + cr + str(res.get("x", ""))).encode()).digest()
+        payload = aesCbcDecrypt(stdB64Decode(res.get("d", "")), res.get("v", ""), key)
+        if not payload:
+            return []
+        try:
+            pdata = json_loads(payload)
+        except Exception:
+            return []
+        playerHtml = ""
+        epd = pdata.get("encrypted_player_data")
+        if epd and epd.get("ct"):
+            simpleKey = unhexlify(str(epd.get("k1", "")) + str(epd.get("k2", "")) + str(epd.get("k3", "")) + str(epd.get("k4", "")))
+            if len(simpleKey) in [16, 24, 32]:
+                playerHtml = aesCbcDecrypt(stdB64Decode(epd.get("ct", "")), epd.get("iv", ""), simpleKey) or ""
+        elif pdata.get("processed_template"):
+            playerHtml = pdata.get("processed_template")
+        if not playerHtml:
+            return []
+        videoSrc = re.search(r"videoSrc:\s*'([^']+)", playerHtml)
+        if not videoSrc:
+            return []
+        urlMeta = {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": ref, "Origin": ref[:-1]}
+        subTracks = []
+        subBlock = re.search(r"subtitles:\s*(\[.+?\])\s*,", playerHtml, re.DOTALL)
+        if subBlock:
+            try:
+                for sub in json_loads(subBlock.group(1)):
+                    src = sub.get("src") or sub.get("file") or sub.get("url")
+                    if src:
+                        subTracks.append({"title": "", "url": src, "lang": sub.get("lang") or sub.get("label") or ""})
+            except Exception:
+                pass
+        if subTracks:
+            urlMeta["external_sub_tracks"] = subTracks
+        url = urlparser.decorateUrl(videoSrc.group(1), urlMeta)
+        urltab.append({"name": "Drakkar", "url": url})
         return urltab
 
     def parserCOUDMAILRU(self, baseUrl):  # Fix 221125
@@ -2363,6 +2751,8 @@ class pageParser(CaptchaHelper):
                 baseUrl = baseUrl.replace("/d/", "/").replace("_n", "")
         if "streamwish.to" in baseUrl:
             baseUrl = baseUrl.replace("streamwish.to", "hglamioz.com")
+        if "rubyvidhub.com" in baseUrl or "rubystm.com" in baseUrl or "streamruby" in baseUrl:
+            HTTP_HEADER.pop("Referer", None)  # embed is refused ("restricted for this domain") whenever a Referer is sent
         if "dropload." in baseUrl:
             baseUrl = re.sub(r"dropload\.co/embed-([^./]+)\.html", r"dr0pstream.com/e/\1", baseUrl)
             baseUrl = baseUrl.replace("dropload.tv", "dr0pstream.com").replace("dropload.io", "dr0pstream.com")
@@ -2499,6 +2889,41 @@ class pageParser(CaptchaHelper):
                 subTracks.append({"title": "", "url": "https:" + src if src.startswith("//") else src, "lang": label})
         url = urlparser.decorateUrl(url[::-1], {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1], "external_sub_tracks": subTracks})
         urltab.extend(getDirectM3U8Playlist(url))
+        return urltab
+
+    def parserVIXEO(self, baseUrl):  # add 020926 - vixeo.io (filmpalast "Vixeo HD"), a vidsonic.net front
+        printDBG("parserVIXEO baseUrl[%s]" % baseUrl)
+        urltab = []
+        subTracks = []
+        host = urlparser.getDomain(baseUrl, False)
+        HTTP_HEADER = self.cm.getDefaultHeader()
+        HTTP_HEADER["Referer"] = baseUrl
+        sts, data = self.cm.getPage(baseUrl, {"header": HTTP_HEADER})
+        if not sts:
+            return []
+        m = re.search(r'data-config=(["\'])([A-Za-z0-9+/=_-]+)\1', data)
+        if not m:
+            return []
+        blob = m.group(2).replace("-", "+").replace("_", "/").rstrip("=")
+        try:
+            cfg = json_loads(base64.b64decode(blob + "=" * (-len(blob) % 4)).decode())
+        except Exception:
+            printExc()
+            return []
+        # cfg["source"] is "|"-separated hex; concatenated, hex-decoded and byte-reversed it yields the stream url
+        src = str(cfg.get("source", "") or "").replace("|", "")
+        if not src:
+            return []
+        url = "".join(chr(int(src[i:i + 2], 16)) for i in range(0, len(src), 2))[::-1]
+        for sub in (cfg.get("subtitles") or []):
+            surl = sub.get("url") or sub.get("src") or sub.get("file") or ""
+            if surl:
+                subTracks.append({"title": "", "url": "https:" + surl if surl.startswith("//") else surl, "lang": sub.get("label") or sub.get("lang") or ""})
+        url = urlparser.decorateUrl(url, {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1], "external_sub_tracks": subTracks})
+        if ".m3u8" in url:
+            urltab.extend(getDirectM3U8Playlist(url))
+        else:
+            urltab.append({"name": "MP4", "url": url})
         return urltab
 
     def parserVIDCLOUD(self, baseUrl):  # add 280126

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.02.01"
+IPTV_VERSION = "2026.09.02.02"


### PR DESCRIPTION
…dfilmetv

================================================================ EN
================================================================

urlparser.py - new hoster resolvers
  * parserFIRESTREAM - firestream.to (filmpalast/kinoger "Firestream HD"): GET /e/<id> -> "token-blob" -> JSON POST /api/videos/<id>/resolve -> signedVideoUrl / signedVideoSdUrl (HLS).
  * parserPLAYMATE - playmate.to (filmpalast "Playmate HD"): JSON POST /api/s {c,d} -> sx (HLS master, .txt extension), kx = subs. The HLS segments are disguised as .css/.js/.woff (anti-adblock) and exteplayer3 cannot demux them - playback needs the setting "[HLS/M3U8] buffering" ON so the stream goes through hlsdl.
  * parserVIXEO - vixeo.io (filmpalast "Vixeo HD"), a vidsonic.net front: data-config base64 -> JSON, source = "|"-joined hex -> hex-decode + byte-reverse -> stream url, plus subtitle tracks.
  * parserDRAKKAR - drakkar.st (premiumsmart.eu backend): decode the inline _cr/_ept/_ws blob, POST /stream, AES-CBC decrypt the response and the embedded player data -> videoSrc + subtitles.

urlparser.py - hoster fixes
  * parserBYSE (filemoon / byse.sx) - rewritten for the new captcha / proof-of-work wall: access/challenge -> access/attest (ECDSA P-256 signature + browser fingerprint) -> captcha -> local PoW solver -> captcha/verify -> X-Captcha-Token -> playback; plain playback path kept for videos without a captcha. + rotation domains (bysezoxexe, cinegrab, furher.in, kerapoxy, moonmov, sb1254w9megshle, smdfs40r, streamlyplayero, z1ekv717, ...).
  * parserSTREAMUP - kinoger.pw and odysseusa.cc added (vidara / streamix family; POST /api/stream -> streaming_url).
  * parserSST - fsst.online: follow the redirect to incvideo1.online and use the final host as Referer; handle both a <source> list and the Playerjs file: value (single MP4 or [360p]/[720p] multi-quality). The old, broken single-URL branch is gone.
  * parserDOOD - dood.yt / playmogo.com / dsvplay.com: rewrite /w/ (watch page) to /e/ (embed page); playmogo.com added to the rotation list.
  * parserJWPLAYER - rubyvidhub.com / rubystm.com / streamruby.*: drop the Referer header (the embed page refuses any Referer with "restricted for this domain"). Note: the streamruby CDN additionally blocks the receiver's TLS fingerprint, so this mirror can still fail - the other kinoger mirrors (firestream / kinoger.pw / fsst) cover it.

hosthdfilmetv.py
  * meinecloud.click/movie/... is a mirror-list page, not a hoster - it is now expanded to the real hoster embeds it links (voe / dropload / mixdrop / ...) instead of an unsupported "Meinecloud" entry.

hostkinoking.py
  * Full rewrite for the redesigned kinoking.cc:
    - list/search: Tailwind "fav-data-source" cards (data-id / -type / -title / -img / -quality).
    - movies: movie.php renders a server picker; every "?id=..&link=<key>" variant is fetched and its <iframe> mirror collected. meinecloud embeds are expanded; vidsync.xyz / cinesrc.st aggregator embeds are skipped (not resolvable).
    - series: series.php?id=..&season=.. carries an inline allEpisodesData JSON with per-episode video_links.
  * Watched flag: "mark as seen" / "started" state + MENU toggle, with generic folder propagation (series / season / episode).
  * Sidecar .txt / .jpg written next to downloads; optional media-name normalization (Show - SxxExx - Title).
  * Dead code removed (getFullIconUrl, the list_value branch); the phantom "Next page" now only appears on a full page (>= 24 items).

hostcineto.py
  * reCAPTCHA is now routed to MyE2i by default - CaptchaHelper's internal Google "api/fallback" solver is dead plugin-wide, so a bypass service is mandatory. 9kw.eu / 2captcha.com remain selectable in the host config; solve the captcha on your phone/PC via the MyE2i extension.
  * Crash fixes: the cine.to API now returns integers where it used to send strings - str() applied to the description parts, the year and the "/out/<id>" link IDs (was: "TypeError: expected str, int found" on every title).

================================================================ DE
================================================================

urlparser.py - neue Hoster-Resolver
  * parserFIRESTREAM - firestream.to (filmpalast/kinoger "Firestream HD"): GET /e/<id> -> "token-blob" -> JSON-POST /api/videos/<id>/resolve -> signedVideoUrl / signedVideoSdUrl (HLS).
  * parserPLAYMATE - playmate.to (filmpalast "Playmate HD"): JSON-POST /api/s {c,d} -> sx (HLS-Master, .txt-Endung), kx = Untertitel. Die HLS-Segmente sind als .css/.js/.woff getarnt (Anti-Adblock), exteplayer3 kann das nicht demuxen - fuer die Wiedergabe muss die Einstellung "[HLS/M3U8] Pufferung" AN sein, dann laeuft der Stream ueber hlsdl.
  * parserVIXEO - vixeo.io (filmpalast "Vixeo HD"), ein vidsonic.net-
    Frontend: data-config-Base64 -> JSON, source = "|"-getrennte Hex ->
    Hex-Dekodieren + Byte-Reverse -> Stream-URL, plus Untertitelspuren.
  * parserDRAKKAR - drakkar.st (Backend von premiumsmart.eu): den inline _cr/_ept/_ws-Block dekodieren, POST /stream, Antwort und die eingebetteten Player-Daten per AES-CBC entschluesseln -> videoSrc + Untertitel.

urlparser.py - Hoster-Korrekturen
  * parserBYSE (filemoon / byse.sx) - neu geschrieben fuer die neue Captcha- / Proof-of-Work-Sperre: access/challenge -> access/attest (ECDSA-P-256-Signatur + Browser-Fingerprint) -> captcha -> lokaler PoW-Loeser -> captcha/verify -> X-Captcha-Token -> playback; der einfache playback-Weg bleibt fuer Videos ohne Captcha. + Rotations- Domains (bysezoxexe, cinegrab, furher.in, kerapoxy, moonmov, sb1254w9megshle, smdfs40r, streamlyplayero, z1ekv717, ...).
  * parserSTREAMUP - kinoger.pw und odysseusa.cc ergaenzt (vidara- / streamix-Familie; POST /api/stream -> streaming_url).
  * parserSST - fsst.online: dem Redirect nach incvideo1.online folgen und den finalen Host als Referer nehmen; sowohl eine <source>-Liste als auch den Playerjs-file:-Wert verarbeiten (einzelnes MP4 oder [360p]/[720p]-Multiquali). Der alte, kaputte Einzel-URL-Zweig ist weg.
  * parserDOOD - dood.yt / playmogo.com / dsvplay.com: /w/ (Watch-Seite) auf /e/ (Embed-Seite) umschreiben; playmogo.com in die Rotationsliste.
  * parserJWPLAYER - rubyvidhub.com / rubystm.com / streamruby.*: den Referer-Header weglassen (die Embed-Seite lehnt jeden Referer mit "restricted for this domain" ab). Hinweis: die streamruby-CDN blockt zusaetzlich den TLS-Fingerprint der Box, dieser Mirror kann also weiterhin scheitern - die anderen kinoger-Mirrors (firestream / kinoger.pw / fsst) fangen das ab.

hosthdfilmetv.py
  * meinecloud.click/movie/... ist eine Mirror-Listen-Seite, kein Hoster - sie wird jetzt zu den echten Hoster-Embeds aufgeloest (voe / dropload / mixdrop / ...) statt eines nicht unterstuetzten "Meinecloud"- Eintrags.

hostkinoking.py
  * Komplett-Rewrite fuer das neue kinoking.cc:
    - Liste/Suche: Tailwind-"fav-data-source"-Karten (data-id / -type / -title / -img / -quality).
    - Filme: movie.php zeigt einen Server-Picker; jede "?id=..&link=<key>"- Variante wird geladen und ihr <iframe>-Mirror eingesammelt. meinecloud-Embeds werden aufgeloest; vidsync.xyz / cinesrc.st (Aggregatoren) werden uebersprungen (nicht aufloesbar).
    - Serien: series.php?id=..&season=.. enthaelt inline ein allEpisodesData-JSON mit den video_links je Folge.
  * Wiedergabe-Status: "als gesehen" / "gestartet" + MENU-Umschalter, mit generischer Ordner-Propagation (Serie / Staffel / Folge).
  * Sidecar-.txt/.jpg neben Downloads; optionale Namens-Normalisierung (Serie - SxxExx - Titel).
  * Toter Code entfernt (getFullIconUrl, der list_value-Zweig); die Phantom-"Naechste Seite" erscheint nur noch bei voller Seite (>= 24 Eintraege).

hostcineto.py
  * reCAPTCHA laeuft jetzt standardmaessig ueber MyE2i - der interne Google-"api/fallback"-Loeser von CaptchaHelper ist plugin-weit tot, ein Bypass-Dienst ist also Pflicht. 9kw.eu / 2captcha.com bleiben in der Host-Konfiguration waehlbar; das Captcha loest man am Handy/PC ueber die MyE2i-Erweiterung.
  * Crash-Fixes: die cine.to-API liefert jetzt Ganzzahlen, wo frueher Strings kamen - str() auf die Beschreibungs-Teile, das Jahr und die "/out/<id>"-Link-IDs ("TypeError: expected str, int found" bei jedem Titel).