### PR TITLE
Fix/framework parser guards

### DIFF
--- a/IPTVPlayer/components/iptvarticleview.py
+++ b/IPTVPlayer/components/iptvarticleview.py
@@ -183,10 +183,12 @@ class IPTVArticleView(Screen):
         # already scaled globally by openATV) declares its own splitPosition
         # and must not have this HD-reference number forced onto it too.
         if not skinchrome.isExternalSkin(self.skinName):
-            try:
-                self["text"].instance.setSplitPosition(skinchrome.scalePixels(330, skinchrome.getScale()))
-            except Exception:
-                printExc()
+            textInstance = self["text"].instance
+            if hasattr(textInstance, "setSplitPosition"):
+                try:
+                    textInstance.setSplitPosition(skinchrome.scalePixels(330, skinchrome.getScale()))
+                except Exception:
+                    printExc()
         self.hideSpinner()
         self.loadCover()
         # header logo: the host's own logo if it has one, otherwise fall

--- a/IPTVPlayer/components/iptvchoicebox.py
+++ b/IPTVPlayer/components/iptvchoicebox.py
@@ -43,6 +43,17 @@ class IPTVChoiceBoxWidget(Screen):
         width = self.params.get('width', 300)
         height = self.params.get('height', 300)
 
+        # The screen declares resolution="1280,720" and is centered, and
+        # callers size 'height' to fit every row (numItems * rowHeight +
+        # margin). With many options that exceeds the 720 reference
+        # viewport, so the box hangs off the top and bottom of the screen
+        # and the list - sized e-N against that oversized screen - never
+        # scrolls. Cap both axes to the reference viewport (minus a small
+        # margin) so the list stays on-screen and its own scrollbar takes
+        # over instead.
+        height = min(height, 700)
+        width = min(width, 1240)
+
         # Pure info dialogs (no per-row action, e.g. the OSK's Help screen)
         # pass selectable=False so moving through rows doesn't paint them as
         # if they were a real, actionable selection. The list itself is

--- a/IPTVPlayer/components/iptvplayerwidget.py
+++ b/IPTVPlayer/components/iptvplayerwidget.py
@@ -1739,7 +1739,8 @@ class E2iPlayerWidget(Screen):
                 printExc()
 
             try:
-                sel = self["list"].l.getCurrentSelection()[0]
+                sel = self["list"].l.getCurrentSelection()
+                sel = sel[0] if sel else None
             except Exception:
                 printExc()
                 self.getRefreshedCurrList()

--- a/IPTVPlayer/hosts/hostbasketballvideocom.py
+++ b/IPTVPlayer/hosts/hostbasketballvideocom.py
@@ -41,8 +41,8 @@ class BasketballVideo(CBaseHostClass):
             return []
         cUrl = data.meta['url']
         self.setMainUrl(cUrl)
-        data = self.cm.ph.getAllItemsBeetwenMarkers(data, '<nav', '</nav')[0]
-        data = re.compile(r'a href="([^"]+)"\s*?>([^<]+)', re.DOTALL).findall(data)
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, '<nav', '</nav')
+        data = re.compile(r'a href="([^"]+)"\s*?>([^<]+)', re.DOTALL).findall(data[0] if data else '')
         for url, title in data:
             params = dict(cItem)
             params.update({'category': 'list_items', 'title': title, 'url': self.getFullUrl(url)})
@@ -75,8 +75,10 @@ class BasketballVideo(CBaseHostClass):
         sts, data = self.getPage(cItem['url'])
         if not sts:
             return []
-        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="fullstory block_elem"', 'class="full_info block_elem"')[0]
-        data = re.compile(r'''(?:src|href)=['"]([^'^"]+?)['"]\s(?:width|rel)''', re.DOTALL).findall(data)
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'class="fullstory block_elem"', 'class="full_info block_elem"')
+        if not data:
+            return urltab
+        data = re.compile(r'''(?:src|href)=['"]([^'^"]+?)['"]\s(?:width|rel)''', re.DOTALL).findall(data[0])
         for url in data:
             url = 'https:' + url if url.startswith('//') else url
             if any(d in url for d in ("gamesontvtoday.com", "nfl-video.com", "guidedesgemmes.com", "nhlgamestoday.com")):

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -2814,7 +2814,10 @@ class pageParser(CaptchaHelper):
         if match:
             match = match.group(1).replace("&quot;", '"').replace("&amp;", "&")
             js = json_loads(match).get("flashvars", {}).get("metadata")
-            js = json_loads(js)
+            if isinstance(js, str):
+                js = json_loads(js) if js else {}
+            if not isinstance(js, dict):
+                js = {}
             url = js.get("hlsManifestUrl") or js.get("ondemandHls") or js.get("hlsMasterPlaylistUrl")
             if url:
                 url = urlparser.decorateUrl(url, {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": host, "Origin": host[:-1]})

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.06.01"
+IPTV_VERSION = "2026.09.06.02"


### PR DESCRIPTION
Changelog against python3:

* libs/urlparser.py - parserOKRU: OK.ru now serves flashvars.metadata as an already-decoded object on some embed pages instead of a JSON string, so the unconditional second json_loads() raised TypeError and every ok.ru link failed to resolve. Parse only when it is a string, use a dict as-is, fall back to {} otherwise. Restores ok.ru playback for all hosts.

* components/iptvarticleview.py - onStart(): setSplitPosition is a newer eLabel API missing on some images; the call was caught but printed a traceback on every article view (INFO button). Guard with hasattr() before calling.

* components/iptvplayerwidget.py - ok_pressed(): getCurrentSelection() returns None (not a list) on an empty list, so [0] raised TypeError. Take [0] only when the result is truthy, otherwise fall through to the refresh path.

* components/iptvchoicebox.py - IPTVChoiceBoxWidget.__prepareSkin(): callers size the popup height to fit every row, which overflowed the 1280x720 reference viewport the centered screen declares, pushing link/action/player pickers off the top and bottom of the screen with no scrolling. Clamp both axes to the viewport so the list's own scrollbar takes over.

* hosts/hostbasketballvideocom.py - listSubMenu() and getLinksForVideo() took [0] of getAllItemsBeetwenMarkers() with no length check; a page missing the expected <nav> / "fullstory block_elem" block (some nfl-video.com detail pages) raised IndexError and killed the host thread. Return empty instead.