### PR TITLE
E2iPlayer info / diagnostics screen and debug-log management

### DIFF
--- a/IPTVPlayer/components/iptvconfigmenu.py
+++ b/IPTVPlayer/components/iptvconfigmenu.py
@@ -136,6 +136,15 @@ config.plugins.iptvplayer.debugprint = ConfigSelection(default="", choices=[("",
                                                                             ("/tmp/iptv.dbg", _("Yes, to file /tmp/iptv.dbg")),
                                                                             ("/home/root/logs/iptv.dbg", _("Yes, to file /home/root/logs/iptv.dbg")),
                                                                             ])
+config.plugins.iptvplayer.debug_clear_on_start = ConfigYesNo(default=True)
+config.plugins.iptvplayer.debug_max_size = ConfigSelection(default="0", choices=[
+    ("0", _("unlimited")), ("2", "2 MB"), ("5", "5 MB"), ("10", "10 MB"),
+    ("20", "20 MB"), ("50", "50 MB"), ("100", "100 MB")])
+config.plugins.iptvplayer.debug_on_limit = ConfigSelection(default="truncate", choices=[
+    ("truncate", _("truncate the file")),
+    ("rotate", _("rotate (keep the old one as iptv-<date>.dbg)"))])
+config.plugins.iptvplayer.debug_rotate_keep = ConfigSelection(default="3", choices=[
+    ("1", "1"), ("2", "2"), ("3", "3"), ("5", "5"), ("10", "10")])
 
 # icons
 config.plugins.iptvplayer.IconsSize = ConfigSelection(default="100", choices=[("100", "100x100"), ("120", "120x120"), ("135", "135x135")])
@@ -382,10 +391,16 @@ class E2iVKQuickSettings(ConfigBaseWidget):
 
 class ConfigMenu(ConfigBaseWidget):
 
+    HAS_BLUE_KEY = True
+
     def __init__(self, session):
         printDBG("ConfigMenu.__init__ -------------------------------")
         self.list = []
         ConfigBaseWidget.__init__(self, session)
+        try:
+            self["key_blue"].setText(_("Info"))
+        except Exception:
+            printExc()
         # remember old
         self.showcoverOld = config.plugins.iptvplayer.showcover.value
         self.SciezkaCacheOld = config.plugins.iptvplayer.SciezkaCache.value
@@ -403,6 +418,13 @@ class ConfigMenu(ConfigBaseWidget):
     def layoutFinished(self):
         ConfigBaseWidget.layoutFinished(self)
         self.setTitle(_("E2iPlayer - settings"))
+
+    def keyBlue(self):
+        try:
+            from Plugins.Extensions.IPTVPlayer.components.iptvplayerinfoview import OpenInfoView
+            OpenInfoView(self.session)
+        except Exception:
+            printExc()
 
     @staticmethod
     def fillConfigList(list,):
@@ -538,7 +560,16 @@ class ConfigMenu(ConfigBaseWidget):
         list.append(getConfigListEntry(_("Remember last search history selection"), config.plugins.iptvplayer.rememberHistorySelection))
         list.append(getConfigListEntry(_("T9 letter jump in lists"), config.plugins.iptvplayer.enableT9MainList))
         list.append(getConfigListEntry(_("Write current title to file:"), config.plugins.iptvplayer.curr_title_file))
+
+        list.append(getConfigListEntry(_("----- DEBUG CONFIGURATION -----"), ))
         list.append(getConfigListEntry(_("Debug logs"), config.plugins.iptvplayer.debugprint))
+        if config.plugins.iptvplayer.debugprint.value not in ("", "console"):
+            list.append(getConfigListEntry("    " + _("Clear the log file at plugin start"), config.plugins.iptvplayer.debug_clear_on_start))
+            list.append(getConfigListEntry("    " + _("Maximum log file size"), config.plugins.iptvplayer.debug_max_size))
+            if config.plugins.iptvplayer.debug_max_size.value != "0":
+                list.append(getConfigListEntry("    " + _("When the maximum is reached"), config.plugins.iptvplayer.debug_on_limit))
+                if config.plugins.iptvplayer.debug_on_limit.value == "rotate":
+                    list.append(getConfigListEntry("        " + _("Number of rotated files to keep"), config.plugins.iptvplayer.debug_rotate_keep))
 
     def runSetup(self):
         self.list = []
@@ -655,7 +686,10 @@ class ConfigMenu(ConfigBaseWidget):
             config.plugins.iptvplayer.favourites_use_watched_flag,
             config.plugins.iptvplayer.hostsListType,
             config.plugins.iptvplayer.skinforceallinternal,
-            config.plugins.iptvplayer.IPTVDMShowNotification
+            config.plugins.iptvplayer.IPTVDMShowNotification,
+            config.plugins.iptvplayer.debugprint,
+            config.plugins.iptvplayer.debug_max_size,
+            config.plugins.iptvplayer.debug_on_limit
             # config.plugins.iptvplayer.captcha_bypass_free,
             # config.plugins.iptvplayer.captcha_bypass_pay
         ]

