### PR TITLE
Use HTTPS for well-known service URLs; NOSONAR the intentional HTTP (…

### DIFF
--- a/IPTVPlayer/components/captcha_helper.py
+++ b/IPTVPlayer/components/captcha_helper.py
@@ -64,5 +64,5 @@ class CaptchaHelper():
                     self.sessionEx.waitForFinishOpen(MessageBox, '\n'.join(errorMsgTab), type=MessageBox.TYPE_ERROR, timeout=20)
                 if bypassCaptchaService is not None:
                     errorMsgTab.append(_('or'))
-                    errorMsgTab.append(_('You can use \"%s\" or \"%s\" services for automatic solution.') % ("http://2captcha.com/", "https://9kw.eu/", ) + ' ' + _('Go to the host configuration available under blue button.'))
+                    errorMsgTab.append(_('You can use \"%s\" or \"%s\" services for automatic solution.') % ("https://2captcha.com/", "https://9kw.eu/", ) + ' ' + _('Go to the host configuration available under blue button.'))
         return token, errorMsgTab

--- a/IPTVPlayer/components/iptvconfigmenu.py
+++ b/IPTVPlayer/components/iptvconfigmenu.py
@@ -172,13 +172,14 @@ config.plugins.iptvplayer.pluginProtectedByPin = ConfigYesNo(default=False)
 
 config.plugins.iptvplayer.httpssslcertvalidation = ConfigYesNo(default=False)
 
-# PROXY
-config.plugins.iptvplayer.proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
-config.plugins.iptvplayer.german_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
-config.plugins.iptvplayer.russian_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
-config.plugins.iptvplayer.ukrainian_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
-config.plugins.iptvplayer.alternative_proxy1 = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
-config.plugins.iptvplayer.alternative_proxy2 = ConfigText(default="http://user:pass@ip:port", fixed_size=False)
+# PROXY - the default is a placeholder example the user overwrites; a proxy
+# URL is legitimately http as often as https, so S5332 does not apply here
+config.plugins.iptvplayer.proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)  # NOSONAR
+config.plugins.iptvplayer.german_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)  # NOSONAR
+config.plugins.iptvplayer.russian_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)  # NOSONAR
+config.plugins.iptvplayer.ukrainian_proxyurl = ConfigText(default="http://user:pass@ip:port", fixed_size=False)  # NOSONAR
+config.plugins.iptvplayer.alternative_proxy1 = ConfigText(default="http://user:pass@ip:port", fixed_size=False)  # NOSONAR
+config.plugins.iptvplayer.alternative_proxy2 = ConfigText(default="http://user:pass@ip:port", fixed_size=False)  # NOSONAR
 
 # config.plugins.iptvplayer.captcha_bypass_order = ConfigSelection(default="", choices=[("", _("Internal, then external")), ("free", _("Only free")), ("free_pay", _("External free, then paid")), ("pay", _("External paid"))])
 # config.plugins.iptvplayer.captcha_bypass_free = ConfigSelection(default="", choices=[("", _("None")), ("myjd", "MyJDownloader")])
@@ -526,7 +527,7 @@ class ConfigMenu(ConfigBaseWidget):
         list.append(getConfigListEntry(_("%s e-mail") % ('My JDownloader'), config.plugins.iptvplayer.myjd_login))
         list.append(getConfigListEntry(_("%s password") % ('My JDownloader'), config.plugins.iptvplayer.myjd_password))
         list.append(getConfigListEntry(_("%s device name") % ('My JDownloader'), config.plugins.iptvplayer.myjd_jdname))
-        list.append(getConfigListEntry(_("%s API KEY") % 'http://youtube.com/', config.plugins.iptvplayer.api_key_youtube))
+        list.append(getConfigListEntry(_("%s API KEY") % 'https://youtube.com/', config.plugins.iptvplayer.api_key_youtube))
 
         list.append(getConfigListEntry(_("----- CAPTCHA CONFIGURATION -----"), ))
         list.append(getConfigListEntry(_("Default captcha bypass"), config.plugins.iptvplayer.captcha_bypass))
@@ -536,19 +537,19 @@ class ConfigMenu(ConfigBaseWidget):
         # if config.plugins.iptvplayer.captcha_bypass_pay.value == "9kw.eu":
         list.append(getConfigListEntry(_("%s API KEY") % 'https://9kw.eu/', config.plugins.iptvplayer.api_key_9kweu))
         # if config.plugins.iptvplayer.captcha_bypass_pay.value == "2captcha.com":
