### PR TITLE
MyE2i captcha QR code, hostsevenreels fixes, urlparser m3u8-naming/Vi…

### DIFF
--- a/IPTVPlayer/components/captchascriptwidget.py
+++ b/IPTVPlayer/components/captchascriptwidget.py
@@ -40,26 +40,34 @@ class CaptchaScriptWidgetBase(Screen):
     # so kept as-is instead of guessing one is more "correct").
     ACTION_CONTEXTS = ["ColorActions", "OkCancelActions"]
 
-    def __prepareSkin(self):
+    # `extraWidth`/`extraBody`: opt-in hook for a subclass that needs its own
+    # widget(s) next to the shared console box (e.g. UnCaptchaReCaptchaMyE2iWidget's
+    # QR code) - it calls this itself (before `Screen.__init__`, see `__init__`
+    # below) with a wider screen and its own skin snippet, instead of the base
+    # forcing the plain 500px-wide chrome on every subclass.
+    def _prepareSkin(self, extraWidth=0, extraBody=""):
         iconBase = skinchrome.getIconBase()
         HEIGHT = 320
         return """
-        <screen position="center,center" title="%s" size="500,%d" resolution="1280,720" backgroundColor="#34111112" flags="wfNoBorder">
+        <screen position="center,center" title="%s" size="%d,%d" resolution="1280,720" backgroundColor="#34111112" flags="wfNoBorder">
             %s
             <widget name="console" position="10,68" zPosition="2" size="480,%d" font="Regular;24" transparent="1" foregroundColor="white" backgroundColor="black" borderWidth="1" borderColor="black" />
+            %s
             %s
         </screen>
     """ % (
             self.__class__.__name__,
-            HEIGHT,
+            500 + extraWidth, HEIGHT,
             skinchrome.build_header_auto(iconBase=iconBase),
             HEIGHT - 142,
+            extraBody,
             skinchrome.build_footer_auto(HEIGHT, iconBase=iconBase, keys=('red',), showNav=False, showNum=False, showOk=False, showExit=True),
         )
 
     def __init__(self, session, title, sitekey, referer, captchaType=None):
         self.session = session
-        self.skin = self.__prepareSkin()
+        if not getattr(self, "skin", None):
+            self.skin = self._prepareSkin()
         Screen.__init__(self, session)
         self.sitekey = sitekey
         self.referer = referer

--- a/IPTVPlayer/components/recaptcha_mye2i_widget.py
+++ b/IPTVPlayer/components/recaptcha_mye2i_widget.py
@@ -4,15 +4,18 @@
 ###################################################
 # LOCAL import
 ###################################################
-from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, GetPyScriptCmd, getDebugMode, get_ip, is_port_in_use, eConnectCallback
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, rm, GetTmpDir, GetPyScriptCmd, getDebugMode, get_ip, is_port_in_use, eConnectCallback
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 from Plugins.Extensions.IPTVPlayer.components.captchascriptwidget import CaptchaScriptWidgetBase
+from Plugins.Extensions.IPTVPlayer.libs.web_qr import make_qr_png
 ###################################################
 
 ###################################################
 # FOREIGN import
 ###################################################
 from enigma import eConsoleAppContainer
+from Components.Pixmap import Pixmap
+from Tools.LoadPixmap import LoadPixmap
 
 from Plugins.Extensions.IPTVPlayer.p2p3.manipulateStrings import ensure_str, ensure_binary
 
@@ -24,6 +27,13 @@ import re
 import base64
 ###################################################
 
+# HD-reference width the QR pixmap strip adds next to the shared console box,
+# and the square QR pixmap's own size within that strip - kept equal to the
+# console's own height (see `_prepareSkin`'s HEIGHT - 142) so it lines up
+# with the console box instead of reaching down into the footer below it.
+_QR_STRIP_WIDTH = 220
+_QR_SIZE = 178
+
 
 class UnCaptchaReCaptchaMyE2iWidget(CaptchaScriptWidgetBase):
     # the chrome/skin building, eConsoleAppContainer wiring, and
