### PR TITLE
Code-analysis #4: fix regressions, dead code, and a global monkeypatch

### DIFF
--- a/IPTVPlayer/components/ihost.py
+++ b/IPTVPlayer/components/ihost.py
@@ -959,7 +959,7 @@ class CBaseHostClass:
 
     def listsHistory(self, baseItem={'name': 'history', 'category': 'search'}, desc_key='plot', desc_base=None):
         if desc_base is None:
-            desc_base = _("Type: ")
+            desc_base = _("Type:") + " "
         list = self.history.getHistoryList()
         for histItem in list:
             plot = ''

--- a/IPTVPlayer/hosts/hostaflaam.py
+++ b/IPTVPlayer/hosts/hostaflaam.py
@@ -103,8 +103,6 @@ class Aflaam(CBaseHostClass):
 
     def handleService(self, index, refresh=0, searchPattern="", searchType=""):
         CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
-        if self.MAIN_URL is None:
-            self.menu()
         name = self.currItem.get("name", "")
         category = self.currItem.get("category", "")
         printDBG("handleService start\nhandleService: name[%s], category[%s] " % (name, category))

--- a/IPTVPlayer/hosts/hostardmediathek.py
+++ b/IPTVPlayer/hosts/hostardmediathek.py
@@ -881,7 +881,7 @@ class ARDmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
             baseItem = {'name': 'history', 'category': 'search'}
             if self.currItem.get('f_audio'):
                 baseItem['f_audio'] = True
-            self.listsHistory(baseItem, 'desc', _("Type: "))
+            self.listsHistory(baseItem, 'desc', _("Type:") + " ")
         else:
             printExc()
         CBaseHostClass.endHandleService(self, index, refresh)

--- a/IPTVPlayer/hosts/hostcb01uno.py
+++ b/IPTVPlayer/hosts/hostcb01uno.py
@@ -144,8 +144,6 @@ class Cb01(CBaseHostClass):
 
     def handleService(self, index, refresh=0, searchPattern="", searchType=""):
         CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
-        if self.MAIN_URL is None:
-            self.menu()
         name = self.currItem.get("name", "")
         category = self.currItem.get("category", "")
         printDBG("handleService start\nhandleService: name[%s], category[%s] " % (name, category))

--- a/IPTVPlayer/hosts/hostvidea.py
+++ b/IPTVPlayer/hosts/hostvidea.py
@@ -338,7 +338,7 @@ class videa(CBaseHostClass):
                 cItem.update({"search_item": False, "name": "category"})
                 self.listSearchResult(cItem, searchPattern, searchType)
             elif category == "search_history":
-                self.listsHistory({"name": "history", "category": "search", "tab_id": ""}, "desc", _("Type: "))
+                self.listsHistory({"name": "history", "category": "search", "tab_id": ""}, "desc", _("Type:") + " ")
             else:
                 return
             CBaseHostClass.endHandleService(self, index, refresh)

--- a/IPTVPlayer/hosts/hostxalaflix.py
+++ b/IPTVPlayer/hosts/hostxalaflix.py
@@ -147,8 +147,6 @@ class XalaFlix(CBaseHostClass):
 
     def handleService(self, index, refresh=0, searchPattern="", searchType=""):
         CBaseHostClass.handleService(self, index, refresh, searchPattern, searchType)
-        if self.MAIN_URL is None:
-            self.menu()
         name = self.currItem.get("name", "")
         category = self.currItem.get("category", "")
         printDBG("handleService start\nhandleService: name[%s], category[%s] " % (name, category))

--- a/IPTVPlayer/hosts/hostxxx.py
+++ b/IPTVPlayer/hosts/hostxxx.py
@@ -19,11 +19,6 @@ import base64
 import random
 
 try:
-	import http.client as httplib  # Python 3
-except ImportError:
-	import httplib  # Python 2
-
-try:
 	import json
 except ImportError:
 	import simplejson as json
@@ -637,6 +632,12 @@ class Host(CBaseHostClass, XXXParser):
 		return url
 
 	def getPage(self, baseUrl, cookie_domain, cloud_domain, params={}, post_data=None, userAgent=None):
