### PR TITLE
Code cleanups and small bug fixes from code analysis #3

### DIFF
--- a/IPTVPlayer/components/asynccall.py
+++ b/IPTVPlayer/components/asynccall.py
@@ -425,7 +425,7 @@ class CFunctionProxyQueue:
         currThreadName = threading.current_thread().name
         if self.mainThreadName != currThreadName:
             printDBG("ERROR CFunctionProxyQueue.registerFunction: thread [%s] is not main thread" % currThreadName)
-            raise AssertionError
+            raise AssertionError("CFunctionProxyQueue.setProcFun can only be called from the main thread, not [%s]" % currThreadName)
         # field self.procFun is accessed only from main thread
         self.procFun = fun
         return True

--- a/IPTVPlayer/components/ihost.py
+++ b/IPTVPlayer/components/ihost.py
@@ -233,12 +233,12 @@ class ArticleContent:
         "translation": "Translation:"
     }
 
-    def __init__(self, title='', text='', images=[], trailers=[], richDescParams={}, visualizer=None):
+    def __init__(self, title='', text='', images=None, trailers=None, richDescParams=None, visualizer=None):
         self.title = title
         self.text = text
-        self.images = images
-        self.trailers = trailers
-        self.richDescParams = richDescParams
+        self.images = images if images is not None else []
+        self.trailers = trailers if trailers is not None else []
+        self.richDescParams = richDescParams if richDescParams is not None else {}
         if None is visualizer:
             self.visualizer = ArticleContent.VISUALIZER_DEFAULT
         else:

--- a/IPTVPlayer/components/iptvarticleview.py
+++ b/IPTVPlayer/components/iptvarticleview.py
@@ -251,7 +251,7 @@ class IPTVArticleView(Screen):
                             img = Image.open(file_path)
                             img.save(file_path, format="jpeg", quality=80)
                             img.close()
-                        except:
+                        except Exception:
                             printExc()
                     elif not webPEnabled:
                         return

--- a/IPTVPlayer/components/iptvextmovieplayer.py
+++ b/IPTVPlayer/components/iptvextmovieplayer.py
@@ -425,7 +425,7 @@ class IPTVExtMoviePlayer(Screen):
                 return json.loads(response)
 
             return {}
-        except:
+        except Exception:
             printExc()
             return {}
 

--- a/IPTVPlayer/hosts/hostarabseed.py
+++ b/IPTVPlayer/hosts/hostarabseed.py
@@ -406,7 +406,7 @@ class ArabSeed(CBaseHostClass):
                                 if padding != 4:
                                     encoded += "=" * padding
                                 video_url = base64.b64decode(encoded).decode("utf-8")
-                            except:
+                            except Exception:
                                 pass
                         if video_url and video_url.startswith("http"):
                             domain = re.search(r"https?://([^/]+)", video_url)
@@ -457,7 +457,7 @@ class ArabSeed(CBaseHostClass):
             data += "=" * padding
         try:
             return base64.b64decode(data).decode("utf-8", errors="ignore")
-        except:
+        except Exception:
             return None
 
     def exploreSeriesItems(self, cItem):
@@ -792,7 +792,7 @@ class ArabSeed(CBaseHostClass):
                 quality_txt = display.get("value", "")
                 try:
                     quality = int(quality_txt.replace("p", "").strip())
-                except:
+                except Exception:
                     continue
                 qualities.append({"q": quality, "name": "IMDb %dp" % quality, "url": url, "need_resolve": 0})
             qualities.sort(key=lambda x: x["q"], reverse=True)
@@ -843,7 +843,7 @@ class ArabSeed(CBaseHostClass):
             return
         try:
             result = json_loads(response)
-        except:
+        except Exception:
             return
         if result.get("type") != "success":
             return

--- a/IPTVPlayer/hosts/hostasi1tv.py
+++ b/IPTVPlayer/hosts/hostasi1tv.py
@@ -186,7 +186,7 @@ class Asi1TV(CBaseHostClass):
             if current_match:
                 try:
                     current_page = int(current_match.group(1))
-                except:
+                except Exception:
                     current_page = 1
             all_page_numbers = re.findall(r'<a[^>]+href=["\'][^"\']*page/(\d+)/?["\'][^>]*>([\d,٬]+)</a>', pagination)
             if all_page_numbers:
@@ -194,7 +194,7 @@ class Asi1TV(CBaseHostClass):
                 clean_num = last_num_str.replace(",", "").replace("٬", "")
                 try:
                     total_pages = int(clean_num)
-                except:
+                except Exception:
                     total_pages = current_page + 1
             else:
                 total_pages = current_page + 1
@@ -460,7 +460,7 @@ class Asi1TV(CBaseHostClass):
                     try:
                         idx = int(m.group(0))
                         return k_list[idx] if idx < len(k_list) else m.group(0)
-                    except:
+                    except Exception:
                         return m.group(0)
 
                 return re.sub(r"\b\d+\b", repl, text)

--- a/IPTVPlayer/hosts/hostbotolat.py
+++ b/IPTVPlayer/hosts/hostbotolat.py
@@ -432,7 +432,7 @@ class BtolatCom(CBaseHostClass):
                     try:
                         m, d, y = raw_date.split("/")
                         video_date = "%s-%s-%s" % (d.zfill(2), m.zfill(2), y)
-                    except:
+                    except Exception:
                         video_date = raw_date
                 # Description = league + date
                 if cat_name and video_date:
@@ -784,7 +784,7 @@ class BtolatCom(CBaseHostClass):
         try:
             if not os.path.exists(os.path.dirname(file_path)):
                 os.makedirs(os.path.dirname(file_path))