--- a/IPTVPlayer/components/iptvplayerinfoview.py
+++ b/IPTVPlayer/components/iptvplayerinfoview.py
@@ -1,0 +1,699 @@
+# -*- coding: utf-8 -*-
+#
+#  E2iPlayer info / diagnostics screen.
+#
+#  Opened from the PlayerSelector BLUE menu -> "Info" and from the main
+#  settings BLUE key. Three pages, switched with LEFT / RIGHT:
+#
+#    About   - version, project link, credits (the old MessageBox content)
+#    System  - E2iPlayer / Python / image / box, every externally loaded
+#              tool and its version, free space, the debug-log setting
+#    Log     - a live tail of the E2iPlayer debug log (if enabled)
+#
+#  GREEN  saves the current page to /tmp (sysinfo.txt or debug.txt).
+#  YELLOW toggles the live refresh on the Log page.
+#  BLUE   clears the debug log (Log page only).
+#
+#  LogSystemInfoAtStartup() is called from plugin start: it runs the probe
+#  once and writes the full snapshot (incl. binary versions) near the top
+#  of the debug log, so it is already in any log a user shares for
+#  support. The screen reuses that cached result.
+#
+import os
+import re
+import sys
+
+from enigma import eTimer
+from Components.ActionMap import ActionMap
+from Components.ScrollLabel import ScrollLabel
+from Components.Sources.StaticText import StaticText
+from Screens.Screen import Screen
+
+from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
+from Plugins.Extensions.IPTVPlayer.components import skinchrome
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import (
+    printDBG, printExc, iptv_system, eConnectCallback, formatBytes, GetImageName,
+    GetIPTVPlayerVersion, GetIPTVPlayerComitStamp, GetShortPythonVersion,
+    GetConfigDir, GetTmpDir,
+)
+try:
+    from Plugins.Extensions.IPTVPlayer.tools.iptvtools import GetDebugLogPath
+except Exception:
+    def GetDebugLogPath():
+        return ""
+
+SYSINFO_FILE = "/tmp/e2iplayer_sysinfo.txt"
+DEBUGCOPY_FILE = "/tmp/e2iplayer_debug.txt"
+
+LOG_TAIL_BYTES = 96 * 1024
+LOG_REFRESH_MS = 2000
+
+PAGE_ABOUT, PAGE_SYSTEM, PAGE_LOG = 0, 1, 2
+PAGE_NAMES = {PAGE_ABOUT: _("About"), PAGE_SYSTEM: _("System"), PAGE_LOG: _("Log")}
+
+_HEADING_COLOR = 0x0066ccff   # same accent blue IPTVArticleView uses for labels
+_TEXT_COLOR = 0x00ffffff
+
+# One shell script that probes every external binary at once, so the
+# System page needs a single non-blocking iptv_system() call. It is
+# written to a temp file and run as `sh <file>` - otherwise iptv_system
+# logs the whole ~1 KB command three times per run into the debug log.
+# stdin from /dev/null (exteplayer3/gstplayer read commands from stdin
+# and would otherwise block); `timeout` guards the rest if it exists.
+# duktape's `duk` has no --version flag, so run a one-line script that
+# prints Duktape.version (e.g. 20700 -> shown as 2.7.0).
+_PROBE_SCRIPT_PATH = "/tmp/.e2i_sysprobe.sh"
+
+_P = '</dev/null 2>&1'
+_PROBE_SCRIPT = (
+    'T=""; command -v timeout >/dev/null 2>&1 && T="timeout 4"; '
+    'w(){ command -v "$1" 2>/dev/null || echo "-"; }; '
+    'echo "@@hlsdl";       ($T hlsdl %s            || true) | head -n 2; '
+    'echo "@@cmdwrap";     ($T cmdwrap %s          || true) | head -n 1; '
+    'echo "@@lsdir";       w lsdir; '
+    'echo "@@f4mdump";     ($T f4mdump %s          || true) | head -n 1; '
+    'echo "@@ffmpeg";      ($T ffmpeg -version %s   || true) | head -n 1; '
+    'echo "@@wget";        ($T wget --version %s    || true) | head -n 1; '
+    'echo "@@rtmpdump";    ($T rtmpdump --help %s   || true) | grep -i rtmpdump | head -n 1; '
+    'echo "@@exteplayer3"; ($T exteplayer3 %s       || true) | head -n 2; '
+    'echo "@@gstplayer";   ($T gstplayer %s         || true) | head -n 2; '
+    'echo "@@duktape";     D=/tmp/.e2i_dukver.js; '
+    '  printf "%%s" \'try{var v=Duktape.version;print(Math.floor(v/10000)+"."+(Math.floor(v/100)%%100)+"."+(v%%100))}catch(e){print("?")}\' > $D; '
+    '  ($T duk $D %s || true) | head -n 1; rm -f $D; '
+    'echo "@@deps";        (opkg list-installed 2>/dev/null | grep -i e2iplayer-deps || true); '
+    'echo "@@end"\n'
+) % ((_P,) * 9)
+
+_PROBE_CACHE = None       # parsed binary block, reused for the whole session
+_PROBE_KEEPALIVE = None   # holds the iptv_system object until its callback fires
+_STARTUP_KEEPALIVE = None
+_SNAPSHOT_LOGGED = False   # the full snapshot is already in the current log
+
+
+def _log_snapshot(si):
+    """Write the full system snapshot into the debug log, at most once per
+    log (reset when the log is cleared)."""
+    global _SNAPSHOT_LOGGED
+    if _SNAPSHOT_LOGGED:
+        return
+    _SNAPSHOT_LOGGED = True
+    try:
+        printDBG("=== E2iPlayer system info ===\n"
+                 + _SystemInfo.toPlain(si.buildSystemText(withBinaries=True))
+                 + "\n=== end system info ===")
+    except Exception:
+        printExc()
+
+
+def _free_space(path):
+    try:
+        st = os.statvfs(path)
+        return "%s %s / %s" % (
+            formatBytes(st.f_bavail * st.f_frsize, 1), _("free"),
+            formatBytes(st.f_blocks * st.f_frsize, 1),
+        )
+    except Exception:
+        return "?"
+
+
+def _read_first_line(path):
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    return line
+    except Exception:
+        pass
+    return ""
+
+
+def _debug_log_path():
+    """The resolved debug file path, or '' when the log is off / to console."""
+    try:
+        return GetDebugLogPath() or ""
+    except Exception:
+        return ""
+
+
+_MARKUP_RE = re.compile(r"\\c[0-9a-fA-F]{8}")
+
+
+def _strip_markup(text):
+    """Drop the ScrollLabel \\cRRGGBBAA colour codes for plain-text output."""
+    return _MARKUP_RE.sub("", text)
+
+
+class _SystemInfo(object):
+    """Everything needed to gather + render the System page. No UI, so it
+    can also be used headless at plugin start."""
+
+    def __init__(self):
+        self._systemBinaries = ""
+        self._probe = None
+
+    # ---------------------------------------------------------- gathering
+
+    def _safeDir(self, fnc):
+        try:
+            p = fnc('')
+            return p if p and os.path.isdir(p) else ""
+        except Exception:
+            return ""
+
+    def _image(self):
+        name = GetImageName()  # /etc/os-release PRETTY_NAME
+        if name:
+            return name
+        # /etc/image-version: key=value lines - fallback for images without
+        # a usable os-release
+        kv = {}
+        try:
+            with open("/etc/image-version") as f:
+                for line in f:
+                    if "=" in line:
+                        k, v = line.split("=", 1)
+                        kv[k.strip().lower()] = v.strip()
+        except Exception:
+            pass
+        for combo in (("creator", "version"), ("distro", "imageversion"), ("distro", "version")):
+            if all(k in kv for k in combo):
+                return " ".join(kv[k] for k in combo)
+        if "version" in kv:
+            return kv["version"]
+        line = _read_first_line("/etc/issue")
+        if line:
+            for junk in ("\\n", "\\l", "\\r", "\\s", "\\m"):
+                line = line.replace(junk, "")
+            return line.strip()
+        return "?"
+
+    def _boxtype(self):
+        # boxbranding is what Enigma2 itself uses - baked into the image at
+        # build time. /proc/stb/info/* is whatever the running kernel /
+        # drivers report, which on ported or clone hardware can be a
+        # completely different (and misleading) box id.
+        official = ""
+        try:
+            import boxbranding
+            btype = boxbranding.getBoxType()
+            brand = boxbranding.getMachineBrand()
+            name = boxbranding.getMachineName()
+            official = ("%s %s" % (brand, name)).strip()
+            if btype and btype.lower() not in official.lower():
+                official = "%s (%s)" % (official, btype) if official else btype
+        except Exception:
+            pass
+
+        kernel = ""
+        for path in ("/proc/stb/info/model", "/proc/stb/info/boxtype", "/proc/stb/info/vumodel"):
+            kernel = _read_first_line(path)
+            if kernel:
+                break
+
+        if official and kernel and kernel.lower() not in official.lower():
+            return "%s   [%s: %s]" % (official, _("kernel reports"), kernel)
+        return official or kernel or "?"
+
+    def _pycurlVersion(self):
+        try:
+            import pycurl
+            return pycurl.version.split()[0] if getattr(pycurl, "version", "") else "?"
+        except Exception:
+            return _("not installed")
+
+    def _pilVersion(self):
+        try:
+            import PIL
+            v = getattr(PIL, "__version__", "") or getattr(PIL, "PILLOW_VERSION", "")
+            return str(v) if v else _("installed")
+        except Exception:
+            return _("not installed")
+
+    def _subparserVersion(self):
+        try:
+            from Plugins.Extensions.IPTVPlayer.libs.iptvsubparser import _subparser
+        except Exception as e:
+            return "%s (%s)" % (_("import failed"), str(e)[:60])
+        try:
+            return str(_subparser.version())
+        except Exception:
+            return _("loaded (no version)")
+
+    # --------------------------------------------------------- rendering
+
+    def _parseProbe(self, data):
+        sections, cur = {}, None
+        for raw in data.splitlines():
+            line = raw.rstrip()
+            if line.startswith("@@"):
+                cur = line[2:]
+                if cur != "end":
+                    sections[cur] = []
+                continue
+            if cur and cur in sections and line.strip():
+                sections[cur].append(line.strip())
+
+        def first(key):
+            v = sections.get(key) or []
+            return v[0] if v else _("not found")
+
+        def ver_line(key):
+            v = sections.get(key) or []
+            for line in v:
+                low = line.lower()
+                if line.startswith("{") or "version" in low or " v0." in low or " v1." in low:
+                    return line
+            return v[0] if v else _("not found")
+
+        def present(key):
+            v = (sections.get(key) or ["-"])[0]
+            return _("installed") if v and v != "-" else _("not installed")
+
+        def banner(key):
+            v = sections.get(key) or []
+            if not v:
+                return _("not installed")
+            line = v[0].strip()
+            if line.lower().startswith("version:"):
+                line = "v" + line.split(":", 1)[1].strip()
+            return line or _("installed")
+
+        def row(name, value):
+            return "%s|%s" % (name, value)
+
+        out = ["--- e2iplayer-deps ---"]
+        out.append(row("hlsdl", first("hlsdl")))
+        out.append(row("_subparser", self._subparserVersion()))
+        out.append(row("cmdwrap", banner("cmdwrap")))
+        out.append(row("lsdir", present("lsdir")))
+        out.append(row("f4mdump", banner("f4mdump")))
+        deps = sections.get("deps") or []
+        if deps:
+            out.append(row("deps pkg", deps[0]))
+
+        out.append("")
+        out.append("--- " + _("other binaries") + " ---")
+        out.append(row("ffmpeg", first("ffmpeg")))
+        out.append(row("wget", first("wget")))
+        out.append(row("rtmpdump", first("rtmpdump")))
+        out.append(row("duktape", first("duktape")))
+        out.append(row("exteplayer3", ver_line("exteplayer3")))
+        out.append(row("gstplayer", ver_line("gstplayer")))
+
+        out.append("")
+        out.append("--- " + _("Python modules") + " ---")
+        out.append(row("pycurl", self._pycurlVersion()))
+        out.append(row("Pillow (PIL)", self._pilVersion()))
+        return "\n".join(out)
+
+    def buildSystemText(self, withBinaries=True):
+        lines = []
+
+        def row(label, value):
+            lines.append("%s|%s" % (label, value))
+
+        lines.append("--- E2iPlayer ---")
+        ver = GetIPTVPlayerVersion()
+        stamp = GetIPTVPlayerComitStamp()
+        row(_("version"), ver + (("  " + stamp) if stamp else ""))
+        row("Python", "%s (%s)" % (GetShortPythonVersion(), sys.version.split()[0]))
+
+        lines.append("")
+        lines.append("--- " + _("System") + " ---")
+        row(_("Image"), self._image())
+        row(_("Box"), self._boxtype())
+
+        lines.append("")
+        lines.append("--- " + _("Storage") + " ---")
+        for label, path in ((_("Config"), self._safeDir(GetConfigDir)),
+                            (_("Temp"), self._safeDir(GetTmpDir))):
+            if path:
+                row(label, "%s  [%s]" % (_free_space(path), path))
+
+        lines.append("")
+        lines.append("--- " + _("Debug log") + " ---")
+        logp = _debug_log_path()
+        if logp:
+            sz = ""
+            try:
+                sz = "  (%s)" % formatBytes(os.path.getsize(logp), 1)
+            except Exception:
+                pass
+            row(_("file"), logp + sz)
+        else:
+            row(_("status"), _("off / console"))
+
+        if withBinaries:
+            lines.append("")
+            lines.append(self._systemBinaries or ("--- " + _("Binaries") + " ---\n" + _("(reading...)")))
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def toPlain(text):
+        """label|value -> aligned 'label:  value' for the saved file / log."""
+        out = []
+        for line in _strip_markup(text).split("\n"):
+            if "|" in line and not line.lstrip().startswith("-"):
+                a, b = line.split("|", 1)
+                out.append("%-15s %s" % (a + ":", b))
+            else:
+                out.append(line)
+        return "\n".join(out)
+
+    # ------------------------------------------------------------- probe
+
+    def runProbe(self, onDone):
+        """Fill self._systemBinaries (async) then call onDone(). Uses the
+        module-level cache, so it only ever actually probes once."""
+        global _PROBE_KEEPALIVE
+        self._systemBinaries = ""
+        if _PROBE_CACHE:
+            self._systemBinaries = _PROBE_CACHE
+            onDone()
+            return
+
+        def _cb(code, data):
+            global _PROBE_CACHE, _PROBE_KEEPALIVE
+            _PROBE_KEEPALIVE = None
+            self._probe = None
+            try:
+                self._systemBinaries = self._parseProbe(data or "")
+                _PROBE_CACHE = self._systemBinaries
+            except Exception:
+                printExc()
+                self._systemBinaries = (data or "").strip()
+            try:
+                onDone()
+            except Exception:
+                printExc()
+
+        try:
+            with open(_PROBE_SCRIPT_PATH, "w") as f:
+                f.write(_PROBE_SCRIPT)
+            self._probe = iptv_system("sh %s; rm -f %s" % (_PROBE_SCRIPT_PATH, _PROBE_SCRIPT_PATH), _cb)
+            _PROBE_KEEPALIVE = self._probe
+        except Exception:
+            printExc()
+            self._probe = None
+            self._systemBinaries = _("could not run the probe")
+            onDone()
+
+
+class IPTVPlayerInfoView(_SystemInfo, Screen):
+
+    def __prepareSkin(self):
+        iconBase = skinchrome.getIconBase()
+        return """
+        <screen name="IPTVPlayerInfoView" position="center,center" size="1200,620" resolution="1280,720" title="E2iPlayer" backgroundColor="#34111112" flags="wfNoBorder">
+            %s
+            <widget name="text" position="20,80" size="1160,468" font="Regular;20" splitPosition="230" transparent="1" backgroundColor="black" foregroundColor="white" />
+            <widget name="about" position="20,80" size="1160,468" font="Regular;20" halign="center" transparent="1" backgroundColor="black" foregroundColor="white" />
+            %s
+        </screen>
+        """ % (
+            skinchrome.build_header_auto(iconBase=iconBase),
+            skinchrome.build_footer_auto(620, iconBase=iconBase, keys=('green', 'yellow', 'blue')),
+        )
+
+    def __init__(self, session, aboutText=""):
+        _SystemInfo.__init__(self)
+        self.skin = self.__prepareSkin()
+        Screen.__init__(self, session)
+        self.skinName = skinchrome.forceInternalSkinName(["IPTVPlayerInfoView"])
+
+        self._page = PAGE_ABOUT
+        self._aboutText = aboutText or self._buildAbout()
+        self._systemText = ""
+        self._logAutoRefresh = True
+        self._closed = False
+
+        self["text"] = ScrollLabel(" ")
+        self["about"] = ScrollLabel(" ")
+        self["key_red"] = StaticText("")
+        self["key_green"] = StaticText("")
+        self["key_yellow"] = StaticText("")
+        self["key_blue"] = StaticText("")
+
+        self["actions"] = ActionMap(["OkCancelActions", "DirectionActions", "ColorActions"],
+        {
+            "cancel": self.close,
+            "ok": self.close,
+            "up": self._pageUp,
+            "down": self._pageDown,
+            "left": self._prevPage,
+            "right": self._nextPage,
+            "green": self._save,
+            "yellow": self._toggleAutoRefresh,
+            "blue": self._clearLog,
+        }, -1)
+
+        self._logTimer = eTimer()
+        self._logTimer_conn = eConnectCallback(self._logTimer.timeout, self._refreshLog)
+
+        self.onLayoutFinish.append(self._onStart)
+        self.onClose.append(self._onClose)
+
+    # ---------------------------------------------------------------- lifecycle
+
+    def _onStart(self):
+        self.runProbe(self._finishSystem)
+        self._showPage()
+
+    def _onClose(self):
+        self._closed = True
+        try:
+            self._logTimer.stop()
+        except Exception:
+            pass
+        self._logTimer = None
+        self._logTimer_conn = None
+        # do not terminate self._probe - _PROBE_KEEPALIVE lets it finish
+        # and populate the cache even if the screen is closed at once
+
+    # ------------------------------------------------------------------- paging
+
+    def _nextPage(self):
+        self._page = (self._page + 1) % 3
+        self._showPage()
+
+    def _prevPage(self):
+        self._page = (self._page - 1) % 3
+        self._showPage()
+
+    def _view(self):
+        # About has its own centred widget; System / Log share "text"
+        return self["about"] if self._page == PAGE_ABOUT else self["text"]
+
+    def _pageUp(self):
+        self._view().pageUp()
+
+    def _pageDown(self):
+        self._view().pageDown()
+
+    def _setSplit(self):
+        # the label|value two-column layout is only wanted on the System
+        # page ("text" widget); the Log can contain '|' characters
+        try:
+            inst = self["text"].instance
+            if inst and hasattr(inst, "setSplitPosition"):
+                on = self._page == PAGE_SYSTEM
+                inst.setSplitPosition(skinchrome.scalePixels(230, skinchrome.getScale()) if on else 0)
+        except Exception:
+            printExc()
+
+    def _showPage(self):
+        self._logTimer.stop()
+        name = PAGE_NAMES.get(self._page, "")
+        self.setTitle("E2iPlayer - %s  (%d/3)" % (name, self._page + 1))
+        self._setSplit()
+        aboutPage = self._page == PAGE_ABOUT
+        self["about"].visible = aboutPage
+        self["text"].visible = not aboutPage
+
+        if self._page == PAGE_ABOUT:
+            self["about"].setText(self._aboutText)
+            self["key_green"].setText(_("Save"))
+            self["key_yellow"].setText("")
+            self["key_blue"].setText("")
+        elif self._page == PAGE_SYSTEM:
+            self["text"].setText(self._systemText or (self.buildSystemText(withBinaries=False) + "\n\n" + _("Reading binaries...")))
+            self["key_green"].setText(_("Save"))
+            self["key_yellow"].setText("")
+            self["key_blue"].setText("")
+        else:  # PAGE_LOG
+            self["key_green"].setText(_("Save"))
+            self["key_yellow"].setText(_("Auto refresh: %s") % (_("on") if self._logAutoRefresh else _("off")))
+            self["key_blue"].setText(_("Clear log"))
+            self._refreshLog()
+            if self._logAutoRefresh:
+                self._logTimer.start(LOG_REFRESH_MS, False)
+
+    def _finishSystem(self):
+        _log_snapshot(self)  # in case the startup probe never ran
+        if self._closed:
+            return
+        self._systemText = self.buildSystemText(withBinaries=True)
+        if self._page == PAGE_SYSTEM:
+            self["text"].setText(self._systemText)
+
+    # ------------------------------------------------------------------ content
+
+    def _buildAbout(self):
+        hc = "\\c%08x" % _HEADING_COLOR   # heading colour (ScrollLabel markup)
+        tc = "\\c%08x" % _TEXT_COLOR
+        stamp = GetIPTVPlayerComitStamp()
+
+        version = "Oe-Mirrors Python3 Version Powered by openATV Team\n" \
+                  + GetIPTVPlayerVersion() + (("  (" + stamp + ")") if stamp else "")
+
+        blocks = [
+            (_("version"), version),
+            (_("www:"), "https://github.com/oe-mirrors/e2iplayer"),
+            (_("Developers:"), ", ".join([
+                'samsamsam', 'zdzislaw22', 'mamrot', 'MarcinO', 'skalita', 'atilaks',
+                'huball', 'matzg', 'tomashj291', 'a4tech', 'Blindspot76',
+                'Max (maxbambi)', '-=Mario=- (zadmario)', 'MohamedOS', 'Lululla (Belfagor2005)',
+                'jbleyel', 'Mr.X', 'and others',
+            ])),
+            (_("Testers:"), ", ".join(('Masta2002', 'Testing Community: Enigma2 users worldwide'))),
+            (_("Skinners:"), ", ".join(('stein17', 'and others'))),
+        ]
+        return "\n\n".join("%s%s\n%s%s" % (hc, head, tc, body) for head, body in blocks)
+
+    # -------------------------------------------------------------------- log
+
+    def _refreshLog(self):
+        logp = _debug_log_path()
+        if not logp:
+            self["text"].setText(_("The debug log is disabled or set to console output.\n\nEnable it in the E2iPlayer configuration (Debug -> log to file) and reproduce the problem, then come back here."))
+            return
+        text = self._tail(logp, LOG_TAIL_BYTES)
+        if not text:
+            text = _("The debug log file is empty:\n%s") % logp
+        self["text"].setText(text)
+        for mname in ("lastPage", "moveBottom", "moveEnd"):
+            fn = getattr(self["text"], mname, None)
+            if callable(fn):
+                try:
+                    fn()
+                    break
+                except Exception:
+                    pass
+
+    def _tail(self, path, nbytes):
+        try:
+            size = os.path.getsize(path)
+            with open(path, "rb") as f:
+                if size > nbytes:
+                    f.seek(size - nbytes)
+                    f.readline()  # drop the partial first line
+                data = f.read()
+            return data.decode("utf-8", "ignore")
+        except Exception:
+            return ""
+
+    def _toggleAutoRefresh(self):
+        if self._page != PAGE_LOG:
+            return
+        self._logAutoRefresh = not self._logAutoRefresh
+        self["key_yellow"].setText(_("Auto refresh: %s") % (_("on") if self._logAutoRefresh else _("off")))
+        if self._logAutoRefresh:
+            self._refreshLog()
+            self._logTimer.start(LOG_REFRESH_MS, False)
+        else:
+            self._logTimer.stop()
+
+    def _clearLog(self):
+        if self._page != PAGE_LOG:
+            return
+        from Screens.MessageBox import MessageBox
+        logp = _debug_log_path()
+        if not logp or not os.path.exists(logp):
+            self.session.open(MessageBox, _("The debug log is not active."), type=MessageBox.TYPE_INFO, timeout=6)
+            return
+        self.session.openWithCallback(self._clearLogConfirmed, MessageBox,
+                                      _("Clear the debug log file?\n%s") % logp, type=MessageBox.TYPE_YESNO)
+
+    def _clearLogConfirmed(self, answer):
+        global _SNAPSHOT_LOGGED
+        if not answer:
+            return
+        logp = _debug_log_path()
+        try:
+            open(logp, "w").close()
+            _SNAPSHOT_LOGGED = False  # let the snapshot go into the fresh log
+        except Exception:
+            printExc()
+        try:
+            import glob
+            base, ext = os.path.splitext(logp)
+            for f in glob.glob(base + "-*" + ext):
+                try:
+                    os.remove(f)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        _log_snapshot(self)  # put the snapshot back at the top of the fresh log
+        self._refreshLog()
+
+    # ------------------------------------------------------------------- save
+
+    def _save(self):
+        from Screens.MessageBox import MessageBox
+        try:
+            if self._page == PAGE_LOG:
+                logp = _debug_log_path()
+                if not logp or not os.path.exists(logp):
+                    self.session.open(MessageBox, _("Nothing to save - the debug log is not active."), type=MessageBox.TYPE_INFO, timeout=6)
+                    return
+                dst = DEBUGCOPY_FILE
+                with open(dst, "w") as f:
+                    f.write(self._tail(logp, LOG_TAIL_BYTES * 8))
+            else:
+                dst = SYSINFO_FILE
+                with open(dst, "w") as f:
+                    f.write("=== E2iPlayer - System ===\n\n")
+                    f.write(self.toPlain(self._systemText or self.buildSystemText(withBinaries=True)))
+                    f.write("\n\n\n=== E2iPlayer - About ===\n\n")
+                    f.write(_strip_markup(self._aboutText) + "\n")
+            self.session.open(MessageBox, _("Saved to:\n%s") % dst, type=MessageBox.TYPE_INFO, timeout=8)
+        except Exception:
+            printExc()
+            self.session.open(MessageBox, _("Could not write the file."), type=MessageBox.TYPE_ERROR, timeout=8)
+
+
+def LogSystemInfoAtStartup(force=False):
+    """Called from plugin start: run the binary probe (cached after the
+    first time) and write the full system snapshot near the top of the
+    debug log. `force` re-logs it into a freshly cleared log."""
+    global _STARTUP_KEEPALIVE, _SNAPSHOT_LOGGED
+    if force:
+        _SNAPSHOT_LOGGED = False
+    if _SNAPSHOT_LOGGED:
+        return
+    si = _SystemInfo()
+    _STARTUP_KEEPALIVE = si
+
+    def _done():
+        global _STARTUP_KEEPALIVE
+        _log_snapshot(si)
+        _STARTUP_KEEPALIVE = None
+
+    try:
+        si.runProbe(_done)
+    except Exception:
+        printExc()
+        _STARTUP_KEEPALIVE = None
+
+
+def OpenInfoView(session, aboutText=""):
+    """Entry point used by playerselector / the settings BLUE key."""
+    try:
+        session.open(IPTVPlayerInfoView, aboutText)
+        return True
+    except Exception:
+        printExc()
+        return False