+		# work on our own copy - params defaults to a shared dict (and callers
+		# pass self.defaultParams, itself reused/reassigned all over this
+		# class), so mutating it in place here would leak cloudflare_params
+		# (and whatever getPageCFProtection() adds on top: header/cookiefile/
+		# CFProtection) into unrelated later calls that share the same dict
+		params = dict(params)
 		COOKIEFILE = join(GetCookieDir(), cookie_domain)
 		agent = userAgent or USER_AGENT
 		self.HEADER = {'User-Agent': agent, 'Accept': 'text/html'}
@@ -647,32 +648,20 @@ class Host(CBaseHostClass, XXXParser):
 		def _getFullUrl(url):
 			return url if self.cm.isValidUrl(url) else urljoin(baseUrl, url)
 
-		if params == {}:
-			params = dict(self.defaultParams)
+		# own copy for the same reason as getPage() above
+		params = dict(params) if params else dict(self.defaultParams)
 		COOKIEFILE = join(GetCookieDir(), cookie_domain)
 		params['cookie_items'] = {'xxx': 'ok'}
 		params['cloudflare_params'] = {'domain': cloud_domain, 'cookie_file': COOKIEFILE, 'User-Agent': USER_AGENT, 'full_url_handle': _getFullUrl}
 		return self.cm.getPageCFProtection(baseUrl, params, post_data)
 
 	def _getPage(self, url, addParams={}, post_data=None):
-		try:
-			def patch_http_response_read(func):
-				def inner(*args):
-					try:
-						return func(*args)
-					except httplib.IncompleteRead as e:
-						return e.partial
-				return inner
-			prev_read = httplib.HTTPResponse.read
-			httplib.HTTPResponse.read = patch_http_response_read(httplib.HTTPResponse.read)
-		except Exception:
-			printExc()
-		sts, data = self.cm.getPage(url, addParams, post_data)
-		try:
-			httplib.HTTPResponse.read = prev_read
-		except Exception:
-			printExc()
-		return sts, data
+		# IncompleteRead (server closes the connection before delivering the
+		# full advertised Content-Length) is now handled centrally in
+		# common._readHttpResponse(), which falls back to the partial body
+		# instead of losing the response - no more need to monkeypatch
+		# httplib.HTTPResponse.read process-wide from here.
+		return self.cm.getPage(url, addParams, post_data)
 
 	def getPageWithCFBypass(self, url, max_retries=3, params=None):
 		printDBG("getPageWithCFBypass >>> url: " + url)

--- a/IPTVPlayer/hosts/hostzdfmediathek.py
+++ b/IPTVPlayer/hosts/hostzdfmediathek.py
@@ -80,7 +80,6 @@ class ZDFmediathek(GenericFolderWatchedScraperMixin, CBaseHostClass):
     LOGIN_GOOGLE_URL = ZDF_API_URL + 'identity/thirdparty/google/login'
     REGISTER_URL = MAIN_URL + 'mein-zdf#start'
     SUBSCRIPTIONS_API_URL = MAIN_API_URL + 'mediathekV2/user/subscriptions'
-    PUSH_SUBSCRIBE_URL = 'http://push.live.cellular.de/api/device/'
     BOOKMARKS_API_URL = MAIN_API_URL + 'mediathekV2/user/bookmarks'
     AUTH_TOKEN_API_URL = MAIN_API_URL + 'mediathekV2/token'
     AKAMAI_TOKEN_API_URL = 'https://tg2cl15.zdf.de/generate'

--- a/IPTVPlayer/iptvdm/hlsdownloader.py
+++ b/IPTVPlayer/iptvdm/hlsdownloader.py
@@ -180,14 +180,16 @@ class HLSDownloader(BaseDownloader, SidecarMixin):
         self.localFileSize = DMHelper.getFileSize(fsPath(finalPath))
         if self.localFileSize > 0:
             self.remoteFileSize = self.localFileSize
-        self.status = DMHelper.STS.DOWNLOADED
+            self.status = DMHelper.STS.DOWNLOADED
 
-        self._writeTxtSidecar(finalPath)
+            self._writeTxtSidecar(finalPath)
 