-        except:
+        except Exception:
             pass
         meta = {"host": "botolat", "title": title, "file_path": first_link}
         try:

--- a/IPTVPlayer/hosts/hostbrstej.py
+++ b/IPTVPlayer/hosts/hostbrstej.py
@@ -502,7 +502,7 @@ class Brstej(CBaseHostClass):
                             server_tag = parts[-2]
                         else:
                             server_tag = host
-                    except:
+                    except Exception:
                         server_tag = ""
                     if server_tag:
                         final_name = "%s [ %s ]" % (server_name, server_tag)
@@ -525,7 +525,7 @@ class Brstej(CBaseHostClass):
                         server_tag = parts[-2]
                     else:
                         server_tag = host
-                except:
+                except Exception:
                     server_tag = ""
                 if server_tag:
                     name = "السيرفر الافتراضي [ %s ]" % server_tag

--- a/IPTVPlayer/hosts/hostcimanow.py
+++ b/IPTVPlayer/hosts/hostcimanow.py
@@ -853,7 +853,7 @@ class CimaNow(CBaseHostClass):
             season_num = re.search(r'(\d+)', season_title)
             try:
                 season_num = int(season_num.group(1)) if season_num else 0
-            except:
+            except Exception:
                 season_num = 0
 
             # --- Combine full title ---

--- a/IPTVPlayer/hosts/hostcineto.py
+++ b/IPTVPlayer/hosts/hostcineto.py
@@ -166,7 +166,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
         cItem['category'] = nextCategory
 
         try:
-            data = json_loads(data, '', True)['genres']
+            data = json_loads(data)['genres']
             for item in self.cacheFilters['genres']:
                 params = dict(cItem)
                 params.update(item)
@@ -225,7 +225,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
             return []
 
         try:
-            data = json_loads(data, noneReplacement='', baseTypesAsString=True)
+            data = json_loads(data)
             for item in data['entries']:
                 self._addItem(item, cItem, nextCategory)
         except Exception:
@@ -254,7 +254,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
             return []
 
         try:
-            data = json_loads(data, noneReplacement='', baseTypesAsString=True)['entry']
+            data = json_loads(data)['entry']
             icon = self.getFullIconUrl(data.get('cover', cItem.get('icon', '')))
             printDBG("+++++++++++++++++++++++++++++++++++++++")
             printDBG(data)
@@ -338,7 +338,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
             if not sts:
                 return []
 
-            data = json_loads(data, '', True)['links']
+            data = json_loads(data)['links']
             printDBG(data)
 
             for hosting in data:
@@ -432,7 +432,7 @@ class CineTO(CBaseHostClass, CaptchaHelper):
         icon = ''
 
         try:
-            data = json_loads(data, noneReplacement='', baseTypesAsString=True)['entry']
+            data = json_loads(data)['entry']
             icon = self.getFullIconUrl(data.get('cover', cItem.get('icon', '')))
             title = self.cleanHtmlStr(data['title'])
 

--- a/IPTVPlayer/hosts/hostfilman.py
+++ b/IPTVPlayer/hosts/hostfilman.py
@@ -394,7 +394,7 @@ class Filman(CBaseHostClass, CaptchaHelper):
             decoded_base64 = ensure_str(base64.b64decode(encoded_string))
             decoded_rot13 = self.rot13(decoded_base64)
             return decoded_rot13
-        except:
+        except Exception:
             return ""
 
     def _xd_decode(self, enc, key):
@@ -415,7 +415,7 @@ class Filman(CBaseHostClass, CaptchaHelper):
             host = re.search(r'https?://([^/]+)', url).group(1)
             host = host.replace('www.', '')
             return host.split('.')[0]
-        except:
+        except Exception:
             return "filman"
 
     def _tryDecodeXdFromData(self, data):
@@ -506,9 +506,9 @@ class Filman(CBaseHostClass, CaptchaHelper):
                             try:
                                 player_data_json = json.loads(decoded)
                                 playerUrl = player_data_json.get("src", "")
-                            except:
+                            except Exception:
                                 playerUrl = decoded
-                        except:
+                        except Exception:
                             playerUrl = ""
 
                         if playerUrl and playerUrl.startswith('http'):

--- a/IPTVPlayer/hosts/hostfootyroom.py
+++ b/IPTVPlayer/hosts/hostfootyroom.py
@@ -42,15 +42,15 @@ class FootyRoom(CBaseHostClass):
                 from six.moves.html_parser import HTMLParser
 
                 s = HTMLParser().unescape(s)
-            except:
+            except Exception:
                 try:
                     import html
 
                     s = html.unescape(s)
-                except:
+                except Exception:
                     pass
             return s.strip()
-        except:
+        except Exception:
             return ""
 
     def _getPage(self, url, addParams=None, post_data=None):
@@ -63,7 +63,7 @@ class FootyRoom(CBaseHostClass):
                     hdr.update(addParams.get("header", {}))
                     params["header"] = hdr
             return self.cm.getPage(url, params, post_data)
-        except:
+        except Exception:
             printExc()
         return False, ""
 
@@ -111,7 +111,7 @@ class FootyRoom(CBaseHostClass):
                         comps.append({"title": title, "url": href})
                 if comps:
                     out.append({"title": country, "comps": comps})
-        except:
+        except Exception:
             printExc()
         return out
 
@@ -166,7 +166,7 @@ class FootyRoom(CBaseHostClass):
                     slug = url_norm.split("/matches/")[-1].replace("/review", "")
                     slug = re.sub(r"^\d+/", "", slug)
                     title = slug.replace("-", " ").strip()