-        list.append(getConfigListEntry(_("%s API KEY") % 'http://2captcha.com/', config.plugins.iptvplayer.api_key_2captcha))
+        list.append(getConfigListEntry(_("%s API KEY") % 'https://2captcha.com/', config.plugins.iptvplayer.api_key_2captcha))
 
         list.append(getConfigListEntry(_("----- SUBTITLES CONFIGURATION -----"), ))
         list.append(getConfigListEntry(_("Use subtitles parser extension if available"), config.plugins.iptvplayer.useSubtitlesParserExtension))
         list.append(getConfigListEntry("https://subsource.net/ " + _("API_KEY"), config.plugins.iptvplayer.subsourceapi))
         list.append(getConfigListEntry("https://subdl.com/ " + _("API Key"), config.plugins.iptvplayer.subdlapi))
-        list.append(getConfigListEntry("http://opensubtitles.org/ " + _("login"), config.plugins.iptvplayer.opensuborg_login))
-        list.append(getConfigListEntry("http://opensubtitles.org/ " + _("password"), config.plugins.iptvplayer.opensuborg_password))
-        list.append(getConfigListEntry("http://napisy24.pl/ " + _("login"), config.plugins.iptvplayer.napisy24pl_login))
-        list.append(getConfigListEntry("http://napisy24.pl/ " + _("password"), config.plugins.iptvplayer.napisy24pl_password))
-        list.append(getConfigListEntry("http://vk.com/ " + _("login"), config.plugins.iptvplayer.vkcom_login))
-        list.append(getConfigListEntry("http://vk.com/ " + _("password"), config.plugins.iptvplayer.vkcom_password))
-        list.append(getConfigListEntry("http://1fichier.com/ " + _("e-mail"), config.plugins.iptvplayer.fichiercom_login))
+        list.append(getConfigListEntry("https://opensubtitles.org/ " + _("login"), config.plugins.iptvplayer.opensuborg_login))
+        list.append(getConfigListEntry("https://opensubtitles.org/ " + _("password"), config.plugins.iptvplayer.opensuborg_password))
+        list.append(getConfigListEntry("https://napisy24.pl/ " + _("login"), config.plugins.iptvplayer.napisy24pl_login))
+        list.append(getConfigListEntry("https://napisy24.pl/ " + _("password"), config.plugins.iptvplayer.napisy24pl_password))
+        list.append(getConfigListEntry("https://vk.com/ " + _("login"), config.plugins.iptvplayer.vkcom_login))
+        list.append(getConfigListEntry("https://vk.com/ " + _("password"), config.plugins.iptvplayer.vkcom_password))
+        list.append(getConfigListEntry("https://1fichier.com/ " + _("e-mail"), config.plugins.iptvplayer.fichiercom_login))
         list.append(getConfigListEntry("http://1fichier.com/ " + _("password"), config.plugins.iptvplayer.fichiercom_password))
 
         list.append(getConfigListEntry(_("----- PLAYERS & PLAYBACK CONFIGURATION -----"), ))

--- a/IPTVPlayer/hosts/hostmrpiracy.py
+++ b/IPTVPlayer/hosts/hostmrpiracy.py
@@ -44,7 +44,7 @@ config.plugins.iptvplayer.api_key_2captcha = ConfigText(default="", fixed_size=F
 config.plugins.iptvplayer.mrpiracy_linkcache = ConfigYesNo(default=True)
 config.plugins.iptvplayer.mrpiracy_bypassrecaptcha = ConfigSelection(default="None", choices=[("None", _("None")),
                                                                                                  ("9kw.eu", "https://9kw.eu/"),
-                                                                                                 ("2captcha.com", "http://2captcha.com/")])
+                                                                                                 ("2captcha.com", "https://2captcha.com/")])
 
 
 def GetConfigList():

--- a/IPTVPlayer/hosts/hostmusicbox.py
+++ b/IPTVPlayer/hosts/hostmusicbox.py
@@ -303,11 +303,11 @@ class MusicBox(CBaseHostClass):
         printDBG("MusicBox - list abum tracks")
 
         if url != 0:
-            sts, data = self.cm.getPage('http://ws.audioscrobbler.com/2.0/?method=album.getInfo&mbid=' + url + '&api_key=' + audioscrobbler_api_key + '&format=json', {'header': HEADER})
+            sts, data = self.cm.getPage('https://ws.audioscrobbler.com/2.0/?method=album.getInfo&mbid=' + url + '&api_key=' + audioscrobbler_api_key + '&format=json', {'header': HEADER})
             if not sts:
                 return
         else:
-            sts, data = self.cm.getPage('http://ws.audioscrobbler.com/2.0/?method=album.getInfo&artist=' + urllib_quote(artist) + '&album=' + urllib_quote(album) + '&api_key=' + audioscrobbler_api_key + '&format=json', {'header': HEADER})
+            sts, data = self.cm.getPage('https://ws.audioscrobbler.com/2.0/?method=album.getInfo&artist=' + urllib_quote(artist) + '&album=' + urllib_quote(album) + '&api_key=' + audioscrobbler_api_key + '&format=json', {'header': HEADER})
             if not sts:
                 return
         try:
@@ -338,7 +338,7 @@ class MusicBox(CBaseHostClass):
         if False is self.usePremiumAccount:
             self.sessionEx.waitForFinishOpen(MessageBox, 'Wpisz login do last.fm.', type=MessageBox.TYPE_INFO, timeout=10)
         else:
-            url = 'http://ws.audioscrobbler.com/2.0/?method=user.getPlaylists&user=' + self.lastfm_username + '&api_key=' + audioscrobbler_api_key + '&format=json'
+            url = 'https://ws.audioscrobbler.com/2.0/?method=user.getPlaylists&user=' + self.lastfm_username + '&api_key=' + audioscrobbler_api_key + '&format=json'
             sts, data = self.cm.getPage(url, {'header': HEADER})
             if not sts:
                 return
@@ -357,7 +357,7 @@ class MusicBox(CBaseHostClass):
         printDBG("MusicBox - last.fm list track")
 
         playlist_id = "lastfm://playlist/" + artist
-        url = 'http://ws.audioscrobbler.com/2.0/?method=playlist.fetch&playlistURL=' + playlist_id + '&api_key=' + audioscrobbler_api_key + '&format=json'
+        url = 'https://ws.audioscrobbler.com/2.0/?method=playlist.fetch&playlistURL=' + playlist_id + '&api_key=' + audioscrobbler_api_key + '&format=json'
         printDBG(url)
         sts, data = self.cm.getPage(url, {'header': HEADER})
         if not sts:

--- a/IPTVPlayer/hosts/hostrteieplayer.py
+++ b/IPTVPlayer/hosts/hostrteieplayer.py
@@ -225,7 +225,7 @@ class RteIE(CBaseHostClass):
 
         if '/show/' in cItem['url']:
             try:
-                sts, data = self.cm.getPage('http://feeds.rasset.ie/rteavgen/player/playlist/?type=iptv&format=json&showId=' + id, self.defaultParams)
+                sts, data = self.cm.getPage('https://feeds.rasset.ie/rteavgen/player/playlist/?type=iptv&format=json&showId=' + id, self.defaultParams)
                 data = byteify(json.loads(data))['shows'][0]["media:group"][0]
                 hdsUrl = data['rte:server'] + data['url']
             except Exception:

--- a/IPTVPlayer/hosts/hosttvjworg.py
+++ b/IPTVPlayer/hosts/hosttvjworg.py
@@ -75,7 +75,7 @@ class TVJWORG(CBaseHostClass):
             elif not url.startswith('http'):
                 url = baseUrl + url
         if not baseUrl.startswith('https://'):
-            url = url.replace('https://', 'http://')
+            url = url.replace('https://', 'http://')  # NOSONAR - deliberate scheme match to a non-https MAIN_URL
         return url
 
     def cleanHtmlStr(self, data):

--- a/IPTVPlayer/libs/recaptcha_v2.py
+++ b/IPTVPlayer/libs/recaptcha_v2.py
@@ -31,7 +31,7 @@ class UnCaptchaReCaptcha:
         iteration = 0
         if referer is not None:
             self.HTTP_HEADER['Referer'] = referer
-        reCaptchaUrl = 'http://www.google.com/recaptcha/api/fallback?k=%s' % (key)
+        reCaptchaUrl = 'https://www.google.com/recaptcha/api/fallback?k=%s' % (key)
         while iteration < 20:
             # ,'cookiefile':self.COOKIE_FILE, 'use_cookie': True, 'load_cookie': True, 'save_cookie':True
             sts, data = self.cm.getPage(reCaptchaUrl, {'header': self.HTTP_HEADER, 'raw_post_data': True}, post_data=post_data)