-        if self.sidecarEnabled and self.sidecarImg:
-            self._startImgSidecarDownload(finalPath)
-            return
+            if self.sidecarEnabled and self.sidecarImg:
+                self._startImgSidecarDownload(finalPath)
+                return
         else:
+            # remuxed/finalized file is empty -> treat as interrupted, and
+            # don't write a TXT/image sidecar for a video that isn't there
             self.status = DMHelper.STS.INTERRUPTED
 
         self._finishDownloadFlow()

--- a/IPTVPlayer/iptvdm/iptvdownloadercreator.py
+++ b/IPTVPlayer/iptvdm/iptvdownloadercreator.py
@@ -122,7 +122,7 @@ def DownloaderCreator(url):
     # then ALWAYS prefer FFMPEGDownloader,
     # even for m3u8/HLS.
     #################################################
-    if useFFmpeg or ffmpegCase in ['kinoger', 'pornslash']:
+    if useFFmpeg or ffmpegCase in ['kinoger']:
         printDBG("DownloaderCreator: force FFMPEGDownloader by iptv_use_ffmpeg=True or iptv_ffmpeg_case[%s]" % ffmpegCase)
         try:
             return FFMPEGDownloader()

--- a/IPTVPlayer/iptvdm/mergedownloader.py
+++ b/IPTVPlayer/iptvdm/mergedownloader.py
@@ -658,17 +658,19 @@ class MergeDownloader(BaseDownloader, SidecarMixin):
         self.localFileSize = DMHelper.getFileSize(fsPath(finalPath))
         if self.localFileSize > 0:
             self.remoteFileSize = self.localFileSize
-        self.status = DMHelper.STS.DOWNLOADED
+            self.status = DMHelper.STS.DOWNLOADED
 
-        self._writeTxtSidecar(finalPath)
+            self._writeTxtSidecar(finalPath)
 
-        if self.makeCutsFile:
-            self._writeCutsFile(finalPath)
+            if self.makeCutsFile:
+                self._writeCutsFile(finalPath)
 
-        if self.sidecarEnabled and self.sidecarImg:
-            self._startImgSidecarDownload(finalPath)
-            return
+            if self.sidecarEnabled and self.sidecarImg:
+                self._startImgSidecarDownload(finalPath)
+                return
         else:
+            # remuxed/finalized file is empty -> treat as interrupted, and
+            # don't write a TXT/cuts/image sidecar for a video that isn't there
             self.status = DMHelper.STS.INTERRUPTED
 
         self._finishDownloadFlow()

--- a/IPTVPlayer/libs/keepalive.py
+++ b/IPTVPlayer/libs/keepalive.py
@@ -290,7 +290,7 @@ class KeepAliveHandler:
             # worked.  We'll check the version below, too.
         except (socket.error, http.client.HTTPException):
             r = None
-        except:
+        except BaseException:
             # adding this block just in case we've missed
             # something we will still raise the exception, but
             # lets try and close the connection and remove it

--- a/IPTVPlayer/libs/pCommon.py
+++ b/IPTVPlayer/libs/pCommon.py
@@ -2,6 +2,7 @@
 import base64
 from binascii import hexlify
 import gzip
+from http.client import IncompleteRead
 import http.cookiejar
 from io import BytesIO, StringIO
 import os
@@ -964,6 +965,24 @@ class common:
             for header, value in responseHeaders.items():
                 metadata[header.lower()] = responseHeaders[header]
 
+    def _readHttpResponse(self, fp, maxSize=-1):
+        # Some servers close the connection before delivering the full
+        # response promised by Content-Length. http.client then raises
+        # IncompleteRead and the partial body would otherwise be lost
+        # entirely - use what was actually received instead. This used
+        # to be handled per-host via a global
+        # httplib.HTTPResponse.read monkeypatch (e.g. hostxxx.py); doing
+        # it once here, at the only place that actually calls read(),
+        # covers every caller of getPage()/getURLRequestData() without
+        # touching process-wide state.
+        try:
+            if maxSize == -1:
+                return fp.read()
+            return fp.read(maxSize)
+        except IncompleteRead as e:
+            printDBG("common._readHttpResponse: IncompleteRead, using partial data (%d bytes)" % len(e.partial or b''))
+            return e.partial
+
     def getPage(self, url, addParams={}, post_data=None):
         ''' wraps getURLRequestData '''
 
