### PR TITLE
ARTE mkv filename fix, HDFilme MKV toggle (minimal), DM path safety net

### DIFF
--- a/IPTVPlayer/hosts/hostartetv.py
+++ b/IPTVPlayer/hosts/hostartetv.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # ARTE
 # Rewritten for the api-cdn.arte.tv "emac v4" JSON API + player v2 config
-# Last Modified: 31.08.2026 - split audio/video HLS renditions (merge://) are muxed
+# Last Modified: 05.09.2026 - stamp iptv_format='mkv' alongside iptv_use_ffmpeg/
+# ff_out_container on split audio/video HLS renditions, so the download manager
+# shows .mkv immediately instead of .mp4 needing a rename.
+# 31.08.2026 - split audio/video HLS renditions (merge://) are muxed
 # with ffmpeg (iptv_use_ffmpeg, matroska container) instead of hlsdl, which only
 # re-packages segments and produced unplayable files.
 ###################################################
@@ -422,6 +425,7 @@ class ArteTV(GenericFolderWatchedScraperMixin, CBaseHostClass):
                     if strwithmeta(it['url']).meta.get('audio_url'):
                         extraMeta['iptv_use_ffmpeg'] = True
                         extraMeta['ff_out_container'] = 'matroska'
+                        extraMeta['iptv_format'] = 'mkv'
                     it['url'] = self.up.decorateUrl(it['url'], extraMeta)
                     it['need_resolve'] = 0
                     urlTab.append(it)

--- a/IPTVPlayer/hosts/hosthdfilme.py
+++ b/IPTVPlayer/hosts/hosthdfilme.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 25.08.2026 - strip the leading "S<n> E<n>" NUMBERS from the site's raw episode label and keep whatever separator character the site itself already uses (dash or em-dash) untouched, instead of re-building a custom separator; removed the unnecessary EM_DASH/EN_DASH constants and literal-unicode-escape decoding machinery from the previous iteration.
+# Last Modified: 05.09.2026 - added "Create MKV" option (config.plugins.iptvplayer.hdfilme_mkv),
+# mirroring hostfilmpalast.py's MKV toggle: GetConfigList() now exposes it and getVideoLinks()
+# passes it straight through to decorateResolvedLinkItems(), which already wires the correct
+# postprocess meta for WgetDownloader to remux to mkv after the download finishes - same as
+# filmpalast, no extra downloader-forcing needed.
+# 25.08.2026 - strip the leading "S<n> E<n>" NUMBERS from the site's raw episode label and keep whatever separator character the site itself already uses (dash or em-dash) untouched, instead of re-building a custom separator; removed the unnecessary EM_DASH/EN_DASH constants and literal-unicode-escape decoding machinery from the previous iteration.
 
 import re
 
+from Components.config import config, ConfigYesNo, getConfigListEntry
 from Plugins.Extensions.IPTVPlayer.components.ihost import CBaseHostClass, CHostBase, RetHost
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
@@ -15,9 +21,13 @@ from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecarFromIte
 from Plugins.Extensions.IPTVPlayer.tools.iptvnaming import extractNum, formatSxxExx, stripLeadingSxxExx
 from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled, IsMediaNamingNormalized
 
+config.plugins.iptvplayer.hdfilme_mkv = ConfigYesNo(default=True)
+
 
 def GetConfigList():
-    return []
+    optionList = []
+    optionList.append(getConfigListEntry(_("Create MKV"), config.plugins.iptvplayer.hdfilme_mkv))
+    return optionList
 
 
 def gettytul():
@@ -362,7 +372,8 @@ class HDFilme(CBaseHostClass):
         printDBG("HDFilme.getVideoLinks [%s]" % videoUrl)
         if self.cm.isValidUrl(videoUrl):
             sidecar = sidecarFromUrlMeta(videoUrl, IsSidecarEnabled())
-            return decorateResolvedLinkItems(self.up.getVideoLinkExt(videoUrl), sidecar)
+            cfgMkvEnabled = config.plugins.iptvplayer.hdfilme_mkv.value
+            return decorateResolvedLinkItems(self.up.getVideoLinkExt(videoUrl), sidecar, cfgMkvEnabled)
         return []
 
     def getArticleContent(self, cItem):