--- a/IPTVPlayer/components/iptvplayerwidget.py
+++ b/IPTVPlayer/components/iptvplayerwidget.py
@@ -42,7 +42,7 @@ from Plugins.Extensions.IPTVPlayer.libs.pCommon import CParsingHelper
 from Plugins.Extensions.IPTVPlayer.libs.urlparser import urlparser
 from Plugins.Extensions.IPTVPlayer.tools.iptvfavourites import IPTVFavourites
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import FreeSpace as iptvtools_FreeSpace, \
-                                                          mkdirs as iptvtools_mkdirs, GetIPTVPlayerVersion, \
+                                                          mkdirs as iptvtools_mkdirs, GetIPTVPlayerVersion, GetShortSystemInfo, \
                                                           printDBG, printExc, iptv_system, GetHostsList, IsHostEnabled, \
                                                           eConnectCallback, GetSkinsDir, GetIconDir, GetPluginDir, \
                                                           SortHostsList, GetHostsOrderList, CSearchHistoryHelper, \
@@ -261,7 +261,7 @@ class E2iPlayerWidget(Screen):
         )
 
     def __init__(self, session):
-        printDBG("E2iPlayerWidget.__init__ desktop IPTV_VERSION[%s]\n" % (E2iPlayerWidget.IPTV_VERSION))
+        printDBG("E2iPlayerWidget.__init__ desktop IPTV_VERSION[%s] %s\n" % (E2iPlayerWidget.IPTV_VERSION, GetShortSystemInfo()))
         self.session = session
 
         self.skin = self.__prepareSkin()