@@ -993,7 +1012,7 @@ class common:
                     metadata['status_code'] = e.code
                     self.fillHeaderItems(metadata, e.fp.info(), True, collectAllHeaders=addParams.get('collect_all_headers'))
 
-                    data = e.fp.read(addParams.get('max_data_size', -1))
+                    data = self._readHttpResponse(e.fp, addParams.get('max_data_size', -1))
                     if e.fp.info().get('Content-Encoding', '') == 'gzip':
                         data = DecodeGzipped(data)
 
@@ -1369,10 +1388,7 @@ class common:
                     pass
 
                 max = params.get('max_data_size', -1)
-                if max == -1:
-                    data = response.read()
-                else:
-                    data = response.read(max)
+                data = self._readHttpResponse(response, max)
                 response.close()
             except HTTPError as e:
                 ignoreCodeRanges = params.get('ignore_http_code_ranges', [(404, 404), (500, 500)])
@@ -1393,10 +1409,7 @@ class common:
                     except Exception:
                         pass
                     max = params.get('max_data_size', -1)
-                    if max == -1:
-                        data = e.fp.read()
-                    else:
-                        data = e.fp.read(max)
+                    data = self._readHttpResponse(e.fp, max)
                     # e.msg
                     # e.headers
                 elif e.code == 503:

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -2392,7 +2392,8 @@ class pageParser(CaptchaHelper):
         def xn(e, v):
             if v:
                 v = int(v)
-                e = [e[v - 1], e[len(e) - v]]
+                if 0 < v <= len(e):
+                    e = [e[v - 1], e[len(e) - v]]
             t = list(map(ft, e))
             return b"".join(t)
 
@@ -2531,7 +2532,10 @@ class pageParser(CaptchaHelper):
         for redirectDomain in ["boosteradx.online", "byse.sx", "streamlyplayer.online"]:
             baseUrl = baseUrl.replace(redirectDomain, "streamlyplayero.online")
         ref = urlparser.getDomain(baseUrl, False)
-        mid = re.search(r"/(?:e|d|download)/([0-9a-zA-Z]+)", baseUrl).group(1)
+        midMatch = re.search(r"/(?:e|d|download)/([0-9a-zA-Z]+)", baseUrl)
+        if not midMatch:
+            return []
+        mid = midMatch.group(1)
         HTTP_HEADER = self.cm.getDefaultHeader()
         HTTP_HEADER["User-Agent"] = UA
         HTTP_HEADER["Referer"] = ref