--- a/IPTVPlayer/libs/ustvnow.py
+++ b/IPTVPlayer/libs/ustvnow.py
@@ -75,7 +75,7 @@ class UstvnowApi:
         if 0 < len(url) and not url.startswith('http'):
             url = self.MAIN_URL + url
         if not self.MAIN_URL.startswith('https://'):
-            url = url.replace('https://', 'http://')
+            url = url.replace('https://', 'http://')  # NOSONAR - deliberate scheme match to a non-https MAIN_URL
         return url
 
     def cleanHtmlStr(self, str):

--- a/IPTVPlayer/libs/webcamera.py
+++ b/IPTVPlayer/libs/webcamera.py
@@ -32,7 +32,7 @@ class WebCameraApi(CBaseHostClass):
     def __init__(self):
         CBaseHostClass.__init__(self)
         self.MAIN_URL = 'https://www.webcamera.pl/'
-        self.DEFAULT_ICON_URL = 'http://static.webcamera.pl/webcamera/img/loader-min.png'
+        self.DEFAULT_ICON_URL = 'https://static.webcamera.pl/webcamera/img/loader-min.png'
         self.HEADER = {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:21.0) Gecko/20100101 Firefox/21.0', 'Referer': self.getMainUrl(), 'Accept': 'text/html'}
         self.AJAX_HEADER = dict(self.HEADER)
         self.AJAX_HEADER.update({'X-Requested-With': 'XMLHttpRequest'})

--- a/IPTVPlayer/scripts/fakejd.py
+++ b/IPTVPlayer/scripts/fakejd.py
@@ -135,8 +135,8 @@ def encrypt(secret_token, data):
 class Myjdapi:
     def __init__(self):
         self._request_id = int(time.time() * 1000)
-        self._api_url = "http://api.jdownloader.org"
-        self._app_key = "http://git.io/vmcsk"
+        self._api_url = "http://api.jdownloader.org"  # NOSONAR - MyJDownloader API base; requests are AES-signed on top
+        self._app_key = "http://git.io/vmcsk"  # NOSONAR - fixed protocol identifier string, never dereferenced
         self._api_version = 1
         self._devices = None
         self._login_secret = None

--- a/IPTVPlayer/scripts/keepalive_proxy.py
+++ b/IPTVPlayer/scripts/keepalive_proxy.py
@@ -58,7 +58,7 @@ class Proxy(SimpleHTTPRequestHandler):
             if url.startswith('/https/'):
                 url = 'https://' + url[7:]
             elif url.startswith('/http/'):
-                url = 'http://' + url[6:]
+                url = 'http://' + url[6:]  # NOSONAR - rebuilds whatever scheme the /http/ proxy path asked for
 
             sts, resp = getPage(url, HTTP_HEADER)
             if sts:

--- a/IPTVPlayer/scripts/livesports.py
+++ b/IPTVPlayer/scripts/livesports.py
@@ -162,7 +162,7 @@ class Proxy(http.server.SimpleHTTPRequestHandler):
         if keyUrl.startswith('/https/'):
             keyUrl = 'https://' + keyUrl[7:]
         elif keyUrl.startswith('/http/'):
-            keyUrl = 'http://' + keyUrl[6:]
+            keyUrl = 'http://' + keyUrl[6:]  # NOSONAR - rebuilds whatever scheme the /http/ proxy path asked for
 
         printDBG("do_GET: " + keyUrl)
 

--- a/IPTVPlayer/subproviders/subprov_napiprojektpl.py
+++ b/IPTVPlayer/subproviders/subprov_napiprojektpl.py
@@ -45,7 +45,7 @@ def GetConfigList():
 class NapiProjektProvider(CBaseSubProviderClass):
 
     def __init__(self, params={}):