--- a/IPTVPlayer/components/playerselector.py
+++ b/IPTVPlayer/components/playerselector.py
@@ -586,6 +586,14 @@ class _PlayerSelectorListMode:
         return _getSearchResultsHeight(numItems)
 
     def showInfo(self):
+        try:
+            from Plugins.Extensions.IPTVPlayer.components.iptvplayerinfoview import OpenInfoView
+            if OpenInfoView(self.session):
+                return
+        except Exception:
+            printExc()
+
+        # fallback - the plain "About" MessageBox
         TextMSG = _('version') + " :\n" + GetIPTVPlayerVersion() + '\n\n'
         TextMSG += _("www:") + " " + "\nhttps://github.com/oe-mirrors/e2iplayer" + '\n\n'
         TextMSG += _("Developers:") + " " + "\n"
@@ -603,8 +611,10 @@ class _PlayerSelectorListMode:
             'Blindspot76',
             'Max (maxbambi)',
             '-=Mario=- (zadmario)',
+            'MohamedOS',
             'Lululla (Belfagor2005)',
             'jbleyel',
+            'Mr.X',
             'and others'
         ]
         TextMSG += ", ".join(developers)

--- a/IPTVPlayer/plugin.py
+++ b/IPTVPlayer/plugin.py
@@ -10,7 +10,6 @@ from Plugins.Plugin import PluginDescriptor
 from Screens.MessageBox import MessageBox
 from Tools.BoundFunction import boundFunction
 from Components.config import config