-                except:
+                except Exception:
                     title = "Match"
             added.add(url_norm)
             matches.append({"title": title or "Match", "url": url_norm, "icon": icon})
@@ -197,7 +197,7 @@ class FootyRoom(CBaseHostClass):
                     slug = href_norm.split("/matches/")[-1].replace("/review", "")
                     slug = re.sub(r"^\d+/", "", slug)
                     title = slug.replace("-", " ").strip()
-                except:
+                except Exception:
                     title = "Match"
             matches.append({"title": title or "Match", "url": href_norm, "icon": self.DEFAULT_ICON_URL})
         return matches
@@ -260,7 +260,7 @@ class FootyRoom(CBaseHostClass):
         countries = self._getCountries(force=True)
         try:
             idx = int(str(cItem.get("country_idx", "-1")).strip())
-        except:
+        except Exception:
             idx = -1
         comps = []
         if 0 <= idx < len(countries):
@@ -330,7 +330,7 @@ class FootyRoom(CBaseHostClass):
                             src = "https://www.youtube.com/watch?v=" + vid.group(1)
                     if src:
                         urlTab.append({"name": provider + ": " + title[:50], "url": src, "need_resolve": 1})
-            except:
+            except Exception:
                 printExc()
         # 2) Fallback: JSON-LD
         if not urlTab:
@@ -341,7 +341,7 @@ class FootyRoom(CBaseHostClass):
                     embed = ld_data.get("embedUrl", "")
                     if embed and "youtube" in embed:
                         urlTab.append({"name": "YouTube", "url": embed.replace("/embed/", "/watch?v="), "need_resolve": 1})
-                except:
+                except Exception:
                     printExc()
         return urlTab
 
@@ -349,7 +349,7 @@ class FootyRoom(CBaseHostClass):
         """Resolve video URL via urlparser"""
         try:
             return self.up.getVideoLinkExt(url)
-        except:
+        except Exception:
             printExc()
         return []
 
@@ -369,7 +369,7 @@ class FootyRoom(CBaseHostClass):
                 self.listMatches(self.currItem)
             else:
                 self.listMainMenu(self.currItem)
-        except:
+        except Exception:
             printExc()
         CBaseHostClass.endHandleService(self, index, refresh)
 

--- a/IPTVPlayer/hosts/hostm4sport.py
+++ b/IPTVPlayer/hosts/hostm4sport.py
@@ -427,7 +427,7 @@ class m4sport(CBaseHostClass):
                 if len(tt) == 2:
                     bv = tt[1].strip()[:-6].capitalize()
             return bv
-        except:
+        except Exception:
             return '-'
 
     def listSearchResult(self, cItem, searchPattern, searchType):

--- a/IPTVPlayer/hosts/hostmindigo.py
+++ b/IPTVPlayer/hosts/hostmindigo.py
@@ -279,7 +279,7 @@ class EPGProvider:
             if len(self.cache) > 100:
                 self.cache.popitem()
             self.cache[chId] = item
-        except:
+        except Exception:
             printExc()
             return None
         return item
@@ -392,7 +392,7 @@ class MindiGoHU(CBaseHostClass):
         try:
             from Plugins.Extensions.IPTVPlayer.epgproviders.porthu import EPGProvider as EPGProvider_porthu
             self.epgProvider_porthu = EPGProvider_porthu()
-        except:
+        except Exception:
             self.epgProvider_porthu = EPGProviderNone()
 
     def getFullIconUrl(self, url):
@@ -954,7 +954,7 @@ class MindiGoHU(CBaseHostClass):
                         data = json_loads(data)["errorMessage"]
                         if data:
                             SetIPTVPlayerLastHostError(data)
-                    except:
+                    except Exception:
                         pass
                     return []
                 data = json_loads(data)
@@ -973,7 +973,7 @@ class MindiGoHU(CBaseHostClass):
                                 data = json_loads(data)["errorMessage"]
                                 if data:
                                     SetIPTVPlayerLastHostError(data)
-                            except:
+                            except Exception:
                                 pass
                             return []
                         data = json_loads(data)
@@ -1132,7 +1132,7 @@ class MindiGoHU(CBaseHostClass):
             self.token = token.value
             self.getChannels()
             return True
-        except:
+        except Exception:
             printExc()
             self.sessionEx.open(MessageBox, _('Login failed.'), type=MessageBox.TYPE_ERROR, timeout=10)
         # self.userProducts = set()

--- a/IPTVPlayer/hosts/hostmovizhome.py
+++ b/IPTVPlayer/hosts/hostmovizhome.py
@@ -103,19 +103,19 @@ class MovizHome(CBaseHostClass):
         for item in data:
             try:
                 url = self.getFullUrl(self.cm.ph.getSearchGroups(item, '<a[^>]+href="([^"]+)"')[0])
-            except:
+            except Exception:
                 continue
             try:
                 title = unescape(self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, 'title="([^"]+)"')[0]))
                 title = re.sub(r"^(فيلم|مسلسل|انمي|برنامج)\s+", "", title).strip()
-            except:
+            except Exception:
                 try:
                     title = unescape(self.cleanHtmlStr(self.cm.ph.getSearchGroups(item, '<h3 class="title">([^<]+)</h3>')[0]))
-                except:
+                except Exception:
                     title = ""
             try:
                 icon = self.getFullIconUrl(self.cm.ph.getSearchGroups(item, 'data-src="([^"]+)"')[0])
-            except:
+            except Exception:
                 icon = ""
             genre = self.cm.ph.getSearchGroups(item, r'<li[^>]*class="genre"[^>]*>\s*([^<]+)')
             quality = self.cm.ph.getSearchGroups(item, r'<li[^>]*class="quality"[^>]*>\s*([^<]+)')
