### PR TITLE
Fix real SonarCloud bugs + analysis-scope config

### DIFF
--- a/IPTVPlayer/hosts/hostfavourites.py
+++ b/IPTVPlayer/hosts/hostfavourites.py
@@ -126,9 +126,9 @@ class Favourites(CBaseHostClass):
             self.hostName = None
             retlist = []
             urlList = self.up.getVideoLinkExt(item.data)
-            for item in urlList:
-                name = self.host.cleanHtmlStr(item["name"])
-                url = item["url"]
+            for urlItem in urlList:
+                name = self.cleanHtmlStr(urlItem["name"])
+                url = urlItem["url"]
                 retlist.append(CUrlItem(name, url, 0))
             ret = RetHost(RetHost.OK, value=retlist)
         elif CFavItem.RESOLVER_DIRECT_LINK == item.resolver:
@@ -412,7 +412,6 @@ class IPTVHost(CHostBase):
                     if self.isItemWatched(idx, ret.value[idx]):
                         ret.value[idx].isWatched = True
                         ret.value[idx].isStarted = False
-                        ret.value[idx].name = ret.value[idx].name
                     elif self.isItemStarted(idx, ret.value[idx]):
                         ret.value[idx].isStarted = True
             self.cachedRet = ret

--- a/IPTVPlayer/hosts/hostlodynet.py
+++ b/IPTVPlayer/hosts/hostlodynet.py
@@ -1579,8 +1579,6 @@ class Lodynet(CBaseHostClass):
                             label = "576p"
                         elif "384" in label:
                             label = "384p"
-                        else:
-                            label = label
                     else:
                         if ".m3u8" in video_url.lower():
                             label = "HLS Stream"

--- a/IPTVPlayer/hosts/hostm4sport.py
+++ b/IPTVPlayer/hosts/hostm4sport.py
@@ -364,7 +364,7 @@ class m4sport(CBaseHostClass):
                     vl = 'https:' + vl
                 if not self.cm.isValidUrl(vl):
                     return ''
-                if len(vl) != '':
+                if vl:
                     bu = vl
         except Exception:
             return ''

--- a/IPTVPlayer/hosts/hoststreamliveto.py
+++ b/IPTVPlayer/hosts/hoststreamliveto.py
@@ -70,7 +70,6 @@ class StreamLiveTo(CBaseHostClass):
 
     def getPage(self, url, params={}, post_data=None):
         return self.cm.getPage(url, params, post_data)
-        return self.checkBotProtection(url, params)
 
     def cleanHtmlStr(self, data):
         data = data.replace('&nbsp;', ' ')

--- a/IPTVPlayer/hosts/hostwebhuplayer.py
+++ b/IPTVPlayer/hosts/hostwebhuplayer.py
@@ -197,7 +197,7 @@ class webhuplayer(CBaseHostClass):
                         if self._copy(destination_fo + '/*', self.path_webh):
                             msg = 'Sikerült a webmedia könyvtár frissítése/telepítése!'
                             self.sessionEx.open(MessageBox, msg, type=MessageBox.TYPE_INFO, timeout=10)
-                            self.list_tartalom()
+                            self.list_tartalom({'name': 'category'})
                         else:
                            msg = 'A frissítés/telepítés sikertelen! (Másolási hiba)'
                            self.sessionEx.open(MessageBox, msg, type=MessageBox.TYPE_ERROR, timeout=20)

--- a/IPTVPlayer/hosts/hostxxx.py
+++ b/IPTVPlayer/hosts/hostxxx.py
@@ -736,9 +736,9 @@ class Host(CBaseHostClass, XXXParser):
 	def getJumpItem(self, max_page, url, name):
 		name = name.split('-')[0] + "-JUMP"
 		if max_page:
-			return CDisplayListItem(_("Jump"), _("Jump to a selected page, max: {}").format(max_page), CDisplayListItem.TYPE_CATEGORY, [url], name, '', str(max_page) if max_page else None, imageType="JUMP")
+			return CDisplayListItem(_("Jump"), _("Jump to a selected page, max: {}").format(max_page), CDisplayListItem.TYPE_CATEGORY, [url], name, '', str(max_page), imageType="JUMP")
 		else:
-			return CDisplayListItem(_("Jump"), _("Jump to a selected page"), CDisplayListItem.TYPE_CATEGORY, [url], name, '', str(max_page) if max_page else None, imageType="JUMP")
+			return CDisplayListItem(_("Jump"), _("Jump to a selected page"), CDisplayListItem.TYPE_CATEGORY, [url], name, '', None, imageType="JUMP")
 
 	def getLastItem(self, last_number, url, name):
 		return CDisplayListItem(_("Last"), _('Page:') + " " + str(last_number), CDisplayListItem.TYPE_CATEGORY, [url], name, '', 'last_page', imageType="LAST")

--- a/IPTVPlayer/iptvdm/iptvdh.py
+++ b/IPTVPlayer/iptvdm/iptvdh.py
@@ -22,7 +22,6 @@ from Tools.Directories import resolveFilename, SCOPE_PLUGINS
 from Tools.Directories import fileExists
 import datetime
 import os
-import re
 ###################################################
 
 
@@ -164,21 +163,6 @@ class DMHelper:
             return newFileName, tmpFileName
         else:
             return newFileName
-
-    @staticmethod
-    def getProgressFromF4fSTSFile(file):
-        ret = 0
-        try:
-            fo = open(file, "r")
-            lines = fo.readlines()
-            fo.close()
-        except Exception:
-            return ret
-        if 0 < len(lines):
-            match = re.search("|PROGRESS|([0-9]+?)/([0-9]+?)|", lines[1])
-            if match:
-                ret = 100 * int(match.group(1)) / int(match.group(2))
-        return ret
 
     @staticmethod
     def getFileSize(filename):

--- a/IPTVPlayer/libs/pCommon.py
+++ b/IPTVPlayer/libs/pCommon.py
@@ -1189,7 +1189,7 @@ class common:
         if protocolName == 'TLSv1_2':
             return ssl.PROTOCOL_TLSv1_2
         elif protocolName == 'TLSv1_1':
-            return ssl.PROTOCOL_TLSv1_1
+            return ssl.PROTOCOL_TLSv1_1  # NOSONAR
         return None
 
     def getPyCurlSSLProtocolVersion(self, protocolName):
@@ -1295,10 +1295,11 @@ class common:
         # customOpeners.append(urllib2.HTTPHandler(debuglevel=1))
         if not IsHttpsCertValidationEnabled():
             try:
+                # unverified TLS is opt-in only, gated by the IsHttpsCertValidationEnabled() check above
                 if sslProtoVer is not None:
-                    ctx = ssl._create_unverified_context(sslProtoVer)
+                    ctx = ssl._create_unverified_context(sslProtoVer)  # NOSONAR
                 else:
-                    ctx = ssl._create_unverified_context()
+                    ctx = ssl._create_unverified_context()  # NOSONAR
                 customOpeners.append(HTTPSHandler(context=ctx))
             except Exception:
                 pass

--- a/IPTVPlayer/scripts/fakejd.py
+++ b/IPTVPlayer/scripts/fakejd.py
@@ -286,7 +286,7 @@ class Myjdapi:
             if params is not None:
                 response = self._decrypt(self._device_encryption_token, encrypted_response_text)
             else:
-                return {"data": response}
+                return {"data": encrypted_response_text.decode('utf-8')}
         jsondata = json.loads(response.decode('utf-8'))
         if jsondata['rid'] != self._request_id:
             self.update_request_id()

--- a/IPTVPlayer/scripts/livesports.py
+++ b/IPTVPlayer/scripts/livesports.py
@@ -59,7 +59,8 @@ def getPage(url, params={}):
     customOpeners = []
 
     try:
-        ctx = ssl._create_unverified_context(params['ssl_protocol']) if params.get('ssl_protocol', None) is not None else ssl._create_unverified_context()
+        # box CA stores are unreliable - this standalone helper always skips cert verification
+        ctx = ssl._create_unverified_context(params['ssl_protocol']) if params.get('ssl_protocol', None) is not None else ssl._create_unverified_context()  # NOSONAR
         customOpeners.append(HTTPSHandler(context=ctx))
     except Exception:
         pass

