### PR TITLE
hostzdfmediathek: keep https, drop the legacy http downgrade

### DIFF
--- a/IPTVPlayer/hosts/hostzdfmediathek.py
+++ b/IPTVPlayer/hosts/hostzdfmediathek.py
@@ -151,11 +151,7 @@ class ZDFmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
         return sts, data
 
     def getIconUrl(self, url):
-        url = self.getFullUrl(url)
-        if url.startswith('https://'):
-            url = 'http' + url[5:]
-
-        return url
+        return self.getFullUrl(url)
 
     def _getNum(self, v, default=0):
         try:
@@ -415,9 +411,11 @@ class ZDFmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
                 for item in data:
                     quality = item['quality']
                     url = item['url']
-                    if url.startswith('https://'):
-                        url = 'http' + url[5:]
-                    for type in [{'pattern': 'http_m3u8_http', 'name': 'm3u8'}, {'pattern': 'mp4_http', 'name': 'mp4'}]:
+                    # keep the https URLs ZDF actually serves - the old
+                    # 'http' + url[5:] downgrade was a workaround for ancient
+                    # enigma2 images that could not do TLS to the Akamai CDN;
+                    # modern images do, and the CDN answers both schemes.
+                    for type in [{'pattern': 'm3u8', 'name': 'm3u8'}, {'pattern': 'mp4_', 'name': 'mp4'}]:
                         if type['pattern'] not in item['type']:
                             continue
                         if type['name'] == 'mp4':

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.09.02"
+IPTV_VERSION = "2026.09.09.03"


### PR DESCRIPTION
getIconUrl() and getLinksForVideo() forced every ZDF URL from https to http ('http' + url[5:]) - a workaround for old enigma2 images that couldn't do TLS to the Akamai/zdfvod CDN. ZDF is https-only now, modern images do TLS fine, and the CDN answers both schemes anyway, so the downgrade is at best a wasted redirect. The formitaeten type filter is loosened from 'http_m3u8_http'/'mp4_http' to 'm3u8'/'mp4_' so it still matches whether ZDF labels the delivery _http or _https.

TEST on the box: open ZDF mediathek, play a VOD and a live stream, check the poster icons load.