@@ -132,7 +132,7 @@ class MovizHome(CBaseHostClass):
                 try:
                     imdb_val = float(imdb)
                     imdb_color = G if imdb_val >= 6.0 else R
-                except:
+                except Exception:
                     imdb_color = W
                 desc_lines.append("%sIMDB Rating:%s %s%s%s" % (Y, W, imdb_color, imdb, W))
             desc = "\n".join(desc_lines)
@@ -155,17 +155,17 @@ class MovizHome(CBaseHostClass):
         for item in items:
             try:
                 url = self.cm.ph.getSearchGroups(item, r'<a[^>]+href="([^"]+)"')[0]
-            except:
+            except Exception:
                 url = ""
             try:
                 title = self.cm.ph.getSearchGroups(item, r'<h3 class="title">(.*?)</h3>')[0]
                 title = self.cleanHtmlStr(title)
                 title = re.sub(r"^(فيلم|مسلسل|انمي|برنامج)\s+", "", title).strip()
-            except:
+            except Exception:
                 title = ""
             try:
                 icon = self.cm.ph.getSearchGroups(item, r'data-src="([^"]+)"')[0]
-            except:
+            except Exception:
                 icon = ""
             genre = self.cm.ph.getSearchGroups(item, r'<li[^>]*class="genre"[^>]*>\s*([^<]+)')
             quality = self.cm.ph.getSearchGroups(item, r'<li[^>]*class="quality"[^>]*>\s*([^<]+)')
@@ -182,7 +182,7 @@ class MovizHome(CBaseHostClass):
                 try:
                     imdb_val = float(imdb)
                     imdb_color = G if imdb_val >= 6.0 else R
-                except:
+                except Exception:
                     imdb_color = W
                 desc_lines.append("%sIMDB Rating:%s %s%s%s" % (Y, W, imdb_color, imdb, W))
             desc = "\n".join(desc_lines)

--- a/IPTVPlayer/hosts/hostmusicbox.py
+++ b/IPTVPlayer/hosts/hostmusicbox.py
@@ -358,13 +358,13 @@ class MusicBox(CBaseHostClass):
 
         playlist_id = "lastfm://playlist/" + artist
         url = 'http://ws.audioscrobbler.com/2.0/?method=playlist.fetch&playlistURL=' + playlist_id + '&api_key=' + audioscrobbler_api_key + '&format=json'
-        print(url)
+        printDBG(url)
         sts, data = self.cm.getPage(url, {'header': HEADER})
         if not sts:
             return
         try:
             data = json_loads(data)['playlist']['trackList']['track']
-            print(data)
+            printDBG(str(data))
             for x in range(len(data)):
                 item = data[x]
                 artist = item['creator']

--- a/IPTVPlayer/hosts/hostradioe.py
+++ b/IPTVPlayer/hosts/hostradioe.py
@@ -335,7 +335,7 @@ class RadioECtWs(CBaseHostClass):
                     try:
                         size_mb = float(fsize) / (1024 * 1024)
                         desc_parts.append("%.1f MB" % size_mb)
-                    except:
+                    except Exception:
                         pass
                 desc = " | ".join(desc_parts) if desc_parts else "ملف أرشيفي"
                 episode_data = {"title": title, "url": download_url, "icon": cItem.get("icon"), "desc": Y + desc + W, "format": fformat, "size": fsize, "source": fsource, "base_name": base_name, "episode_num": episode_num}
@@ -357,7 +357,7 @@ class RadioECtWs(CBaseHostClass):
                 is_original = ep.get("source") == "original"
                 try:
                     size = float(ep["size"])
-                except:
+                except Exception:
                     size = 999999999
                 return (ep_num, not is_mp3, not is_original, size)
 

--- a/IPTVPlayer/hosts/hostraiplay.py
+++ b/IPTVPlayer/hosts/hostraiplay.py
@@ -94,59 +94,59 @@ class Raiplay(CBaseHostClass):
         else:
             url = self.getFullUrl(pathId)
             url = url.replace("[RESOLUTION]", "256x-")
-        print(">>> getThumbnailUrl - fullUrl:", url)
+        printDBG(">>> getThumbnailUrl - fullUrl: %s" % url)
         return url
 
     def getThumbnailUrl2(self, item):
-        print(">>> getThumbnailUrl2 - item keys:", item.keys())
+        printDBG(">>> getThumbnailUrl2 - item keys: %s" % list(item.keys()))
 
         # Check for 'transparent-icon' first
         if "transparent-icon" in item:
             icon_url = item["transparent-icon"]
             if "[an error occurred" not in icon_url:  # filtro anti-errore
-                print(">>> Using transparent-icon:", icon_url)
+                printDBG(">>> Using transparent-icon: %s" % icon_url)
                 return self.getThumbnailUrl(icon_url)
             else:
-                print(">>> Skipping invalid transparent-icon:", icon_url)
+                printDBG(">>> Skipping invalid transparent-icon: %s" % icon_url)
 
         if "audio" in item:
             ch_image_url = item["poster"]
-            print(">>> Using poster:", ch_image_url)
+            printDBG(">>> Using poster: %s" % ch_image_url)
             return self.getThumbnailUrl(ch_image_url)
 
         if "chImage" in item:
             ch_image_url = item["chImage"]
-            print(">>> Using chImage:", ch_image_url)
+            printDBG(">>> Using chImage: %s" % ch_image_url)
             return self.getThumbnailUrl(ch_image_url)
 
         # Fallback: check standard images
         if "images" in item and isinstance(item["images"], dict):
             images = item["images"]
