### PR TITLE
Hoster resiliency: parserBYSE JSON headers, parserSTREAMTAPE / parser…

### DIFF
--- a/IPTVPlayer/hosts/hostpremiumsmarteu.py
+++ b/IPTVPlayer/hosts/hostpremiumsmarteu.py
@@ -213,4 +213,4 @@ class IPTVHost(CHostBase):
         CHostBase.__init__(self, Premiumsmarteu(), True, [])
 
     def withArticleContent(self, cItem):
-        return cItem["category"] in ["video", "list_seasons", "list_episodes"]
+        return cItem.get("category") in ["video", "list_seasons", "list_episodes"]

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -1344,16 +1344,26 @@ class pageParser(CaptchaHelper):
         cUrl = self.cm.meta["url"]
         if "/embed" not in cUrl:
             url = self.cm.getFullUrl("/embed/" + cUrl.rsplit("/", 1)[(-1)], cUrl)
-            sts, tmp = self.cm.getPage(baseUrl, {"header": HTTP_HEADER})
+            sts, tmp = self.cm.getPage(url, {"header": HTTP_HEADER})
             if not sts:
                 return False
             data += tmp
             cUrl = self.cm.meta["url"]
-        data = ph.search(data, """['"]([a-zA-Z0-9=]{128,512})['"]""")[0]
+        blob = ph.search(data, """['"]([a-zA-Z0-9=]{128,512})['"]""")[0]
+        if not blob:
+            # upzone.cc caps free-user transfer and then serves a stripped
+            # "premium only" page with no player payload (Polish: "Transfer dla
+            # darmowych uzytkownikow zostal wyczerpany ... PREMIUM").
+            if "wyczerpany" in data or "PREMIUM" in data:
+                SetIPTVPlayerLastHostError(_("upzone.cc: free transfer limit reached - PREMIUM account required."))
+            return False
         js_params = [{"path": GetJSScriptFile("upzonecc.byte")}]
-        js_params.append({"code": "print(cnc(atob('%s')));" % data})
+        js_params.append({"code": "print(cnc(atob('%s')));" % blob})
         ret = js_execute_ext(js_params)
-        url = self.cm.getFullUrl(ret["data"].strip(), cUrl)
+        streamUrl = (ret.get("data", "") if ret else "").strip()
+        if not streamUrl:
+            return False
+        url = self.cm.getFullUrl(streamUrl, cUrl)
         return strwithmeta(url, {"Referer": cUrl, "User-Agent": HTTP_HEADER["User-Agent"]})
 
     def parser1FICHIERCOM(self, baseUrl):  # Need test
@@ -1978,10 +1988,21 @@ class pageParser(CaptchaHelper):
                     subLang = self.cm.ph.getSearchGroups(track, 'srclang="([^"]+?)"')[0]
                     subLabel = self.cm.ph.getSearchGroups(track, 'label="([^"]+?)"')[0]
                     subTracks.append({"title": subLabel + "_" + subLang, "url": subUrl, "lang": subLang, "format": "srt"})
-            t = self.cm.ph.getSearchGroups(data, """innerHTML = ([^;]+?);""")[0] + ";"
+            t = self.cm.ph.getSearchGroups(data, """innerHTML = ([^;]+?);""")[0]
+            if not t:
+                # no player token in the page - streamtape now serves a
+                # bot/geo wall (HTTP 200 with an interstitial) instead of the
+                # real embed; bail out cleanly instead of eval()-ing garbage.
+                printDBG("parserSTREAMTAPE no innerHTML token - page blocked?")
+                return urltabs
+            t = t + ";"
             printDBG("parserSTREAMTAPE t[%s]" % t)
             t = t.replace(".substring(", "[", 1).replace(").substring(", ":][").replace(");", ":]") + "[1:]"
-            t = eval(t)
+            try:
+                t = eval(t)
+            except Exception:
+                printExc()
+                return urltabs
             if t.startswith("/"):
                 t = "https:/" + t
             if self.cm.isValidUrl(t):
@@ -2240,7 +2261,13 @@ class pageParser(CaptchaHelper):
         sts, data = self.cm.getPage(host + "api/stream", {"header": HTTP_HEADER, "raw_post_data": True}, post)
         if not sts:
             return []
-        data = json_loads(data)
+        try:
+            # a dead strmup mirror redirects /api/stream to a parked domain that
+            # answers 200 with a few bytes of HTML - don't crash on that
+            data = json_loads(data)
+        except Exception:
+            printDBG("parserSTREAMUP non-JSON response - host down/parked?")
+            return []
         url = data.get("streaming_url")
         if isinstance(data.get("subtitles"), list):
             subTracks = [{"title": "", "url": sub.get("file_path"), "lang": sub.get("language")} for sub in data.get("subtitles", []) if sub.get("file_path") and sub.get("language")]
@@ -2487,6 +2514,17 @@ class pageParser(CaptchaHelper):
             except Exception:
                 return None
 
