### PR TITLE
urlparser: add parserVIDSST for vids.st

### DIFF
--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -558,6 +558,7 @@ class urlparser:
             "vidoza.co": self.pp.parserJWPLAYER,
             "vidoza.net": self.pp.parserJWPLAYER,
             "vidoza.org": self.pp.parserJWPLAYER,
+            "vids.st": self.pp.parserVIDSST,
             "vidsonic.net": self.pp.parserVIDSONIC,
             "vidsrc.bz": self.pp.parserVIDSRC,
             "vidsrc.cc": self.pp.parserMEGAFILES,
@@ -3138,4 +3139,37 @@ class pageParser(CaptchaHelper):
                 printExc()
                 return []
 
+        return urltab
+
+    def parserVIDSST(self, baseUrl):  # add 050926 - vids.st (premiumsmart.eu "VidsST" mirror), bespoke ArtPlayer host
+        printDBG("parserVIDSST baseUrl[%s]" % baseUrl)
+        urltab = []
+        host = urlparser.getDomain(baseUrl, False)
+        HTTP_HEADER = self.cm.getDefaultHeader()
+        HTTP_HEADER["Referer"] = baseUrl
+        sts, data = self.cm.getPage(baseUrl, {"header": HTTP_HEADER})
+        if not sts:
+            return []
+        # the /e/<id> embed page carries the master playlist url in a plain JS const
+        m = re.search(r'''const\s+url\s*=\s*["'](https?:[^"']+\.m3u8[^"']*)["']''', data)
+        if not m:
+            m = re.search(r'''["'](https?:(?:\\?/){2}[^"']+?/master\.m3u8[^"']*)["']''', data)
+        if not m:
+            return []
+        url = m.group(1).replace("\\/", "/")
+        subTracks = []
+        sm = re.search(r'"subtitleUrl"\s*:\s*"([^"]+)"', data)
+        if sm and sm.group(1):
+            lm = re.search(r'"subtitleLabel"\s*:\s*"([^"]*)"', data)
+            label = lm.group(1) if lm else ""
+            subTracks.append({"title": label, "url": sm.group(1).replace("\\/", "/"), "lang": label})
+        url = urlparser.decorateUrl(url, {
+            "User-Agent": HTTP_HEADER["User-Agent"],
+            "Referer": baseUrl,
+            "Origin": host[:-1] if host.endswith("/") else host,
+            "external_sub_tracks": subTracks,
+        })
+        urltab.extend(getDirectM3U8Playlist(url, checkExt=False, checkContent=True))
+        if not urltab:
+            urltab.append({"name": "vids.st", "url": url, "need_resolve": 0})
         return urltab

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.05.08"
+IPTV_VERSION = "2026.09.05.09"


### PR DESCRIPTION
vids.st is one of premiumsmart.eu's mirror hosts (issue oe-mirrors#551 mentions abyssplayer alongside it). It had no parser, so picking the "VidsST" link in hostpremiumsmarteu silently did nothing.

vids.st is a bespoke ArtPlayer/hls.js host: the /e/<id> embed page carries the HLS master playlist URL in a plain
`const url = "https://vids.st/storage/cdn/video<id>/master.m3u8"` - no packer, no token. Fetch page, scrape the const, hand the master playlist to getDirectM3U8Playlist (multi-audio POL/ENG merges like the other mirrors). Referer = the embed URL.

Verified against a live link: page regex hits, master + variant playlists return 200 with only a Referer header. Not box-tested.