-            print(">>> Available image keys:", images.keys())
+            printDBG(">>> Available image keys: %s" % list(images.keys()))
 
             if "landscape" in images:
-                print(">>> Using landscape:", images["landscape"])
+                printDBG(">>> Using landscape: %s" % images["landscape"])
                 return self.getThumbnailUrl(images["landscape"])
             elif "landscape43" in images:
-                print(">>> Using landscape43:", images["landscape43"])
+                printDBG(">>> Using landscape43: %s" % images["landscape43"])
                 return self.getThumbnailUrl(images["landscape43"])
             elif "portrait" in images:
-                print(">>> Using portrait:", images["portrait"])
+                printDBG(">>> Using portrait: %s" % images["portrait"])
                 return self.getThumbnailUrl(images["portrait"])
             elif "portrait43" in images:
-                print(">>> Using portrait43:", images["portrait43"])
+                printDBG(">>> Using portrait43: %s" % images["portrait43"])
                 return self.getThumbnailUrl(images["portrait43"])
             elif "portrait_logo" in images:
-                print(">>> Using portrait_logo:", images["portrait_logo"])
+                printDBG(">>> Using portrait_logo: %s" % images["portrait_logo"])
                 return self.getThumbnailUrl(images["portrait_logo"])
             elif "square" in images:
-                print(">>> Using square:", images["square"])
+                printDBG(">>> Using square: %s" % images["square"])
                 return self.getThumbnailUrl(images["square"])
             elif "default" in images:
-                print(">>> Using default:", images["default"])
+                printDBG(">>> Using default: %s" % images["default"])
                 return self.getThumbnailUrl(images["default"])
 
-        print(">>> No valid thumbnail found, using DEFAULT_ICON_URL")
+        printDBG(">>> No valid thumbnail found, using DEFAULT_ICON_URL")
         return self.DEFAULT_ICON_URL
 
     def getFullUrl(self, url):
@@ -254,7 +254,7 @@ class Raiplay(CBaseHostClass):
 
                                     return {'url': url[0], 'ct': ct[0], 'key': key}
 
-                                except:
+                                except Exception:
                                     return {'url': url[0], 'ct': ct[0], 'key': ''}
                         else:
                             return {'url': url[0], 'ct': ct[0], 'key': ''}
@@ -274,7 +274,7 @@ class Raiplay(CBaseHostClass):
             #    printExc()
             # return mediaUrl
 
-        except:
+        except Exception:
             return {'url': '', 'type': '', 'key': ''}
 
     def getLinksForVideo(self, cItem):
@@ -339,7 +339,7 @@ class Raiplay(CBaseHostClass):
         try:
             response = json_loads(data)
             tv_stations = response["dirette"]
-        except:
+        except Exception:
             printExc()
             return
 
@@ -467,8 +467,8 @@ class Raiplay(CBaseHostClass):
         str1 = cItem['name']
         epgDate = str1[:10]
         channelName = str1[11:]
-        print(">>> listEPG called with cItem name:", cItem['name'])
-        print(">>> epgDate:", epgDate, "channelName:", channelName)
+        printDBG(">>> listEPG called with cItem name: %s" % cItem['name'])
+        printDBG(">>> epgDate: %s channelName: %s" % (epgDate, channelName))
         channel_id = channelName.replace(" ", "-").lower()
         url = self.EPG_URL
         url = url.replace("[idCanale]", channel_id)
@@ -476,7 +476,7 @@ class Raiplay(CBaseHostClass):
 
         sts, data = self.getPage(url)
         if not sts:
-            print(">>> Failed to get page data")
+            printDBG(">>> Failed to get page data")
             return
 
         items = self.cm.ph.getAllItemsBeetwenMarkers(data, ('<li', '>', 'eventSpan'), '</li>')
@@ -484,16 +484,16 @@ class Raiplay(CBaseHostClass):
         for idx, i in enumerate(items):
             videoUrl = self.cm.ph.getSearchGroups(i, '''data-href=['"]([^'^"]+?)['"]''')[0]
             videoUrl = self.getFullUrl(videoUrl)
-            print(">>> item #", idx, "videoUrl:", videoUrl)
+            printDBG(">>> item #%s videoUrl: %s" % (idx, videoUrl))
 
             icon = self.cm.ph.getSearchGroups(i, '''data-img=['"]([^'^"]+?)['"]''')[0]
-            print(">>> item #", idx, "raw icon data-img:", icon)
+            printDBG(">>> item #%s raw icon data-img: %s" % (idx, icon))
             if icon:
                 icon = self.getFullUrl(icon)
-                print(">>> item #", idx, "full icon URL:", icon)
+                printDBG(">>> item #%s full icon URL: %s" % (idx, icon))
             else:
                 icon = self.DEFAULT_ICON_URL
-                print(">>> item #", idx, "no icon found")
+                printDBG(">>> item #%s no icon found" % idx)
             title = re.findall("<p class=\"info\">([^<]+?)</p>", i)
             title = title[0] if title else ''
             startTime = re.findall("<p class=\"time\">([^<]+?)</p>", i)
@@ -790,7 +790,7 @@ class Raiplay(CBaseHostClass):
             if not sts:
                 return
             response = json_loads(data)
-        except:
+        except Exception:
             return
 
         dominio = "RaiNews|Category-6dd7493b-f116-45de-af11-7d28a3f33dd2"
@@ -894,7 +894,7 @@ class Raiplay(CBaseHostClass):
 
         try:
             j = json_loads(data)
-        except:
+        except Exception:
             return
 
         videos = j.get("hits", [])