@@ -31,14 +41,25 @@ class UnCaptchaReCaptchaMyE2iWidget(CaptchaScriptWidgetBase):
     # `UnCaptchaReCaptchaMyJDWidget` via `CaptchaScriptWidgetBase`. Only
     # the genuinely MyE2i-specific bits remain here:
     # `ip_address`/`port` bookkeeping, the exact `mye2iserver` command,
-    # and the regex-based JSON-substring extraction its script's log
-    # output actually needs (unlike MyJD's plain `byteify(json.loads())`).
+    # the regex-based JSON-substring extraction its script's log output
+    # actually needs (unlike MyJD's plain `byteify(json.loads())`), and a
+    # QR code of the local URL the script prints, so it can be scanned with
+    # a phone instead of typed in by hand.
     ACTION_CONTEXTS = ["ColorActions", "OkCancelActions"]
 
     def __init__(self, session, title, sitekey, referer, captchaType):
+        # scale="1" is required here - without it Enigma2 draws the loaded
+        # pixmap at its native size (see make_qr_png()'s own `scale` factor,
+        # much bigger than this box) instead of fitting it into the widget.
+        qrWidget = '<widget name="qrcode" position="%d,68" size="%d,%d" zPosition="2" scale="1" alphatest="blend" transparent="1" />' % (500 + (_QR_STRIP_WIDTH - _QR_SIZE) // 2, _QR_SIZE, _QR_SIZE)
+        self.skin = CaptchaScriptWidgetBase._prepareSkin(self, extraWidth=_QR_STRIP_WIDTH, extraBody=qrWidget)
         CaptchaScriptWidgetBase.__init__(self, session, title, sitekey, referer, captchaType)
+        self["qrcode"] = Pixmap()
+        self["qrcode"].hide()  # shown once startExecution() has an image to put in it
         self.ip_address = get_ip()
         self.port = 9001
+        self._qrPath = GetTmpDir("mye2i_web_access_qr.png")
+        self.onClose.append(self._removeQrFile)
 
     def _scriptFinishedMsg(self):
         return _('MyE2i script finished.')
@@ -51,6 +72,18 @@ class UnCaptchaReCaptchaMyE2iWidget(CaptchaScriptWidgetBase):
         if not matches:
             return None
         return json.loads(matches[0])
+
+    def _removeQrFile(self):
+        rm(self._qrPath)
+
+    def _scriptStderrAvail(self, data):
+        hadResult = bool(self.result)
+        CaptchaScriptWidgetBase._scriptStderrAvail(self, data)
+        if not hadResult and self.result:
+            # captcha just got solved - the QR code (and the file behind it)
+            # served its purpose, drop both instead of leaving them lying around.
+            self["qrcode"].hide()
+            self._removeQrFile()
 
     def startExecution(self):
         captcha = {'siteKey': self.sitekey, 'sameOrigin': True, 'siteUrl': self.referer, 'contextUrl': '/'.join(self.referer.split('/')[:3]), 'boundToDomain': True, 'stoken': None, 'captchaType': self.captchaType}
@@ -68,6 +101,17 @@ class UnCaptchaReCaptchaMyE2iWidget(CaptchaScriptWidgetBase):
             self.port += 1
 
         cmd = GetPyScriptCmd('mye2iserver') + ' "%s" "%s" "%s"' % (captcha, self.ip_address, self.port)
+
+        try:
+            # scale=10 -> a 370x370 native PNG, comfortably above the qrcode
+            # widget's box even at WQHD (_QR_SIZE=178 HD-reference * 2.0 =
+            # 356px there) so Enigma2's scale="1" only ever downscales it,
+            # never blows it up past its native resolution.
+            make_qr_png("http://%s:%s" % (self.ip_address, self.port), self._qrPath, scale=10, border=4)  # NOSONAR - LAN-only mye2iserver.py has no TLS support
+            self["qrcode"].instance.setPixmap(LoadPixmap(self._qrPath))
+            self["qrcode"].show()
+        except Exception:
+            printExc()
 
         self["console"].setText(_('Please Open site:\nhttp://{0}:{1}\nin a web browser with the MyE2i extension installed').format(self.ip_address, self.port))
 

--- a/IPTVPlayer/hosts/hostsevenreels.py
+++ b/IPTVPlayer/hosts/hostsevenreels.py
@@ -42,13 +42,9 @@ class SevenReels(GenericFolderWatchedScraperMixin, CBaseHostClass):
     # how to resolve show up as playable links. "tv" appends /<season>/<episode>.
     EMBEDS = (
         ('AdRock', 'https://vidrock.net/%(kind)s/%(id)s%(se)s'),
-        ('Strigil', 'https://strigil.cc/embed/%(kind)s/%(id)s%(se)s?embedKey=key_c90081fa77254eb5&autoPlay=true'),
-        ('VidSrc', 'https://vidsrc.mov/embed/%(kind)s/%(id)s%(se)s'),
         ('VidEasy', 'https://player.videasy.to/%(kind)s/%(id)s%(se)s?title=%(title)s&year=%(year)s'),
-        ('VidLink', 'https://vidlink.pro/%(kind)s/%(id)s%(se)s'),
         ('VidCore', 'https://vidcore.net/%(kind)s/%(id)s%(se)s'),
         ('VidNest', 'https://vidnest.fun/%(kind)s/%(id)s%(se)s'),
-        ('Vidzee', 'https://player.vidzee.wtf/embed/%(kind)s/%(id)s%(se)s'),
         ('VidUp', 'https://vidup.to/%(kind)s/%(id)s%(se)s'),
     )
 
@@ -141,10 +137,19 @@ class SevenReels(GenericFolderWatchedScraperMixin, CBaseHostClass):
             printExc()
             return
 
+        items = self._extractItems(parsed)
+        ids = [item.get('id') for item in items if item.get('id')]
+        if page > 1 and ids and ids == cItem.get('_prev_ids'):
+            # some 7reels endpoints never report total_pages and just keep
+            # re-serving the last real page once you page past the end of the
+            # list, instead of an empty one - stop here instead of showing
+            # (and re-offering "Next page" on) the same titles forever.
+            return
+
         defType = 'tv' if 'discover/tv' in cItem['url'] else 'movie'
         normalize = IsMediaNamingNormalized()
         count = 0
-        for item in self._extractItems(parsed):
+        for item in items:
             mediaId = item.get('id')
             title = self.cleanHtmlStr(item.get('title') or item.get('name') or '')
             if not mediaId or not title:
@@ -157,6 +162,7 @@ class SevenReels(GenericFolderWatchedScraperMixin, CBaseHostClass):
             dispTitle = ('%s (%s)' % (title, year)) if (year and (normalize or mediaType == 'movie')) else title
             params = dict(cItem)
             params.pop('page', None)
+            params.pop('_prev_ids', None)
             params.update({
                 'good_for_fav': True,
                 'category': 'video',
@@ -176,11 +182,12 @@ class SevenReels(GenericFolderWatchedScraperMixin, CBaseHostClass):
             count += 1
 
         totalPages = parsed.get('total_pages') or parsed.get('totalPages') or 0
-        if count and totalPages and page < totalPages:
+        hasMore = (page < totalPages) if totalPages else bool(count)
+        if count and hasMore:
             params = dict(cItem)
             params.pop('isWatched', None)
             params.pop('isStarted', None)
-            params.update({'good_for_fav': False, 'title': _('Next page'), 'page': page + 1, 'category': 'list_items'})
+            params.update({'good_for_fav': False, 'title': _('Next page'), 'page': page + 1, 'category': 'list_items', '_prev_ids': ids})
             self.addDir(params)
 
     def listSearchResult(self, cItem, searchPattern, searchType):

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -3343,7 +3343,9 @@ class pageParser(CaptchaHelper):
                 if label:
                     name += " %s" % label
                 if ".m3u8" in url.lower():
-                    urltab.extend(getDirectM3U8Playlist(decoUrl, sortWithMaxBitrate=99999999))
+                    for item in getDirectM3U8Playlist(decoUrl, sortWithMaxBitrate=99999999):
+                        item["name"] = ("%s %s" % (name, item.get("name", ""))).strip()
+                        urltab.append(item)
                 else:
                     urltab.append({"name": name, "url": decoUrl})
         return urltab
@@ -3411,7 +3413,9 @@ class pageParser(CaptchaHelper):
                     name += " %sp" % src["quality"]
                 decoUrl = urlparser.decorateUrl(url, {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": "https://peachify.top/", "Origin": "https://peachify.top"})
                 if ".m3u8" in url.lower():
-                    urltab.extend(getDirectM3U8Playlist(decoUrl, sortWithMaxBitrate=99999999))
+                    for item in getDirectM3U8Playlist(decoUrl, sortWithMaxBitrate=99999999):
+                        item["name"] = ("%s %s" % (name, item.get("name", ""))).strip()
+                        urltab.append(item)
                 else:
                     urltab.append({"name": name, "url": decoUrl})
         return urltab
@@ -3674,10 +3678,14 @@ class pageParser(CaptchaHelper):
             decoUrl = urlparser.decorateUrl(streamUrl, {"User-Agent": HTTP_HEADER["User-Agent"], "Referer": ref, "Origin": ref[:-1], "iptv_use_ffmpeg": True})
             if ".m3u8" in streamUrl:
                 for item in getDirectM3U8Playlist(decoUrl, sortWithMaxBitrate=99999999):
-                    item["name"] = "%s %s" % (label, item.get("name", ""))
+                    item["name"] = ("%s %s" % (label, item.get("name", ""))).strip()
                     urltab.append(item)
             else:
                 urltab.append({"name": label, "url": decoUrl})
+        # the "Euro" server has repeatedly been observed serving short ad clips
+        # instead of the real movie/episode - push it to the back so it isn't
+        # the first thing the user tries, without dropping it as a fallback.
+        urltab.sort(key=lambda item: 1 if "euro" in item.get("name", "").lower() else 0)
         return urltab
 
     def parserVIDSST(self, baseUrl):  # add 050926 - vids.st (premiumsmart.eu "VidsST" mirror), bespoke ArtPlayer host

--- a/IPTVPlayer/libs/urlparserhelper.py
+++ b/IPTVPlayer/libs/urlparserhelper.py
@@ -461,11 +461,10 @@ def getDirectM3U8Playlist(M3U8Url, checkExt=True, variantCheck=True, cookieParam
                         codecs.append(c.split('.')[0].strip())
                         item['codecs'] = ','.join(codecs)
                 except Exception:
-                    item['codecs'] = None
-                item['name'] = "bitrate: %s res: %dx%d %s" % (item['bitrate'],
-                                                              item['width'],
-                                                              item['height'],
-                                                              item['codecs'])
+                    item['codecs'] = ''
+                item['name'] = "bitrate: %s res: %dx%d" % (item['bitrate'], item['width'], item['height'])
+                if item['codecs']:
+                    item['name'] += ' ' + item['codecs']
                 try:
                     videoRange = playlist.stream_info.video_range
                     if videoRange and videoRange.upper() not in ('SDR', ''):

--- a/IPTVPlayer/libs/web_qr.py
+++ b/IPTVPlayer/libs/web_qr.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+###################################################
+# LOCAL import
+###################################################
+from Plugins.Extensions.IPTVPlayer.p2p3.manipulateStrings import ensure_binary
+###################################################
+
+###################################################
+# FOREIGN import
+###################################################
+import struct
+import zlib
+###################################################
+
+_SIZE = 29
+_DATA_CODEWORDS = 55
+_ECC_CODEWORDS = 15
+_MASK = 0
+
+
+def _gf_mul(x, y):
+    z = 0
+    while y:
+        if y & 1:
+            z ^= x
+        y >>= 1
+        x <<= 1
+        if x & 0x100:
+            x ^= 0x11D
+    return z
+
+
+def _rs_generator(degree):
+    gen = [1]
+    root = 1
+    for _ in range(degree):
+        out = [0] * (len(gen) + 1)
+        for i, coef in enumerate(gen):
+            out[i] ^= coef
+            out[i + 1] ^= _gf_mul(coef, root)
+        gen = out
+        root = _gf_mul(root, 2)
+    return gen
+
+
+_RS_GENERATOR = _rs_generator(_ECC_CODEWORDS)  # only ever used at this one fixed degree
+
+
+def _rs_remainder(data, degree):
+    gen = _RS_GENERATOR
+    rem = [0] * degree
+    for value in data:
+        factor = value ^ rem[0]
+        rem = rem[1:] + [0]
+        for i in range(degree):
+            rem[i] ^= _gf_mul(gen[i + 1], factor)
+    return rem
+
+
+def _append_bits(bits, value, length):
+    for i in range(length - 1, -1, -1):
+        bits.append((value >> i) & 1)
+
+
+def _codewords(text):
+    raw = ensure_binary(text)
+    if len(raw) > 53:
+        raise ValueError("text too long for QR v3-L (max 53 bytes, got %d)" % len(raw))
+
+    bits = []
+    _append_bits(bits, 0x4, 4)  # byte mode
+    _append_bits(bits, len(raw), 8)
+    for value in bytearray(raw):
+        _append_bits(bits, value, 8)
+    capacity = _DATA_CODEWORDS * 8
+    bits.extend([0] * min(4, capacity - len(bits)))
+    while len(bits) % 8:
+        bits.append(0)
+    data = []
+    for pos in range(0, len(bits), 8):
+        value = 0
+        for bit in bits[pos:pos + 8]:
+            value = (value << 1) | bit
+        data.append(value)
+    pads = (0xEC, 0x11)
+    n = 0
+    while len(data) < _DATA_CODEWORDS:
+        data.append(pads[n & 1])
+        n += 1
+    return data + _rs_remainder(data, _ECC_CODEWORDS)
+
+
+def _bch_digit(value):
+    digit = 0
+    while value:
+        digit += 1
+        value >>= 1
+    return digit
+
+
+def _format_bits():
+    # Error correction L is encoded as 01; mask 0.
+    g15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | 1
+    g15_mask = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1)
+    data = (1 << 3) | _MASK
+    value = data << 10
+    while _bch_digit(value) - _bch_digit(g15) >= 0:
+        value ^= g15 << (_bch_digit(value) - _bch_digit(g15))
+    return ((data << 10) | value) ^ g15_mask
+
+
+_FORMAT_BITS = _format_bits()  # ECC level and mask are both fixed, so this never changes
+
+
+def _matrix(text):
+    modules = [[None] * _SIZE for _ in range(_SIZE)]
+
+    def finder(row, col):
+        for rr in range(-1, 8):
+            y = row + rr
+            if y <= -1 or y >= _SIZE:
+                continue
+            for cc in range(-1, 8):
+                x = col + cc
+                if x <= -1 or x >= _SIZE:
+                    continue
+                dark = ((0 <= rr <= 6 and cc in (0, 6)) or
+                        (0 <= cc <= 6 and rr in (0, 6)) or
+                        (2 <= rr <= 4 and 2 <= cc <= 4))
+                modules[y][x] = dark
+
+    finder(0, 0)
+    finder(_SIZE - 7, 0)
+    finder(0, _SIZE - 7)
+
+    # Version 3 alignment centres are 6 and 22. Overlapping finder positions skip.
+    for row in (6, 22):
+        for col in (6, 22):
+            if modules[row][col] is not None:
+                continue
+            for rr in range(-2, 3):
+                for cc in range(-2, 3):
+                    modules[row + rr][col + cc] = (
+                        rr in (-2, 2) or cc in (-2, 2) or (rr == 0 and cc == 0)
+                    )
+
+    for row in range(8, _SIZE - 8):
+        if modules[row][6] is None:
+            modules[row][6] = (row % 2 == 0)
+    for col in range(8, _SIZE - 8):
+        if modules[6][col] is None:
+            modules[6][col] = (col % 2 == 0)
+
+    bits = _FORMAT_BITS
+    for i in range(15):
+        dark = ((bits >> i) & 1) == 1
+        if i < 6:
+            modules[i][8] = dark
+        elif i < 8:
+            modules[i + 1][8] = dark
+        else:
+            modules[_SIZE - 15 + i][8] = dark
+    for i in range(15):
+        dark = ((bits >> i) & 1) == 1
+        if i < 8:
+            modules[8][_SIZE - i - 1] = dark
+        elif i < 9:
+            modules[8][15 - i] = dark
+        else:
+            modules[8][14 - i] = dark
+    modules[_SIZE - 8][8] = True
+
+    data = _codewords(text)
+    inc = -1
+    row = _SIZE - 1
+    bit_index = 7
+    byte_index = 0
+    for original_col in range(_SIZE - 1, 0, -2):
+        col = original_col
+        if col <= 6:
+            col -= 1
+        while True:
+            for current_col in (col, col - 1):
+                if modules[row][current_col] is None:
+                    dark = False
+                    if byte_index < len(data):
+                        dark = ((data[byte_index] >> bit_index) & 1) == 1
+                    if (row + current_col) % 2 == 0:  # mask 0
+                        dark = not dark
+                    modules[row][current_col] = dark
+                    bit_index -= 1
+                    if bit_index == -1:
+                        byte_index += 1
+                        bit_index = 7
+            row += inc
+            if row < 0 or row >= _SIZE:
+                row -= inc
+                inc = -inc
+                break
+    return modules
+
+
+def _png_chunk(name, payload):
+    return struct.pack(">I", len(payload)) + name + payload + struct.pack(">I", zlib.crc32(name + payload) & 0xFFFFFFFF)
+
+
+def make_qr_png(text, path, scale=9, border=4):
+    matrix = _matrix(text)
+    width = (_SIZE + border * 2) * scale
+    rows = []
+    for y in range(-border, _SIZE + border):
+        line = bytearray()
+        for x in range(-border, _SIZE + border):
+            dark = 0 <= y < _SIZE and 0 <= x < _SIZE and bool(matrix[y][x])
+            value = 0 if dark else 255
+            line.extend([value] * scale)
+        raw = bytes(line)
+        for _ in range(scale):
+            rows.append(b"\x00" + raw)  # grayscale, filter 0
+    payload = b"".join(rows)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, width, 8, 0, 0, 0, 0))
+    png += _png_chunk(b"IDAT", zlib.compress(payload, 9))
+    png += _png_chunk(b"IEND", b"")
+
+    with open(path, "wb") as handle:
+        handle.write(png)
+    return path

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.11.01"
+IPTV_VERSION = "2026.09.12.01"


### PR DESCRIPTION
…dCore cleanup

MyE2i ReCaptcha/Cloudflare solver now shows a QR code of the local http://<ip>:<port> URL next to the console text, so it can be scanned with a phone instead of typed in by hand (new dependency-free QR v3-L PNG generator, libs/web_qr.py; CaptchaScriptWidgetBase gets a small _prepareSkin() extension hook instead of being forked, so the MyJD sibling widget is unaffected). Thanks to MOHAMED_OS, who brought this in.

hostsevenreels: dropped dead embeds (Strigil, VidSrc, VidLink, Vidzee) and made pagination keep going past a missing total_pages as long as new titles keep coming back - comparing each page's media ids against the previous page's to stop cleanly once the API starts re-serving the same page instead of returning an empty one. Thanks to alawa for these.

urlparser/urlparserhelper: getDirectM3U8Playlist() no longer leaves a literal "None" in a variant's name when codec parsing fails (fixed at the source instead of patched per caller); parserVIDNEST/parserPEACHIFY now label their m3u8 variants with the provider/server name like their siblings already do; parserVIDCORE's "Euro" server mirror (repeatedly serves ad clips instead of the real title) is sorted to the back instead of being dropped, so it's still usable as a fallback.