-import os
 
 
 def Plugins(**kwargs):
@@ -111,13 +110,26 @@ class pluginAutostart(Screen):
 
 
 def doRunMain(session):
-    for DBGfile in ['/hdd/iptv.dbg', '/tmp/iptv.dbg', '/home/root/logs/iptv.dbg']:
-        if os.path.exists(DBGfile):
-            os.remove(DBGfile)
     session.open(E2iPlayerWidget)
 
 
 def runMain(session, nextFunction=doRunMain):
+    # clear the debug log(s) here so every entry path (incl. the wizard
+    # autostart) behaves the same; ClearDebugLogsAtStart() itself honors
+    # config.plugins.iptvplayer.debug_clear_on_start (default: on)
+    cleared = False
+    try:
+        from Plugins.Extensions.IPTVPlayer.tools.iptvtools import ClearDebugLogsAtStart
+        cleared = ClearDebugLogsAtStart()
+    except Exception:
+        pass
+    # fire the binary probe once and drop the full system snapshot near
+    # the top of the (now fresh) debug log
+    try:
+        from Plugins.Extensions.IPTVPlayer.components.iptvplayerinfoview import LogSystemInfoAtStartup
+        LogSystemInfoAtStartup(force=cleared)
+    except Exception:
+        pass
     nextFunction(session)
 
 