--- a/IPTVPlayer/hosts/hostrtlmost.py
+++ b/IPTVPlayer/hosts/hostrtlmost.py
@@ -60,7 +60,7 @@ def _getImageExtKey(images, role):
         for i in images:
             if i.get('role') == role:
                 return i['external_key']
-    except:
+    except Exception:
         pass
     return None
 
@@ -68,11 +68,11 @@ def _getImageExtKey(images, role):
 def _updateOtherInfo(otherInfo, item):
     try:
         otherInfo['duration'] = str(datetime.timedelta(seconds=item['duration']))
-    except:
+    except Exception:
         pass
     try:
         otherInfo['age_limit'] = str(item['csa']['sort_index'])
-    except:
+    except Exception:
         pass
 
 
@@ -483,7 +483,7 @@ class RtlMostHU(CBaseHostClass):
             cj.save(self.COOKIE_FILE)
             self.loggedIn = True
             return True
-        except:
+        except Exception:
            printExc()
            self.sessionEx.open(MessageBox, _('Login failed.'), type=MessageBox.TYPE_ERROR, timeout=10)
         return False

--- a/IPTVPlayer/hosts/hoststreamstat.py
+++ b/IPTVPlayer/hosts/hoststreamstat.py
@@ -103,7 +103,7 @@ class StreamStat(CBaseHostClass):
         for i in id:
             try:
                icons.append({i: links[id.index(i)]})
-            except:
+            except Exception:
                pass
         for i in web:
             title = titles[web.index(i)]
@@ -111,12 +111,12 @@ class StreamStat(CBaseHostClass):
             url = 'https://streamstat.net' + i
             try:
                icon = icons[id.index(web.index(i))]
-            except:
+            except Exception:
                icon = None
             try:
                desc = descs[web.index(i)]
                desc = desc.replace("&nbsp;", " ")
-            except:
+            except Exception:
                desc = "No description available currently."
             printDBG(str(desc))
             if title == "":

--- a/IPTVPlayer/hosts/hosttv2play.py
+++ b/IPTVPlayer/hosts/hosttv2play.py
@@ -163,7 +163,7 @@ class TV2Play(CBaseHostClass):
                         plot = plot[3:]
                     if plot.endswith("</p>"):
                         plot = plot[:-4]
-                except:
+                except Exception:
                    pass
                 if 'EPISODE' in card['cardType']:
                     dirType = 'episodes'
@@ -244,7 +244,7 @@ class TV2Play(CBaseHostClass):
                     elif i['contentType'] != 'ARTICLE':
                         params = {'category': 'list_items', 'title': urllib_unquote(i['title']), 'url': "https://tv2play.hu/api/search/" + i['url'], 'icon': icon, 'desc': urllib_unquote(i['lead'])}
                         self.addDir(params)
-            except:
+            except Exception:
                pass
         if cItem['page'] != length:
             params = {'title': "Következő oldal", 'icon': None, 'page': cItem['page'], 'category': 'list_filters'}

--- a/IPTVPlayer/hosts/hostxtream.py
+++ b/IPTVPlayer/hosts/hostxtream.py
@@ -31,7 +31,7 @@ try:
     if not hasattr(config.plugins.iptvplayer, 'xtream_useragent'):
         config.plugins.iptvplayer.xtream_useragent = ConfigText(default="", fixed_size=False)
 except Exception as e:
-    print("Xtream config init error:", e)
+    printDBG("Xtream config init error: %s" % e)
 
 
 def GetConfigList():

--- a/IPTVPlayer/hosts/hostxxx.py
+++ b/IPTVPlayer/hosts/hostxxx.py
@@ -5162,7 +5162,7 @@ class Host(CBaseHostClass, XXXParser):
 			sts, data = self._getPage(url, self.defaultParams)
 			if not sts:
 				return ''
-			data = data = data.split('<li><a href')
+			data = data.split('<li><a href')
 			if len(data):
 				del data[0]
 			for item in data:
@@ -19536,11 +19536,11 @@ class Host(CBaseHostClass, XXXParser):
 			prev = self.cm.ph.getSearchGroups(data, 'prev"><a href=["]([^"]+?)["]', 1, True)[0]
 			if prev:
 				printDBG('PREVIOUS: ' + prev)
-			first = self.cm.ph.getSearchGroups(data, 'first"><a href=["]([^"]+?)["]', 1, True)[0]
-			if first:
-				if first.startswith('/'):
-					first = self.MAIN_URL + first
-				printDBG('FIRST: ' + first)
+			firstHref = self.cm.ph.getSearchGroups(data, 'first"><a href=["]([^"]+?)["]', 1, True)[0]
+			if firstHref:
+				if firstHref.startswith('/'):
+					firstHref = self.MAIN_URL + firstHref
+				printDBG('FIRST: ' + firstHref)
 			data = data.split('class="item  "')
 			if len(data):
 				del data[0]
@@ -19580,9 +19580,9 @@ class Host(CBaseHostClass, XXXParser):
 				printDBG('PREV NUMBER: ' + str(prev_number))
 				if int(prev_number) >= 2:
 					valTab.append(self.getPreviousItem(str(prev_number), previous, name, "previous"))
-			if first:
+			if firstHref:
 				if int(next_number) >= 3 or int(last_number) >= 3:
-					valTab.append(self.getFirstItem('', first, name, 'first'))
+					valTab.append(self.getFirstItem('', firstHref, name, 'first'))
 			return valTab
 
 		if 'W1MP' == name:

--- a/IPTVPlayer/hosts/hostzdfmediathek.py
+++ b/IPTVPlayer/hosts/hostzdfmediathek.py
@@ -15,7 +15,7 @@ from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Play
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
 ###################################################
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
-from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote, urllib_unquote
+from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote
 from Plugins.Extensions.IPTVPlayer.p2p3.pVer import isPY2
 
 ###################################################
