### PR TITLE
Fix parserBYSE 404 detection + EkinoTv play.ekino.link 403

### DIFF
--- a/IPTVPlayer/hosts/hostekinotv.py
+++ b/IPTVPlayer/hosts/hostekinotv.py
@@ -135,12 +135,22 @@ class EkinoTv(CBaseHostClass):
     def getVideoLinks(self, url):
         printDBG("EkinoTv.getVideoLinks [%s]" % url)
         urlTab = []
+        pageUrl = url
         sts, data = self.getPage(url)
         if not sts:
             return []
         url = self.cm.ph.getSearchGroups(data, 'href="([^"]+)" target')[0]
         if 'play.ekino.link' in url:
-            sts, data = self.cm._getPageWithPyCurl(url, self.HEADER)
+            # self.HEADER was being passed as `params` itself, not wrapped
+            # as {"header": self.HEADER} - _getPageWithPyCurl() then found
+            # no 'header' key in it, fell through to pCommon's own generic
+            # HOST-string fallback (no Referer at all), and the CDN 403'd
+            # the request. Also add a Referer, since play.ekino.link is
+            # reached via a redirect page and CDNs like this commonly
+            # require one.
+            header = dict(self.HEADER)
+            header["Referer"] = pageUrl
+            sts, data = self.cm._getPageWithPyCurl(url, {"header": header})
             url = self.cm.ph.getSearchGroups(data, 'iframe src="([^"]+)')[0]
         if self.cm.isValidUrl(url):
             return self.up.getVideoLinkExt(url)

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -2487,7 +2487,13 @@ class pageParser(CaptchaHelper):
 
         embed = ""
         detailsUrl = "%sapi/videos/%s/details" % (ref, mid)
-        sts, data = self.cm.getPage(detailsUrl, {"header": dict(HTTP_HEADER)})
+        # with_metadata=True is required for statusCode() below to see the
+        # real HTTP status: getPageWithPyCurl() treats a 404 as sts=True by
+        # default (ignore_http_code_ranges), and only attaches .meta when
+        # asked to - without it, statusCode() always fell through to its
+        # sts-based 200/0 guess and this 404 retry never actually fired,
+        # even though the site returns a valid JSON body on 404s.
+        sts, data = self.cm.getPage(detailsUrl, {"header": dict(HTTP_HEADER), "with_metadata": True})
         details = tryJson(data) if sts else None
         if details is None or statusCode(data, sts) == 404:
             embed = "embed/"

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.05.01"
+IPTV_VERSION = "2026.09.05.02"


### PR DESCRIPTION
From github.com/oe-mirrors/e2iplayer#483's latest comment (sb1254w9megshle.org
+ ekino.ws logs):

- parserBYSE (urlparser.py): the "retry /details with embed/ prefix on 404" branch never actually fired for hosts that return a valid JSON body on a 404 (like sb1254w9megshle.org). statusCode() reads data.meta['status_code'], but the /details getPage() call never passed with_metadata=True, so data was a plain string with no .meta - statusCode() always fell back to its sts-based 200/0 guess, and sts is True for a 404 by design (getPageWithPyCurl()'s default ignore_http_code_ranges treats 404/500 as "got a response"). Added with_metadata=True so the real status code is actually seen.

- EkinoTv.getVideoLinks() (hostekinotv.py): the play.ekino.link request passed self.HEADER directly as _getPageWithPyCurl()'s params instead of wrapping it as {"header": self.HEADER}. Since that dict has no "header" key, the header lookup fell through to pCommon's generic HOST-string fallback - a bare User-Agent with no Referer at all - which the CDN 403'd. Fixed the wrapping and added a Referer (the ekino.ws page that led to the play.ekino.link redirect).

Neither fix was possible to verify live (no test box in this environment) - both address a concrete, confirmed code defect found by tracing the reported debug logs, not a guess.