--- a/IPTVPlayer/tools/iptvtools.py
+++ b/IPTVPlayer/tools/iptvtools.py
@@ -626,7 +626,95 @@ def getDebugMode():
     return DBG
 
 
+# the three file paths the debug-log config UI offers
+DEBUG_LOG_PATHS = ('/hdd/iptv.dbg', '/tmp/iptv.dbg', '/home/root/logs/iptv.dbg')
+
+
+def GetDebugLogPath():
+    """The resolved debug file path, or '' when logging is off / to console."""
+    DBG = getDebugMode()
+    if not DBG or DBG == 'console':
+        return ''
+    return '/hdd/iptv.dbg' if DBG == 'debugfile' else DBG
+
+
+def _debugCfg(name, default):
+    try:
+        return getattr(config.plugins.iptvplayer, name).value
+    except Exception:
+        return default
+
+
+def _rotatedGlob(path):
+    base, ext = os.path.splitext(path)
+    try:
+        import glob
+        return sorted(glob.glob(base + '-*' + ext))
+    except Exception:
+        return []
+
+
+def ClearDebugLogsAtStart():
+    """Called from plugin start. Deletes the active debug file plus every
+    preset path plus their rotated <base>-<date><ext> siblings - unless the
+    user turned 'clear at start' off (default on = the old behaviour).
+    Returns True when it actually removed something."""
+    if not _debugCfg('debug_clear_on_start', True):
+        return False
+    targets = set(DEBUG_LOG_PATHS)
+    cur = GetDebugLogPath()
+    if cur:
+        targets.add(cur)
+    removed = False
+    for path in targets:
+        for f in [path] + _rotatedGlob(path):
+            try:
+                if os.path.exists(f):
+                    os.remove(f)
+                    removed = True
+            except Exception:
+                pass
+    return removed
+
+
+_g_dbg_calls = 0
+
+
+def _enforceDebugLogLimit(path):
+    try:
+        maxMB = int(_debugCfg('debug_max_size', '0') or '0')
+    except Exception:
+        maxMB = 0
+    if maxMB <= 0:
+        return
+    try:
+        if os.path.getsize(path) < maxMB * 1024 * 1024:
+            return
+    except Exception:
+        return
+    try:
+        if _debugCfg('debug_on_limit', 'truncate') == 'rotate':
+            base, ext = os.path.splitext(path)
+            stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+            os.rename(path, '%s-%s%s' % (base, stamp, ext))
+            try:
+                keep = int(_debugCfg('debug_rotate_keep', '3') or '3')
+            except Exception:
+                keep = 3
+            old = _rotatedGlob(path)
+            for f in (old[:-keep] if keep > 0 else old):
+                try:
+                    os.remove(f)
+                except Exception:
+                    pass
+        else:
+            open(path, 'w').close()
+    except Exception:
+        pass
+
+
 def printDBG(DBGtxt, writeMode='a'):