-        self.MAIN_URL = 'http://www.napiprojekt.pl/'
+        self.MAIN_URL = 'https://www.napiprojekt.pl/'
         self.USER_AGENT = 'DMnapi 13.1.30'
         self.HTTP_HEADER = {'User-Agent': 'Mozilla/5.0', 'Referer': self.MAIN_URL, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate'}
         self.AJAX_HEADER = {'User-Agent': 'Mozilla/5.0', 'Referer': self.MAIN_URL, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate', 'X-Requested-With': 'XMLHttpRequest'}

--- a/IPTVPlayer/subproviders/subprov_napisy24pl.py
+++ b/IPTVPlayer/subproviders/subprov_napisy24pl.py
@@ -51,7 +51,7 @@ def GetConfigList():
 class Napisy24plProvider(CBaseSubProviderClass):
 
     def __init__(self, params={}):
-        self.MAIN_URL = 'http://napisy24.pl/'
+        self.MAIN_URL = 'https://napisy24.pl/'
         self.USER_AGENT = 'DMnapi 13.1.30'
         self.HTTP_HEADER = {'User-Agent': self.USER_AGENT, 'Referer': self.MAIN_URL, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate'}
 
@@ -108,7 +108,7 @@ class Napisy24plProvider(CBaseSubProviderClass):
             else:
                 self.logedIn = True
         else:
-            self.sessionEx.open(MessageBox, _('Service %s requires registration. \nPlease fill your login and password in the %s configuration.') % ('http://napisy24.pl/', 'E2iPlayer'), type=MessageBox.TYPE_ERROR, timeout=10)
+            self.sessionEx.open(MessageBox, _('Service %s requires registration. \nPlease fill your login and password in the %s configuration.') % ('https://napisy24.pl/', 'E2iPlayer'), type=MessageBox.TYPE_ERROR, timeout=10)
 
     def sortSubtitlesByDurationMatch(self):
         # we need duration to sort
@@ -313,7 +313,7 @@ class Napisy24plProvider(CBaseSubProviderClass):
         fileName = self._getFileName(title, lang, subId, imdbid)
         fileName = GetSubtitlesDir(fileName)
 
-        url = 'http://napisy24.pl/download?napisId={0}&typ=sru'.format(subId)
+        url = 'https://napisy24.pl/download?napisId={0}&typ=sru'.format(subId)
         tmpFile = GetTmpDir(self.TMP_FILE_NAME)
         tmpFileZip = tmpFile + '.zip'
 

--- a/IPTVPlayer/subproviders/subprov_opensubtitlesorg.py
+++ b/IPTVPlayer/subproviders/subprov_opensubtitlesorg.py
@@ -49,7 +49,7 @@ class OpenSubOrgProvider(CBaseSubProviderClass):
     def __init__(self, params={}):
         self.USER_AGENT = 'IPTVPlayer v1'
         self.HTTP_HEADER = {'User-Agent': self.USER_AGENT, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate'}
-        self.MAIN_URL = 'http://api.opensubtitles.org/xml-rpc'
+        self.MAIN_URL = 'http://api.opensubtitles.org/xml-rpc'  # NOSONAR - xml-rpc endpoint, kept on http (matches subprov_opensubtitlesorg3)
 
         params['cookie'] = 'opensubtitlesorg.cookie'
         CBaseSubProviderClass.__init__(self, params)

--- a/IPTVPlayer/subproviders/subprov_opensubtitlesorg3.py
+++ b/IPTVPlayer/subproviders/subprov_opensubtitlesorg3.py
@@ -236,7 +236,7 @@ class OpenSubtitlesRest(CBaseSubProviderClass):
 
         login = config.plugins.iptvplayer.opensuborg_login.value
         password = config.plugins.iptvplayer.opensuborg_password.value
-        loginUrl = 'http://api.opensubtitles.org/xml-rpc'
+        loginUrl = 'http://api.opensubtitles.org/xml-rpc'  # NOSONAR - see the https->http normalisation below
         loginData = '''<methodCall>
                          <methodName>LogIn</methodName>
                            <params>
@@ -256,7 +256,7 @@ class OpenSubtitlesRest(CBaseSubProviderClass):
                        </methodCall>'''
 
         if baseUrl.startswith('https://'):
-            baseUrl = 'http://' + baseUrl.split('://', 1)[-1]
+            baseUrl = 'http://' + baseUrl.split('://', 1)[-1]  # NOSONAR - opensubtitles xml-rpc is used over http on purpose (box TLS)
 
         url = baseUrl
         attempt = 0

--- a/IPTVPlayer/subproviders/subprov_popcornsubtitles.py
+++ b/IPTVPlayer/subproviders/subprov_popcornsubtitles.py
@@ -36,7 +36,7 @@ def GetConfigList():
 class YoutubeComProvider(CBaseSubProviderClass):
 
     def __init__(self, params={}):
-        self.MAIN_URL = 'http://popcornsubtitles.com/'
+        self.MAIN_URL = 'https://popcornsubtitles.com/'
         self.USER_AGENT = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/37.0.2062.120 Chrome/37.0.2062.120 Safari/537.36'
         self.HTTP_HEADER = {'User-Agent': self.USER_AGENT, 'Referer': self.MAIN_URL, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate'}
 

--- a/IPTVPlayer/subproviders/subprov_subsro.py
+++ b/IPTVPlayer/subproviders/subprov_subsro.py
@@ -46,7 +46,7 @@ class SubsRoProvider(CBaseSubProviderClass):
         self.dInfo = params['discover_info']
 
     def getMainUrl(self):
-        return 'http://subs.ro/'
+        return 'https://subs.ro/'
 
     def getMaxFileSize(self):
         return 1024 * 1024 * 10  # 10MB, max size of sub file to be download

--- a/IPTVPlayer/subproviders/subprov_subtitlesgr.py
+++ b/IPTVPlayer/subproviders/subprov_subtitlesgr.py
@@ -31,7 +31,7 @@ def GetConfigList():
 class SubtitlesGrProvider(CBaseSubProviderClass):
 
     def __init__(self, params={}):
-        self.MAIN_URL = 'http://gr.greek-subtitles.com/'
+        self.MAIN_URL = 'https://gr.greek-subtitles.com/'
         self.USER_AGENT = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/37.0.2062.120 Chrome/37.0.2062.120 Safari/537.36'
         self.HTTP_HEADER = {'User-Agent': self.USER_AGENT, 'Referer': self.MAIN_URL, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate'}
 
@@ -52,7 +52,7 @@ class SubtitlesGrProvider(CBaseSubProviderClass):
         printDBG("SubtitlesGrProvider.listSubItems")
         page = cItem.get('page', 0)
         keywords = urllib_quote_plus(self.params['confirmed_title'])
-        baseUrl = "http://gr.greek-subtitles.com/search.php?page=%s&name=%s" % (page, keywords)
+        baseUrl = "https://gr.greek-subtitles.com/search.php?page=%s&name=%s" % (page, keywords)
 
         url = self.getFullUrl(baseUrl)
         sts, data = self.cm.getPage(url)

--- a/IPTVPlayer/suggestions/google.py
+++ b/IPTVPlayer/suggestions/google.py
@@ -19,7 +19,7 @@ class SuggestionsProvider:
 
     def getSuggestions(self, text, locale):
         lang = locale.split('-', 1)[0]
-        url = 'http://suggestqueries.google.com/complete/search?output=firefox&hl=%s&gl=%s%s&q=%s' % (lang, lang, '&ds=yt' if self.forYouyube else '', urllib_quote(text))
+        url = 'https://suggestqueries.google.com/complete/search?output=firefox&hl=%s&gl=%s%s&q=%s' % (lang, lang, '&ds=yt' if self.forYouyube else '', urllib_quote(text))
         sts, data = self.cm.getPage(url)
         if sts:
             retList = []

--- a/IPTVPlayer/suggestions/imdb.py
+++ b/IPTVPlayer/suggestions/imdb.py
@@ -23,7 +23,7 @@ class SuggestionsProvider:
         text = text.encode('ascii', 'ignore').decode('ascii').lower()
         if len(text) > 2:
             text = text.replace(' ', '_')
-            url = 'http://v2.sg.media-imdb.com/suggests/titles/%s/%s.json' % (text[0], text)
+            url = 'https://v2.sg.media-imdb.com/suggests/titles/%s/%s.json' % (text[0], text)
             sts, data = self.cm.getPage(url)
             if sts:
                 retList = []

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.09.04"
+IPTV_VERSION = "2026.09.10.01"


### PR DESCRIPTION
…S5332)

SonarCloud S5332 (clear-text HTTP) cleanup on the non-adult hosts:

http -> https where the service is a well-known site that supports it and was verified reachable over TLS:
  - Last.fm / ws.audioscrobbler.com (hostmusicbox)
  - Google / IMDb search suggestions
  - Google reCAPTCHA fallback
  - opensubtitles.org / napisy24.pl / napiprojekt.pl / subs.ro / greek-subtitles.com / popcornsubtitles.com sub providers
  - RTE feeds.rasset.ie, static.webcamera.pl icon
  - the sub/captcha/API-KEY labels shown in the config screen

# NOSONAR on the genuine false positives:
  - the proxy ConfigText placeholder defaults (a proxy URL is http as often as https, and it is an example the user overwrites)
  - MyJDownloader api_url / app_key (protocol constants, AES-signed)
  - the deliberate https->http scheme-normalisation in hosttvjworg / ustvnow / the /http/ proxy-path rebuilds / opensubtitles xml-rpc

No behaviour change beyond the scheme; no translatable strings touched.