@@ -143,11 +143,6 @@ class ZDFmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
         HTTP_HEADER = dict(self.HEADER)
         params.update({'header': HTTP_HEADER})
 
-        if 'zdf-cdn.live.cellular.de' in url and False:
-            proxy = 'http://www.proxy-german.de/index.php?q={0}&hl=2e1'.format(urllib_quote(url, ''))
-            params['header']['Referer'] = proxy
-            # params['header']['Cookie'] = 'flags=2e5;'
-            url = proxy
         sts, data = self.cm.getPage(url, params, post_data)
         if sts and None is data:
             sts = False
@@ -157,22 +152,10 @@ class ZDFmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
 
     def getIconUrl(self, url):
         url = self.getFullUrl(url)
-        if 'zdf-cdn.live.cellular.de' in url and False:
-            proxy = 'http://www.proxy-german.de/index.php?q={0}&hl=2e1'.format(urllib_quote(url, ''))
-            params = {}
-            params['User-Agent'] = self.HEADER['User-Agent'],
-            params['Referer'] = proxy
-            params['Cookie'] = 'flags=2e5;'
-            url = strwithmeta(proxy, params)
-        elif url.startswith('https://'):
+        if url.startswith('https://'):
             url = 'http' + url[5:]
 
         return url
-
-    def getFullUrl(self, url):
-        if 'proxy-german.de' in url:
-            url = urllib_unquote(self.cm.ph.getSearchGroups(url + '&', r'''\?q=(http[^&]+?)&''')[0])
-        return CBaseHostClass.getFullUrl(self, url)
 
     def _getNum(self, v, default=0):
         try:

--- a/IPTVPlayer/iptvdm/iptvbuffui.py
+++ b/IPTVPlayer/iptvdm/iptvbuffui.py
@@ -445,7 +445,7 @@ class E2iPlayerBufferingWidget(Screen):
             self['rec_button'].hide()
 
     def updateOKButton(self):
-        if self.canRunMoviePlayer and False is self.checkMOOVAtom and (self.isMOOVAtomAtTheBeginning is None or self.moovAtomStatus == self.MOOV_STS.DOWNLOADED):
+        if self.canRunMoviePlayer and self.checkMOOVAtom is False and (self.isMOOVAtomAtTheBeginning is None or self.moovAtomStatus == self.MOOV_STS.DOWNLOADED):
             self['ok_button'].show()
         else:
             self['rec_button'].hide()

--- a/IPTVPlayer/iptvdm/wgetdownloader.py
+++ b/IPTVPlayer/iptvdm/wgetdownloader.py
@@ -442,7 +442,7 @@ class WgetDownloader(BaseDownloader, SidecarMixin):
             return
 
         if self.WGET_STS.DOWNLOADING == self.wgetStatus:
-            print(self.outData)
+            printDBG(self.outData)
             dataLen = len(self.outData)
 
             for idx in range(dataLen):

--- a/IPTVPlayer/libs/hcaptcha.py
+++ b/IPTVPlayer/libs/hcaptcha.py
@@ -1114,8 +1114,11 @@ class UnCaptchahCaptcha:
             for n in range(hCaptcha['imgNumber']):
                 if n in answer:
                     check_answers[hCaptcha['tasklist'][n]["task_key"]] = "true"
-                    # add click in motion data
-                    md.append(mu_click[n])
+                    # add click in motion data - mouse-down uses the down
+                    # timestamps (md_click), mouse-up the up timestamps a few
+                    # ms later (mu_click); previously md_click was unused and
+                    # both got mu_click, making every synthetic click 0ms long
+                    md.append(md_click[n])
                     mu.append(mu_click[n])
                 else:
                     check_answers[hCaptcha['tasklist'][n]["task_key"]] = "false"

--- a/IPTVPlayer/libs/pCommon.py
+++ b/IPTVPlayer/libs/pCommon.py
@@ -512,6 +512,10 @@ class common:
             GetIPTVNotify().push(r'\s'.join([msg1, msg2]), 'error', 40)
             raise Exception("Wrong usage!")
 
+        # work on our own copy - the code below mutates params (return_data,
+        # save_to_file, use_cookie, ssl_protocol) and callers pass shared dicts
+        params = dict(params)
+
         # by default we will work in return_data mode
         if 'return_data' not in params:
             params['return_data'] = True
@@ -842,7 +846,7 @@ class common:
                 try:
                     move(params['save_to_file'], new_name)
                     self.convertWebp(new_name)
-                except:
+                except Exception:
                     pass
 
         except pycurl.error as e:
@@ -885,7 +889,7 @@ class common:
                     move(output_path, file_path)
                     # printDBG("PCommon.convertWebp rename %s %s" % (output_path, file_path))
                     return
-                except:
+                except Exception:
                     printExc()
                     return
 
@@ -1230,6 +1234,9 @@ class common:
             GetIPTVNotify().push(r'\s'.join([msg1, msg2]), 'error', 40)
             raise Exception("Wrong usage!")
 
+        # our own copy - the cookie block below does params['use_cookie'] = True
+        params = dict(params)
+
         if 'max_data_size' in params and not params.get('return_data', False):
             raise Exception("return_data == False is not accepted with max_data_size.\nPlease also note that return_data == False is deprecated and not supported with PyCurl HTTP backend!")
 
@@ -1495,6 +1502,9 @@ class common:
         return strTab
 
     def getPageRequest(self, baseUrl, params={}, post_data=None):