+    global _g_dbg_calls
     DBG = getDebugMode()
     if DBG == '':
         return
@@ -637,6 +725,9 @@ def printDBG(DBGtxt, writeMode='a'):
             DBGfile = '/hdd/iptv.dbg'  # backward compatibility
         else:
             DBGfile = DBG
+        _g_dbg_calls += 1
+        if _g_dbg_calls % 250 == 0:
+            _enforceDebugLogLimit(DBGfile)
         try:
             with open(DBGfile, writeMode) as f:
                 f.write(str(DBGtxt) + '\n')
@@ -1574,6 +1665,29 @@ def GetIPTVPlayerComitStamp():
 
 def GetShortPythonVersion():
     return "%d.%d" % (sys.version_info[0], sys.version_info[1])
+
+
+def GetImageName():
+    """The image's PRETTY_NAME from /etc/os-release, or '' if unavailable."""
+    try:
+        with open('/etc/os-release') as f:
+            for line in f:
+                if line.startswith('PRETTY_NAME='):
+                    return line.split('=', 1)[1].strip().strip('"')
+    except Exception:
+        pass
+    return ''
+
+
+def GetShortSystemInfo():
+    """A one-line image/box/python string for the top of the debug log."""
+    box = ''
+    try:
+        import boxbranding
+        box = boxbranding.getBoxType()
+    except Exception:
+        pass
+    return "image[%s] box[%s] python[%s]" % (GetImageName() or '?', box or '?', GetShortPythonVersion())
 
 
 def GetVersionNum(ver):

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.06.03"
+IPTV_VERSION = "2026.09.07.01"


