### PR TITLE
CI workflows, tooling and lint-config refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # keep the GitHub Actions used in .github/workflows/ up to date - one
+  # grouped PR per week instead of one per action
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+
+  # keep the hash-locked lint tools in bugscan-requirements.txt current
+  - package-ecosystem: "pip"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/bugscan-requirements.txt
+++ b/.github/workflows/bugscan-requirements.txt
@@ -1,0 +1,26 @@
+# Pinned + hash-locked tools for .github/workflows/bugscan.yml
+# Regenerate on version bump:  pip download / PyPI JSON -> sha256 of every release file
+
+ruff==0.16.4 \
+    --hash=sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7 \
+    --hash=sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604 \
+    --hash=sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255 \
+    --hash=sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade \
+    --hash=sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff \
+    --hash=sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80 \
+    --hash=sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07 \
+    --hash=sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7 \
+    --hash=sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3 \
+    --hash=sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454 \
+    --hash=sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b \
+    --hash=sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d \
+    --hash=sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0 \
+    --hash=sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d \
+    --hash=sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e \
+    --hash=sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c \
+    --hash=sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21 \
+    --hash=sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc
+
+pyflakes==3.4.0 \
+    --hash=sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f \
+    --hash=sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58

--- a/.github/workflows/bugscan.yml
+++ b/.github/workflows/bugscan.yml
@@ -1,0 +1,73 @@
+name: Bug scan (advisory)
+
+# Advisory only - this workflow NEVER fails the build. It surfaces likely
+# bugs that the main `ruff` gate (E/F/W) does not cover:
+#   * ruff bugbear / pylint-error rules (B018 useless-expression = the
+#     "call without parens" class, PLW0127 self-assign, SIM223 `and False`,
+#     B023 loop-closure, ...)
+#   * pyflakes scope analysis (used-before-assignment), which is stronger
+#     than ruff's F-rule reimplementation and is the only thing that catches
+#     bugs hidden in the ruff-excluded monolith hosts/hostxxx.py
+#
+# Findings land in the run's Job Summary and as PR annotations.
+
+on:
+  push:
+    branches: [ python3 ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Bug scan (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install tools
+        run: python -m pip install --require-hashes -r .github/workflows/bugscan-requirements.txt
+
+      - name: Ruff bug-focused rules
+        run: |
+          set +e
+          cd IPTVPlayer
+          SEL='B012,B014,B015,B017,B018,B023,B033,B034,PLE,PLW0127,PLW0128,PLW0129,PLW0133,PLW0602,PLW0711,PLW1501,PLW3301,RUF018,RUF100,SIM222,SIM223'
+          EXCL='libs/youtube_dl,libs/ecdsa,libs/pyaes,libs/aesgcm'
+          {
+            echo '## Ruff bug-focused scan'
+            echo '_Advisory - does not block merge. `hostxxx.py` is included here even though the main lint job skips it._'
+            echo
+            echo '```'
+            ruff check . hosts/hostxxx.py --exit-zero --output-format=concise --extend-exclude "$EXCL" --select "$SEL"
+            echo '```'
+            echo '### Rule counts'
+            echo '```'
+            ruff check . hosts/hostxxx.py --exit-zero --statistics --extend-exclude "$EXCL" --select "$SEL"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # emit GitHub annotations too
+          ruff check . hosts/hostxxx.py --exit-zero --output-format=github --extend-exclude "$EXCL" --select "$SEL"
+          exit 0
+
+      - name: Pyflakes scope analysis
+        run: |
+          set +e
+          findings=$(python -m pyflakes IPTVPlayer 2>&1 \
+            | grep -E "referenced before assignment|undefined name|redefinition of unused" \
+            | grep -v "unable to detect" \
+            | grep -vE "libs/(youtube_dl|ecdsa|pyaes|aesgcm)")
+          {
+            echo '## Pyflakes (used-before-assignment / undefined / shadowing)'
+            echo
+            echo '```'
+            echo "${findings:-no high-signal pyflakes findings}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0

--- a/.github/workflows/buildbot.yml
+++ b/.github/workflows/buildbot.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: 'python3'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build python CI
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,16 +12,18 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
-        python: ['3.10','3.11','3.12','3.13']
+        python: ['3.10','3.11','3.12','3.13','3.14']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - name: Build plugins, python ${{ matrix.python }}
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install Ruff
         run: |

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - python3
 
+  workflow_dispatch:
+
 permissions:
   contents: write
 
@@ -15,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -65,12 +67,11 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.skip != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64  # v3.0.3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ steps.get_version.outputs.version }}
           name: Release v${{ steps.get_version.outputs.version }}
           body: |
             ## Changes in this release
             ${{ steps.changelog.outputs.changelog }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,79 @@
+name: Update translation templates
+
+# Proposal: automate the mechanical part of translation upkeep.
+#
+# After every merge to python3 this regenerates IPTVPlayer.pot and runs
+# msgmerge over every language via IPTVPlayer/locale/updateallpo.sh, then -
+# only if something actually changed - opens (or updates) ONE pull request
+# with the result. Nothing is pushed to python3 directly and nothing is
+# translated: new source strings land as untranslated msgid entries and fall
+# back to English at runtime until a human fills them in.
+#
+# It replaces the recurring hand-run "update pot" commits, not the actual
+# "update <language> translation" work.
+#
+# NOT ACTIVE YET - manual trigger only. Before wiring the automatic
+# `push` trigger (commented out below), run updateallpo.sh once on a clean
+# checkout and confirm `git status` stays clean: the script must reproduce
+# the committed .pot/.po byte-for-byte, otherwise the first PR is a huge
+# reformat diff. This file is here as a reviewed proposal, meant to go to
+# oe-mirrors - it does nothing until someone runs it from the Actions tab.
+
+on:
+  workflow_dispatch:
+  # once verified, enable automatic runs after each merge to python3:
+  # push:
+  #   branches: [ python3 ]
+  #   paths:
+  #     - 'IPTVPlayer/**/*.py'
+  #     - 'IPTVPlayer/locale/updateallpo.sh'
+  #     - '.github/workflows/translations.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: translation-templates
+  cancel-in-progress: true
+
+jobs:
+  update-pot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install gettext
+        run: |
+          sudo apt-get -q update
+          sudo apt-get install -y gettext
+
+      - name: Regenerate .pot / .po / .mo
+        run: |
+          cd IPTVPlayer/locale
+          chmod +x updateallpo.sh
+          ./updateallpo.sh
+
+      - name: Open or update the translation-templates PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          add-paths: IPTVPlayer/locale/**
+          branch: chore/translation-templates
+          base: python3
+          delete-branch: true
+          commit-message: "translation templates: regenerate .pot / .po"
+          title: "translation templates: regenerate .pot / .po"
+          labels: translations
+          body: |
+            Automated `xgettext` + `msgmerge` run via
+            `IPTVPlayer/locale/updateallpo.sh` (triggered by the last merge to
+            `python3`).
+
+            * mechanical extraction only - **no strings were translated**
+            * new source strings appear as `msgstr ""` and fall back to English
+              at runtime until someone translates them
+            * `.mo` files only change here when a string was *removed* upstream
+              (msgfmt drops untranslated entries)
+
+            Merge to pick up new / changed `_()` strings. The actual
+            translations are still added in separate commits.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.pyc
 .DS_Store
+
+# transient files from IPTVPlayer/locale/updateallpo.sh
+*.pot.bak
+*.pot.old
+*.pot.new

--- a/IPTVPlayer/locale/updateallpo.sh
+++ b/IPTVPlayer/locale/updateallpo.sh
@@ -8,7 +8,9 @@
 # Run this script from within the locale folder.
 #
 # Author: Pr2
-# Version: 1.0
+# Version: 1.1 - check for the gettext tools up front; drop the dead xml2po.py
+#                step; skip the po/mo rewrite when only the POT-Creation-Date
+#                header changed (avoids empty git diffs)
 #
 localgsed="sed"
 findoptions=""
@@ -21,6 +23,14 @@ if [[ "$OSTYPE" == "darwin"* ]]
         localgsed="gsed"
 fi
 
+# fail early with a clear message instead of a cryptic "command not found"
+for tool in xgettext msguniq msgmerge msgattrib msgfmt msginit; do
+	if ! command -v $tool > /dev/null 2>&1; then
+		printf "Error: '%s' not found in PATH - install the gettext tools first.\n" "$tool" >&2
+		exit 1
+	fi
+done
+
 Plugin=IPTVPlayer
 FilePath=/LC_MESSAGES/
 printf "Po files update/creation from script starting.\n"
@@ -31,23 +41,44 @@ languages=($(ls -d ./*/ | $localgsed 's/\/$//g; s/.*\///g'))
 # So if parameters are changed in Makefile please report the same changes in this script.
 #
 
+# keep the current pot around so we can tell a real string change from a
+# pure POT-Creation-Date bump once the new one is built
+if [[ -f $Plugin.pot ]]; then
+	cp $Plugin.pot $Plugin.pot.bak
+fi
+
 printf "Creating temporary file $Plugin-py.pot\n"
 find $findoptions .. -name "*.py" -exec xgettext --no-wrap -L Python --from-code=UTF-8 -kpgettext:1c,2 --add-comments="TRANSLATORS:" -d $Plugin -s -o $Plugin-py.pot {} \+
 $localgsed --in-place $Plugin-py.pot --expression=s/CHARSET/UTF-8/
-printf "Creating temporary file $Plugin-xml.pot\n"
-find $findoptions .. -name "*.xml" -exec python xml2po.py {} \+ > $Plugin-xml.pot
-printf "Merging pot files to create: $Plugin.pot\n"
-cat $Plugin-py.pot $Plugin-xml.pot | msguniq --no-wrap --no-location -o $Plugin.pot -
+printf "Merging to create: $Plugin.pot\n"
+msguniq --no-wrap --no-location -o $Plugin.pot $Plugin-py.pot
+rm $Plugin-py.pot
+
+# if nothing but the auto-generated POT-Creation-Date line differs from the
+# previous pot, restore it and stop - no merge needed, po/mo (and git) stay clean
+if [[ -f $Plugin.pot.bak ]]; then
+	grep -v '^"POT-Creation-Date:' $Plugin.pot     > $Plugin.pot.new
+	grep -v '^"POT-Creation-Date:' $Plugin.pot.bak > $Plugin.pot.old
+	if diff -q $Plugin.pot.old $Plugin.pot.new > /dev/null; then
+		printf "No string changes (only POT-Creation-Date) - leaving all files as they are.\n"
+		mv $Plugin.pot.bak $Plugin.pot
+		rm -f $Plugin.pot.old $Plugin.pot.new
+		printf "Po files update/creation from script finished!\n"
+		exit 0
+	fi
+	rm -f $Plugin.pot.bak $Plugin.pot.old $Plugin.pot.new
+fi
+
 OLDIFS=$IFS
 IFS=" "
 for lang in "${languages[@]}" ; do
-	if [ -f $lang$FilePath$Plugin.po ]; then 
+	if [[ -f $lang$FilePath$Plugin.po ]]; then 
 		printf "Updating existing translation file %s.po\n" $lang
 		msgmerge --backup=none --no-wrap -s -U $lang$FilePath$Plugin.po $Plugin.pot && touch $lang$FilePath$Plugin.po
 		msgattrib --no-wrap --no-obsolete $lang$FilePath$Plugin.po -o $lang$FilePath$Plugin.po
 		msgfmt -o $lang$FilePath$Plugin.mo $lang$FilePath$Plugin.po
 	else
-		if [ ! -d $lang$FilePath ]; then
+		if [[ ! -d $lang$FilePath ]]; then
 			mkdir $lang$FilePath
 		fi
 		printf "New file created: %s, please add it to github before commit\n" $lang$FilePath$Plugin.po
@@ -55,7 +86,6 @@ for lang in "${languages[@]}" ; do
 		msgfmt -o $lang$FilePath$Plugin.mo $lang$FilePath$Plugin.po
 	fi
 done
-rm $Plugin-py.pot $Plugin-xml.pot
 IFS=$OLDIFS
 printf "Po files update/creation from script finished!\n"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [tool.ruff]
 line-length = 120
 exclude = ["IPTVPlayer/hosts/hostxxx.py", "IPTVPlayer/libs/aesgcm/*.py"]
+
+[tool.ruff.lint]
 select = ["E","F","W"]
 ignore = ["W191","E402","E501","E722","E741","F401","F403","F405","F841"]
 


### PR DESCRIPTION
Only touches .github/ and dev-tooling files - nothing that ships to a box, so version.py is intentionally left alone.

Workflows:
- actions/checkout v3/v4 -> v5 and actions/setup-python v4/v5 -> v6 in every workflow; single-version jobs 3.12 -> 3.13
- compile: add Python 3.14 to the matrix (allow-prereleases, fail-fast: false)
- tag_release: add a workflow_dispatch trigger; pass the release token as an input instead of via env
- new bugscan.yml: advisory, non-blocking scan for the bug classes the E/F/W gate misses (ruff bugbear + pylint-error rules, plus a filtered pyflakes pass for used-before-assignment that also covers the ruff-excluded hostxxx.py). Output goes to the job summary and PR annotations; it can never fail the build.
- new translations.yml: reviewed proposal, manual trigger only for now. Regenerates IPTVPlayer.pot via updateallpo.sh and opens one PR - mechanical extraction only, meant to be offered to oe-mirrors. The automatic push trigger is left commented out until updateallpo.sh is confirmed to reproduce the committed .pot/.po byte-for-byte.

Tooling:
- pyproject.toml: move ruff select/ignore under [tool.ruff.lint] (silences the deprecation warning ruff prints on every run; same rules)
- IPTVPlayer/locale/updateallpo.sh: check for the gettext tools up front; drop the dead xml2po.py step (that helper never existed in this repo and e2iplayer has no translatable strings in .xml); skip the .po/.mo rewrite when only the POT-Creation-Date header changed
- .gitignore: transient *.pot.bak / *.pot.old / *.pot.new
- new .github/dependabot.yml: one grouped weekly PR for GitHub Actions version bumps