+
+        # our own copy - the cookie block below does params['use_cookie'] = True
+        params = dict(params)
 
         self.meta = {}
         metadata = self.meta

--- a/IPTVPlayer/libs/xxxparser.py
+++ b/IPTVPlayer/libs/xxxparser.py
@@ -3775,7 +3775,7 @@ class XXXParser:
 			if not videoUrl:
 				videoUrl = self.cm.ph.getSearchGroups(data, r'source\ssrc=["]([^"]+?)["]', 1, True)[0]
 			if not videoUrl:
-				videoUrl = videoUrl = self.cm.ph.getSearchGroups(data, 'src=["]([^"]+?mp4)["]', 1, True)[0]
+				videoUrl = self.cm.ph.getSearchGroups(data, 'src=["]([^"]+?mp4)["]', 1, True)[0]
 			return urlparser.decorateUrl(videoUrl, {'Referer': url, 'User-Agent': self.USER_AGENT})
 
 		if parser == 'https://xdporner.com':

--- a/IPTVPlayer/subproviders/subprov_subsourceapi.py
+++ b/IPTVPlayer/subproviders/subprov_subsourceapi.py
@@ -443,11 +443,10 @@ class SubsourceAPIProvider(CBaseSubProviderClass):
             response = requests.get(
                 __getSubdown,
                 headers=headers,
-                verify=False,  # NOSONAR
                 allow_redirects=True,
                 timeout=60,
                 stream=True,
-            )  # NOSONAR
+            )
             response.raise_for_status()
             with open(filePath, "wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):

--- a/IPTVPlayer/tools/iptvtools.py
+++ b/IPTVPlayer/tools/iptvtools.py
@@ -708,7 +708,8 @@ def _enforceDebugLogLimit(path):
                 except Exception:
                     pass
         else:
-            open(path, 'w').close()
+            with open(path, 'w'):
+                pass
     except Exception:
         pass
 
@@ -1341,7 +1342,7 @@ class CSearchHistoryHelper():
             if os.path.isfile(self.PATH_FILE):
                 os.remove(self.PATH_FILE)
                 msg = 0, _('Search History successfully deleted.')
-        except:
+        except Exception:
             pass
         return msg
 
@@ -1350,13 +1351,9 @@ class CSearchHistoryHelper():
             self.length = 0
             if os.path.isfile(self.PATH_FILE):
                 try:
-                    num = 0
-                    file = codecs.open(GetSearchHistoryDir("ytlist.txt"), 'r', 'utf-8', 'ignore')
-                    for line in file:
-                        num = num + 1
-                    file.close()
-                    self.length = num
-                except:
+                    with codecs.open(GetSearchHistoryDir("ytlist.txt"), 'r', 'utf-8', 'ignore') as file:
+                        self.length = sum(1 for _line in file)
+                except Exception:
                     pass
 
         if self.length:
@@ -2020,7 +2017,8 @@ def readCFG(cfgName, defVal=''):
         if os.path.exists(myPath):
             cfgPath = os.path.join(myPath, cfgName)
             if os.path.exists(cfgPath):
-                retVal = open(cfgPath, 'r').readline().strip()
+                with open(cfgPath, 'r') as f:
+                    retVal = f.readline().strip()
                 if retVal == 'True':
                     retVal = True
                 elif retVal == 'False':
@@ -2032,7 +2030,8 @@ def readCFG(cfgName, defVal=''):
                         line = line.strip()
                         if line.startswith('config.plugins.iptvplayer.%s=' % cfgName):
                             defVal = line.split('=')[1]
-                            open(cfgPath, 'w').write(defVal)
+                            with open(cfgPath, 'w') as fOut:
+                                fOut.write(defVal)
     return defVal
 
 

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.09.01"
+IPTV_VERSION = "2026.09.09.02"


### PR DESCRIPTION
Bug fixes:
- hostxxx: listsItems() assigned a local `first`, which shadowed the module-level first() helper for the whole ~21k-line method, so the first(currUrl) calls (lines 2000/8667/8854) raised UnboundLocalError / "str object is not callable". Local renamed to firstHref.
- hcaptcha: the answer-click loop appended mu_click to both md and mu, leaving md_click unused and every synthetic click 0ms long; mouse-down now uses md_click.
- hostzdfmediathek: removed two permanently dead `if ... and False:` proxy branches (one hid a stray 1-tuple assignment) plus the now unreachable getFullUrl override.
- pCommon: _getPageWithPyCurl / getURLRequestData / getPageRequest mutated the caller's params dict (params['use_cookie'] = True etc.), which with the params={} default could leak state between calls; they now copy it first.

Cleanups (no behaviour change):
- raw print() debug output -> printDBG: hostraiplay (22), hostmusicbox (2), hostxtream (1), wgetdownloader (1)
- all 59 remaining bare `except:` in hosts plus the last few in components/tools/libs -> `except Exception:` (all plain swallow patterns, none re-raise, so KeyboardInterrupt/SystemExit stop being caught)
- removed pointless `x = x = ...` double assignments (hostxxx, xxxparser)
- asynccall.setProcFun: message on the non-main-thread AssertionError
- ihost.ArticleContent: images=[] / trailers=[] / richDescParams={} -> None guards
- iptvbuffui.updateOKButton: `False is x` -> `x is False`
- iptvtools: wrapped the last bare open() calls in `with`; getLength() rewritten with `with` + sum()
- subprov_subsourceapi: dropped verify=False on the subtitle download so it matches the file's three other requests.get() calls
- hostcineto: stripped the long-dead json_loads(noneReplacement= / baseTypesAsString=) no-op arguments (byteify has been a no-op since the py3 port)

ruff + compileall clean. Not box-tested.