--- a/IPTVPlayer/libs/urlparserhelper.py
+++ b/IPTVPlayer/libs/urlparserhelper.py
@@ -480,7 +480,7 @@ def getDirectM3U8Playlist(M3U8Url, checkExt=True, variantCheck=True, cookieParam
                         altItem = dict(item)
                         altItem['name'] = '[%s] %s' % (_hlsAudioLabel(audio_stream), altItem['name'])
                         metaItem = dict(item['url'].meta)
-                        metaItem.update({'audio_url': audioUrl, 'video_url': altItem['url'], 'ff_out_container': 'mpegts', 'prefered_merger': 'hlsdl'})
+                        metaItem.update({'audio_url': audioUrl, 'video_url': altItem['url'], 'ff_out_container': 'mpegts'})
                         altItem['url'] = decorateUrl("merge://audio_url|video_url", metaItem)
                         retPlaylists.append(altItem)
                 else:
@@ -515,7 +515,7 @@ def getF4MLinksWithMeta(manifestUrl, checkExt=True, cookieParams={}, sortWithMax
     sts, data = cm.getPage(manifestUrl, headerParams, postData)
     if sts:
         liveStreamDetected = False
-        if 'live' == CParsingHelper.getDataBeetwenMarkers('<streamType>', '</streamType>', False):
+        if 'live' == CParsingHelper.getDataBeetwenMarkers(data, '<streamType>', '</streamType>', False)[1].strip():
             liveStreamDetected = True
         tmp = cm.ph.getDataBeetwenMarkers(data, '<manifest', '</manifest>')[1]
         baseUrl = cm.ph.getDataBeetwenReMarkers(tmp, re.compile('<baseURL[^>]*?>'), re.compile('</baseURL>'), False)[1].strip()

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.10.01"
+IPTV_VERSION = "2026.09.11.01"


### PR DESCRIPTION
Changelog vs python3 (16 files):

Bugs
- iptvdm/hlsdownloader.py, iptvdm/mergedownloader.py: _finalizeSuccess() bound its DOWNLOADED/INTERRUPTED status to the wrong condition after an earlier sidecar refactor, and wrote TXT/cuts/image sidecars even for an empty/failed finalize. A successful ffmpeg post-process (Create MKV, chapters) with no image sidecar configured ended up marked INTERRUPTED instead of DOWNLOADED. Both methods restored to their pre-regression structure: status and sidecar writes nested inside "if self.localFileSize > 0:".
- libs/urlparserhelper.py: getF4MLinksWithMeta() called getDataBeetwenMarkers() without its `data` argument (and without reading the [1] result), so F4M/HDS live-stream detection never fired. Fixed the call and added .strip().
- libs/urlparser.py: parserBYSE guarded against two crashes on malformed input - re.search(...).group(1) now checked for no match before use, and xn()'s version-based index is bounds-checked instead of indexing unconditionally.
- hosts/hostxxx.py: getPage()/getPage4k() mutated their params dict in place. All 153 current getPage() callers pass self.defaultParams directly (reassigned ~1000x across this class), so the old code could leak one domain's Cloudflare context (cloudflare_params, plus whatever getPageCFProtection() layers on top) into another call sharing the same dict. Both now copy params first.

Replaced a global monkeypatch
- hosts/hostxxx.py _getPage() used to monkeypatch httplib.HTTPResponse.read process-wide for the duration of every request, to recover the partial body on an IncompleteRead (server closes the connection before the full advertised Content-Length). The patch/unpatch pair had no shared finally, so an exception in between could leave it patched for the rest of the session, and it affected every HTTP read in the plugin, not just this host's. Replaced with libs/pCommon.py's new common._readHttpResponse(), which does the same partial-data recovery locally at the one place that actually calls response.read()/e.fp.read() - no global state. This is exercised whenever the pycurl backend is bypassed: pycurl being unavailable, or (far more commonly) getPageCFProtection() setting CFProtection=True, which ~71 host files go through regardless of pycurl availability. hostxxx._getPage() is now a plain passthrough; its now-unused Python-2/3 httplib import shim was removed (it only existed for the patch).

Dead code removed
- libs/urlparserhelper.py: the 'prefered_merger' meta key, written but never read anywhere (merge:// routing lives in iptvdm/iptvdownloadercreator.py instead).
- iptvdm/iptvdownloadercreator.py: the 'pornslash' entry in the iptv_ffmpeg_case list - traced to the commit that introduced this list (f6929c0f7); iptv_ffmpeg_case is never set to 'pornslash' anywhere in the tree, on this fork or on zadmario.
- hosts/hostaflaam.py, hosts/hostcb01uno.py, hosts/hostxalaflix.py: the "if self.MAIN_URL is None: self.menu()" branch - MAIN_URL is always set in __init__ and menu() does not exist on these classes.
- hosts/hostzdfmediathek.py: PUSH_SUBSCRIBE_URL, unreferenced anywhere in the file (also a SonarCloud S5332 clear-text-HTTP hotspot that goes away with the dead code).

Consistency
- libs/keepalive.py: bare `except:` -> `except BaseException:` (the block re-raises after cleanup, so this only changes what gets caught, not the control flow).
- components/ihost.py, hosts/hostardmediathek.py, hosts/hostvidea.py: `_("Type: ")` -> `_("Type:") + " "`, moving the padding space out of the translated string (reuses the existing "Type:" msgid already seeded via components/translationHelper.py, no .po/.pot/.mo change).

ruff + compileall clean. Not box-tested.