### PR TITLE
hlsdl: don't report an aborted HLS download as finished

### DIFF
--- a/IPTVPlayer/iptvdm/hlsdownloader.py
+++ b/IPTVPlayer/iptvdm/hlsdownloader.py
@@ -54,6 +54,7 @@ class HLSDownloader(BaseDownloader, SidecarMixin):
         self.totalDuration = 0
         self.downloadDuration = 0
         self.liveStream = False
+        self.lastErrorCode = 0  # last non-zero "error_code" reported by hlsdl (e.g. expired/blocked CDN token)
 
         # ffmpeg postprocess support
         self.ffmpegPostEnabled = False
@@ -301,6 +302,9 @@ class HLSDownloader(BaseDownloader, SidecarMixin):
 
                     if "d_t" in obj and obj['d_t'] == 'live':
                         self.liveStream = True
+                    if obj.get("error_code"):
+                        self.lastErrorCode = obj["error_code"]
+                        printDBG("HLSDownloader hlsdl error_code[%r] error_msg[%r]" % (obj.get("error_code"), obj.get("error_msg")))
                     if updateStatistic:
                         BaseDownloader._updateStatistic(self)
                 except Exception:
@@ -353,6 +357,11 @@ class HLSDownloader(BaseDownloader, SidecarMixin):
             self.status = DMHelper.STS.INTERRUPTED
         elif 0 >= self.localFileSize:
             self.status = DMHelper.STS.ERROR
+        elif self._isIncompleteDownload(code):
+            # hlsdl can exit 0 even after aborting mid-stream on an HTTP error
+            # (expired / IP-locked CDN token); don't remux/finalize a truncated file
+            printDBG("HLSDownloader incomplete (code[%r] errCode[%r] dur[%s/%s]) -> INTERRUPTED" % (code, self.lastErrorCode, self.downloadDuration, self.totalDuration))
+            self.status = DMHelper.STS.INTERRUPTED
         elif self.remoteFileSize > 0 and self.remoteFileSize > self.localFileSize:
             self.status = DMHelper.STS.INTERRUPTED
         else:
@@ -370,6 +379,17 @@ class HLSDownloader(BaseDownloader, SidecarMixin):
 
         if not terminated:
             self._finishDownloadFlow()
+
+    def _isIncompleteDownload(self, code):
+        if self.liveStream:
+            return False
+        if code != 0 or self.lastErrorCode:
+            return True
+        # hlsdl exited 0 but the downloaded duration is far short of the playlist
+        # duration -> it stopped early (rejected segment, throttled CDN, ...)
+        if self.totalDuration > 0 and self.downloadDuration < self.totalDuration * 0.90:
+            return True
+        return False
 
     def isLiveStream(self):
         return self.liveStream

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.02.02"
+IPTV_VERSION = "2026.09.02.03"


### PR DESCRIPTION
hlsdl can abort mid-stream on an HTTP error (expired or IP-locked CDN token, e.g. vidara / s1q2105) and still exit with code 0. The status parser ignored the reported {"error_code":..,"error_msg":"http"} entirely, and _cmdFinished only checks byte size for HLS (remoteFileSize is always 0 for HLS) - so a 14 MB torso of an 86 min movie was treated as DOWNLOADED, the remux failed, and a "finished" notification fired anyway.

- status parser now keeps hlsdl's error_code (self.lastErrorCode)
- new _isIncompleteDownload(code): not live AND (exit code != 0 OR error_code set OR downloaded duration < 90% of the playlist duration) -> INTERRUPTED instead of success; no remux, no finished notification, partial file kept for retry