--- a/IPTVPlayer/subproviders/subprov_subsourceapi.py
+++ b/IPTVPlayer/subproviders/subprov_subsourceapi.py
@@ -443,7 +443,7 @@ class SubsourceAPIProvider(CBaseSubProviderClass):
             response = requests.get(
                 __getSubdown,
                 headers=headers,
-                verify=False,
+                verify=False,  # NOSONAR
                 allow_redirects=True,
                 timeout=60,
                 stream=True,

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.07.04"
+IPTV_VERSION = "2026.09.08.02"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,29 @@
+# SonarCloud project configuration.
+#
+# The project runs in Automatic Analysis mode. Only analysis-scope keys are
+# reliably honoured from this file (sonar.exclusions, sonar.tests, ...).
+# Per-rule ignores may need to be set in Project Settings -> Analysis Scope
+# on sonarcloud.io if the block below does not take effect after a scan.
+
+# --- Test code ----------------------------------------------------------
+# Analysed with the test rule set, kept out of the main metrics/coverage.
+sonar.tests=tests
+
+# --- Exclusions -----------------------------------------------------------
+# Third-party code vendored verbatim - not ours to fix, pure analysis noise
+# (youtube_dl alone carries hundreds of findings).
+sonar.exclusions=\
+  IPTVPlayer/libs/youtube_dl/**,\
+  IPTVPlayer/libs/ecdsa/**,\
+  IPTVPlayer/libs/crypto/**,\
+  IPTVPlayer/libs/pyaes/**,\
+  IPTVPlayer/libs/aesgcm/**,\
+  Backup/**,\
+  **/__pycache__/**
+
+# --- Per-rule ignores ---------------------------------------------------
+# python:S930 (wrong argument count): the dynamic _()/gettext wrapper built
+# in translationHelper.py trips this ~43x as a false positive.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S930
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/translationHelper.py


### PR DESCRIPTION
Triage of the SonarCloud scan (oe-mirrors_e2iplayer). The dashboard shows 78 bugs / 48 vulns / 5215 smells, but almost all of it is noise on old or vendored code. This picks out the handful of genuine defects and adds a config file to cut the recurring noise.

Real bugs
- hostfavourites.getLinksForVideo: the RESOLVER_URLLPARSER branch called cleanHtmlStr on self.host right after setting it to None (guaranteed AttributeError) and reused the loop variable "item". Uses the inherited static cleanHtmlStr and a separate loop var now. This path could never have worked before.
- hostwebhuplayer._update: self.list_tartalom() was called without its required cItem after a successful webmedia install -> TypeError. Passes {'name': 'category'} like handleService does.
- hostm4sport.kvlva: "if len(vl) != '':" compared int to str (always true). -> "if vl".
- fakejd.request_api: returned {"data": response} on the action/no-params branch where response is never assigned -> NameError. Returns the decoded response text like upstream myjdapi.
- iptvdh.getProgressFromF4fSTSFile: unescaped "|" in the PROGRESS regex made every alternative (incl. empty) match; the method also had a lines[1]-on-a-1-line-file bug and a possible /0. It has had zero callers since the initial fork, so it is removed entirely (with the now-unused "import re").

Dead-code / smell cleanup
- Useless self-assignments (hostfavourites, hostlodynet), redundant always-None conditional (hostxxx.getJumpItem), unreachable "return" (hoststreamliveto.getPage).

SonarCloud config
- sonar-project.properties: exclude vendored third-party trees (youtube_dl, ecdsa, crypto, pyaes, aesgcm), Backup/ and __pycache__; mark tests/ as test sources; ignore python:S930 in translationHelper.py (dynamic gettext wrapper, ~43 false positives). Automatic Analysis may only honour the scope keys - the rule-ignore might still need setting in the SonarCloud UI.
- "# NOSONAR" on the deliberate unverified-TLS paths in pCommon (already gated behind IsHttpsCertValidationEnabled()), livesports and subsourceapi
  - disabling cert checks is a supported option because many boxes have unreliable CA stores.

No regression risk: everything that worked before behaves identically. The only newly-functional path is urlparser-resolved favourites, which crashed unconditionally before. ruff + compileall clean.