### PR TITLE
hostfavourites: guard getCustomActions / markItemAsViewed against an …

### DIFF
--- a/IPTVPlayer/hosts/hostfavourites.py
+++ b/IPTVPlayer/hosts/hostfavourites.py
@@ -486,7 +486,8 @@ class IPTVHost(CHostBase):
         retlist = []
         if self.useWatchedFlag:
             ret = self.cachedRet
-            if ret.value[Index].isWatched is not True and ret.value[Index].type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO]:
+            if ret is not None and hasattr(ret, 'value') and 0 <= Index < len(ret.value) \
+               and ret.value[Index].isWatched is not True and ret.value[Index].type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO]:
                 hashData = self.getItemHashData(Index, ret.value[Index])
                 if self._createViewedFile(hashData):
                     self.cachedRet.value[Index].isWatched = True
@@ -528,7 +529,8 @@ class IPTVHost(CHostBase):
                                     retCode = RetHost.OK
             if retCode != RetHost.OK:
                 ret = self.cachedRet
-                if ret.value[Index].type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO]:
+                if ret is not None and hasattr(ret, 'value') and 0 <= Index < len(ret.value) \
+                   and ret.value[Index].type in [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO]:
                     tmp = self.getItemHashData(Index, ret.value[Index])
                     if tmp != '':
                         isWatched = bool(self.cachedRet.value[Index].isWatched)

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.05.04"
+IPTV_VERSION = "2026.09.05.05"


### PR DESCRIPTION
…unset cachedRet

Pressing MENU on a favourite row before the favourites list has been cached (self.cachedRet still None) raised
  AttributeError: 'NoneType' object has no attribute 'value'
in getCustomActions, and markItemAsViewed had the same unguarded self.cachedRet.value[Index] access. Both now use the same None / attribute / index check already used elsewhere in the file.