+        def jsonPost():
+            # params for the API POST endpoints (challenge/attest/captcha/
+            # verify/playback). Send a real JSON Content-Type (pycurl otherwise
+            # defaults to application/x-www-form-urlencoded) and disable the
+            # automatic "Expect: 100-continue" handshake, matching the site's
+            # own frontend and upstream ResolveURL (jdata=True).
+            hdr = dict(HTTP_HEADER)
+            hdr["Content-Type"] = "application/json"
+            hdr["Expect"] = ""
+            return {"header": hdr, "raw_post_data": True, "timeout": 40}
+
         baseUrl = baseUrl.replace("/d/", "/e/")
         printDBG("parserBYSE baseUrl[%s]" % baseUrl)
         urltab = []
@@ -2534,20 +2572,20 @@ class pageParser(CaptchaHelper):
 
         if settings.get("captcha_required"):
             challengeUrl = "%sapi/videos/access/challenge" % ref
-            sts, data = self.cm.getPage(challengeUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, "")
+            sts, data = self.cm.getPage(challengeUrl, jsonPost(), "")
             challenge = tryJson(data) if sts else None
             if challenge is None:
                 return []
 
             attestUrl = "%sapi/videos/access/attest" % ref
-            sts, data = self.cm.getPage(attestUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps(wn(challenge)))
+            sts, data = self.cm.getPage(attestUrl, jsonPost(), json_dumps(wn(challenge)))
             attest = tryJson(data) if sts else None
             if attest is None:
                 return []
             fingerprint = {"token": attest.get("token"), "viewer_id": attest.get("viewer_id"), "device_id": attest.get("device_id"), "confidence": attest.get("confidence")}
 
             captchaUrl = "%sapi/videos/%s/%scaptcha" % (ref, mid, embed)
-            sts, data = self.cm.getPage(captchaUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps({"fingerprint": fingerprint}))
+            sts, data = self.cm.getPage(captchaUrl, jsonPost(), json_dumps({"fingerprint": fingerprint}))
             captcha = tryJson(data) if sts else None
             if captcha is None:
                 return []
@@ -2557,17 +2595,17 @@ class pageParser(CaptchaHelper):
 
             verifyUrl = "%sapi/videos/%s/%scaptcha/verify" % (ref, mid, embed)
             verifyPost = {"pow_token": captcha.get("pow_token"), "solution": solution, "fingerprint": fingerprint}
-            sts, data = self.cm.getPage(verifyUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps(verifyPost))
+            sts, data = self.cm.getPage(verifyUrl, jsonPost(), json_dumps(verifyPost))
             verify = tryJson(data) if sts else None
             if verify is None:
                 return []
             HTTP_HEADER["X-Captcha-Token"] = verify.get("token", "")
 
             playbackUrl = "%sapi/videos/%s/%splayback" % (ref, mid, embed)
-            sts, data = self.cm.getPage(playbackUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True, "timeout": 40}, json_dumps({"fingerprint": fingerprint}))
+            sts, data = self.cm.getPage(playbackUrl, jsonPost(), json_dumps({"fingerprint": fingerprint}))
         else:
             playbackUrl = "%sapi/videos/%s/%splayback" % (ref, mid, embed)
-            sts, data = self.cm.getPage(playbackUrl, {"header": dict(HTTP_HEADER), "raw_post_data": True}, json_dumps(fp(16, 0.83, 0.94)))
+            sts, data = self.cm.getPage(playbackUrl, jsonPost(), json_dumps(fp(16, 0.83, 0.94)))
         if not sts:
             return []
 

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.07.04"
+IPTV_VERSION = "2026.09.08.01"


### PR DESCRIPTION
…STREAMUP / parserUPZONECC guards

Fixes reported against oe-mirrors/e2iplayer#571 plus crashes seen in the same debug logs.

parserBYSE
  The captcha flow POSTs JSON bodies, but they were sent via raw_post_data with
  no Content-Type, so pycurl defaulted to application/x-www-form-urlencoded, and
  the larger bodies also tripped libcurl's automatic "Expect: 100-continue".
  A jsonPost() helper now sends Content-Type: application/json and an empty
  Expect header on all six API POSTs (challenge/attest/captcha/verify/both
  playback paths), matching the site frontend and upstream ResolveURL
  (jdata=True); the non-captcha playback POST also gets the same 40s timeout as
  the rest. (byse's access/attest endpoint additionally black-holes some
  clients server-side; that part is not solvable here.)

parserSTREAMTAPE
  streamtape.com now serves a bot/geo interstitial (HTTP 200) with no
  "innerHTML = ...;" assignment. getSearchGroups() then returned "", which
  became eval(";[1:]") -> SyntaxError. Bail out when the token is absent and
  wrap the eval() so a future markup change degrades to "no links".

parserSTREAMUP
  A dead strmup/vidara mirror 302s /api/stream to a parked domain that answers
  200 with a few bytes of HTML (or a bare 500 body); json_loads() crashed.
  Guard it and return [].

parserUPZONECC
  upzone.cc caps free-user transfer and then serves a stripped "premium only"
  page (Polish "...zostal wyczerpany ... PREMIUM") with no player payload; the
  decoder then ran on an empty blob and built an empty URL. Detect the missing
  payload, surface the premium/transfer message via SetIPTVPlayerLastHostError,
  and guard the js_execute_ext output. Also fix the /embed fallback, which
  re-fetched baseUrl instead of the freshly built /embed/ url.

hostpremiumsmarteu
  withArticleContent() raised KeyError 'category' when INFO was pressed on an
  item without that key -> use .get().