### PR DESCRIPTION
New screen (IPTVPlayer/components/iptvplayerinfoview.py), opened from the PlayerSelector BLUE "Info" menu and from the settings BLUE key. It replaces the plain "About" MessageBox with three pages, switched with LEFT / RIGHT:

  * About  - version + "Powered by openATV Team" line, project link, developers / testers / skinners. Centred, coloured headings.
  * System - E2iPlayer / Python / image / box, config and tmp free space, the debug-log setting, and every externally loaded tool with its version: e2iplayer-deps : hlsdl, _subparser, cmdwrap, lsdir, f4mdump, deps opkg package other binaries : ffmpeg, wget, rtmpdump, duktape, exteplayer3, gstplayer python modules : pycurl, Pillow Two-column aligned layout.
  * Log    - live tail of the debug log; YELLOW toggles auto-refresh,
             BLUE clears it (and its rotated files).

  GREEN saves the current page to /tmp (e2iplayer_sysinfo.txt or
  e2iplayer_debug.txt).

The box id is taken from boxbranding (not /proc/stb/info, which reports a wrong model on ported / clone hardware). The tool probe runs once at plugin start via a single non-blocking shell call and the full snapshot (incl. binary versions) is written near the top of the debug log, so it is already present in any log shared for support; the first debug line also carries image / box / python. showInfo() falls back to the old MessageBox if the screen cannot open. New UI strings are English only.

Debug-log management - new "DEBUG CONFIGURATION" section in the settings, shown when logging goes to a file:

  * Clear the log file at plugin start (default: on). The clearing now happens for every entry path, including the wizard autostart, which never cleared before.
  * Maximum log file size (unlimited, or 2..100 MB). printDBG() checks the size periodically and, over the limit, either truncates the file or rotates it to iptv-<date>.dbg and starts a new one.
  * Number of rotated files to keep (rotation only).

iptvtools.py gains GetDebugLogPath / GetImageName / GetShortSystemInfo / ClearDebugLogsAtStart and the size-limit enforcement in printDBG().