### PR TITLE
Remove 2 dead config options: MIPS FPU ABI + hlsdl-alt-media preference

### DIFF
--- a/IPTVPlayer/components/iptvconfigmenu.py
+++ b/IPTVPlayer/components/iptvconfigmenu.py
@@ -34,7 +34,6 @@ from Tools.BoundFunction import boundFunction
 ###################################################
 config.plugins.iptvplayer = ConfigSubsection()
 
-config.plugins.iptvplayer.plarformfpuabi = ConfigSelection(default="", choices=[("", ""), ("hard_float", _("Hardware floating point")), ("soft_float", _("Software floating point"))])
 config.plugins.iptvplayer.exteplayer3path = ConfigText(default="", fixed_size=False)
 config.plugins.iptvplayer.set_curr_title = ConfigYesNo(default=False)
 config.plugins.iptvplayer.curr_title_file = ConfigText(default="", fixed_size=False)
@@ -225,8 +224,6 @@ def IsMediaNamingNormalized():
 
 
 config.plugins.iptvplayer.usepycurl = ConfigYesNo(default=False)
-
-config.plugins.iptvplayer.prefer_hlsdl_for_pls_with_alt_media = ConfigYesNo(default=True)
 
 ###################################################
 
@@ -542,8 +539,6 @@ class ConfigMenu(ConfigBaseWidget):
         list.append(getConfigListEntry(_("Remember last search history selection"), config.plugins.iptvplayer.rememberHistorySelection))
         list.append(getConfigListEntry(_("T9 letter jump in lists"), config.plugins.iptvplayer.enableT9MainList))
         list.append(getConfigListEntry(_("Write current title to file:"), config.plugins.iptvplayer.curr_title_file))
-        list.append(getConfigListEntry(_("MIPS Floating Point Architecture"), config.plugins.iptvplayer.plarformfpuabi))
-        list.append(getConfigListEntry(_("Prefer hlsld for playlist with alt. media"), config.plugins.iptvplayer.prefer_hlsdl_for_pls_with_alt_media))
         list.append(getConfigListEntry(_("Debug logs"), config.plugins.iptvplayer.debugprint))
 
     def runSetup(self):

--- a/IPTVPlayer/tools/iptvtools.py
+++ b/IPTVPlayer/tools/iptvtools.py
@@ -1589,25 +1589,6 @@ def GetVersionNum(ver):
         return 0
 
 
-def IsFPUAvailable():
-    try:
-        if None is IsFPUAvailable.available:
-            with open('/proc/cpuinfo', 'r') as f:
-                data = f.read().strip().upper()
-            if ' FPU ' in data:
-                IsFPUAvailable.available = True
-            else:
-                IsFPUAvailable.available = False
-        if IsFPUAvailable.available is False and config.plugins.iptvplayer.plarformfpuabi.value == 'hard_float':
-            return True
-    except Exception:
-        printExc()
-    return IsFPUAvailable.available
-
-
-IsFPUAvailable.available = None
-
-
 def IsSubtitlesParserExtensionCanBeUsed():
     try:
         if config.plugins.iptvplayer.useSubtitlesParserExtension.value:

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.04.01"
+IPTV_VERSION = "2026.09.05.01"


### PR DESCRIPTION
Both settings had zero live effect:

- "MIPS Floating Point Architecture" (plarformfpuabi): its only reader, IsFPUAvailable() in iptvtools.py, is itself never called anywhere in the running plugin - its one caller lives in Backup/setup/, which is legacy reference code not imported by the live IPTVPlayer/ package. Removed the config option and the now-fully-dead IsFPUAvailable().
- "Prefer hlsld for playlist with alt. media" (prefer_hlsdl_for_pls_with_alt_media): defined and shown in the menu, but never read anywhere else in the codebase.