--- a/IPTVPlayer/iptvdm/iptvdmapi.py
+++ b/IPTVPlayer/iptvdm/iptvdmapi.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 12.07.2026 - added preCheckOnly handling to show "Download already exists" instead of FAILED
+# Last Modified: 05.09.2026 - cmdFinished() now runs the downloader's reported
+# fileName through downloaderhelpers.ensureText() (the same helper HLSDownloader/
+# WgetDownloader/MergeDownloader already use internally) and falls back to
+# DMItem.originalFileName if the downloader ever hands back an empty/invalid
+# path, instead of trusting getFullFileName() as-is.
+# 12.07.2026 - added preCheckOnly handling to show "Download already exists" instead of FAILED
 #
 # IPTV download manager API
 #
@@ -11,6 +16,7 @@
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, eConnectCallback
 from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdh import DMHelper, DMItemBase
 from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdownloadercreator import DownloaderCreator
+from Plugins.Extensions.IPTVPlayer.iptvdm.downloaderhelpers import ensureText
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 ###################################################
 
@@ -31,6 +37,9 @@ class DMItem(DMItemBase):
 
         self.processed = False
         self.downloadIdx = -1
+        # keep the originally requested path so we can fall back to it
+        # if a downloader ever returns a bogus/empty renamed path
+        self.originalFileName = fileName
 
 
 class IPTVDMApi():
@@ -299,6 +308,10 @@ class IPTVDMApi():
         listUDIdx = self.findIdxInQueueUD(item.downloadIdx)
         self.queueUD[listUDIdx].status = DMHelper.STS.DOWNLOADING
         self.queueUD[listUDIdx].fileName = item.fileName
+        # remember the path we actually asked for, so cmdFinished() has a
+        # safe value to fall back to if the downloader ever reports an
+        # empty/invalid renamed path
+        self.queueUD[listUDIdx].originalFileName = item.fileName
 
         url, downloaderParams = DMHelper.getDownloaderParamFromUrl(item.url)
         self.queueUD[listUDIdx].downloader = DownloaderCreator(url)
@@ -325,15 +338,33 @@ class IPTVDMApi():
         # fixing .mp4 -> .mkv to match the real container); pick up the real path
         # so notify / archive / delete all use it. No-op for downloaders that
         # never change it.
+        #
+        # getFullFileName() can come back wrapped in a str SUBCLASS (e.g.
+        # e2iPlayer's own "strwithmeta") after a rename; ensureText() - the
+        # same helper HLSDownloader/WgetDownloader/MergeDownloader already use
+        # for their own path handling - normalizes that before we store it,
+        # and we fall back to the originally requested path if the downloader
+        # ever hands back an empty/invalid one instead of trusting it blindly.
         try:
             dl = self.queueUD[listUDIdx].downloader
             if dl is not None:
-                realPath = dl.getFullFileName()
+                realPath = ensureText(dl.getFullFileName()).strip()
+
                 if realPath and realPath != self.queueUD[listUDIdx].fileName:
                     printDBG("cmdFinished: downloader renamed file -> %s" % realPath)
                     self.queueUD[listUDIdx].fileName = realPath
+                elif not realPath:
+                    printDBG("cmdFinished: downloader returned empty/invalid path, keeping previous fileName[%s]" %
+                        self.queueUD[listUDIdx].fileName)
         except Exception:
             printExc()
+
+        self.queueUD[listUDIdx].fileName = ensureText(self.queueUD[listUDIdx].fileName)
+        if not self.queueUD[listUDIdx].fileName:
+            fallback = ensureText(getattr(self.queueUD[listUDIdx], 'originalFileName', u''))
+            if fallback:
+                printDBG("cmdFinished: invalid fileName, falling back to originalFileName[%s]" % fallback)
+                self.queueUD[listUDIdx].fileName = fallback
 
         self.updateDownloadedItemStatus(listUDIdx)
         self.queueUD[listUDIdx].processed = True

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.05.02"
+IPTV_VERSION = "2026.09.05.03"


### PR DESCRIPTION
- hostartetv.py: stamp iptv_format='mkv' alongside the existing iptv_use_ffmpeg/ff_out_container meta on split audio/video HLS renditions, so the download manager shows .mkv immediately.
- hosthdfilme.py: add the "Create MKV" config toggle (hdfilme_mkv), mirroring hostfilmpalast.py's minimal pattern - just pass the flag into decorateResolvedLinkItems(), which already wires the correct postprocess meta for WgetDownloader's own post-download remux. Deliberately skips a broader scraping-marker rewrite that was checked against the live site and found to be unnecessary churn, with one regression (the "released" year regex would have matched the genre dropdown's current year instead of the movie's actual year).
- iptvdmapi.py: cmdFinished() now runs the downloader-reported fileName through ensureText() and falls back to the originally requested path if a downloader ever hands back an empty/invalid renamed path.