### PR TITLE
fix two harmless-but-noisy exceptions on every playback

### DIFF
--- a/IPTVPlayer/libs/pCommon.py
+++ b/IPTVPlayer/libs/pCommon.py
@@ -874,6 +874,11 @@ class common:
                     img = Image.open(file_path)
                     # img.thumbnail((400, 300), Image.LANCZOS)
                     # printDBG("PCommon.convertWebp save %s" % output_path)
+                    if not png and img.mode not in ('RGB', 'L'):
+                        # JPEG can't hold an alpha channel - a webp with
+                        # transparency (RGBA/LA/P) would raise "cannot write
+                        # mode RGBA as JPEG"
+                        img = img.convert('RGB')
                     img.save(output_path, format="png" if png else "jpeg", quality=80)
                     img.close()
                     os.remove(file_path)

--- a/IPTVPlayer/tools/iptvmoviemetadata.py
+++ b/IPTVPlayer/tools/iptvmoviemetadata.py
@@ -76,6 +76,9 @@ class IPTVMovieMetaDataHandler():
                 if data != {}:
                     sts = True
                     self.data.update(data)
+            except IOError:
+                # no metadata file yet - normal on the first open of a title
+                pass
             except Exception:
                 printExc()
         except Exception:

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.05.05"
+IPTV_VERSION = "2026.09.05.06"


### PR DESCRIPTION
- pCommon.convertWebp(): a WebP poster with an alpha channel (RGBA/LA/P) raised "OSError: cannot write mode RGBA as JPEG" - the poster download then failed with a full traceback in the log. Convert to RGB before the JPEG save (PNG output already supports alpha, so only for JPEG).

- IPTVMovieMetaDataHandler.load(): the per-title metadata file doesn't exist until the title has been played once, so codecs.open() raised FileNotFoundError and printExc() dumped a traceback on the first open of every title. Treat IOError (missing/unreadable file) as "no metadata yet" and return quietly; a real JSON parse error is still logged.

Both were already caught and non-fatal; this just stops them spamming the debug log.