### PR TITLE
YouTube: InnerTube refresh - Google sign-in, signed-in feeds, subtitl…

### DIFF
--- a/IPTVPlayer/components/confighost.py
+++ b/IPTVPlayer/components/confighost.py
@@ -47,6 +47,36 @@ class ConfigHostMenu(ConfigBaseWidget):
         self.list = self.host.GetConfigList()
         ConfigBaseWidget.runSetup(self)
 
+    def keyOK(self):
+        # A host may expose an "action row" in its GetConfigList() - a config
+        # element carrying an `iptv_host_action` attribute - to run something
+        # interactive (a sign-in dialog, a device pairing) straight from its
+        # settings screen, which otherwise only edits plain config values.
+        # The host module then handles it in a module-level HandleConfigAction
+        # (session, action, callback) and calls the callback to have the list
+        # redrawn (e.g. a "Sign in" row becoming "Sign out").
+        try:
+            currItem = self["config"].getCurrent()[1]
+        except Exception:
+            printExc()
+            currItem = None
+        action = getattr(currItem, "iptv_host_action", "") if currItem is not None else ""
+        if action:
+            handler = getattr(self.host, "HandleConfigAction", None)
+            if callable(handler):
+                try:
+                    handler(self.session, action, boundFunction(self._afterConfigAction))
+                except Exception:
+                    printExc()
+                return
+        ConfigBaseWidget.keyOK(self)
+
+    def _afterConfigAction(self, *args):
+        try:
+            self.runSetup()
+        except Exception:
+            printExc()
+
     def changeSubOptions(self):
         try:
             if not isinstance(self["config"].getCurrent()[1], NumericalTextInput):

--- a/IPTVPlayer/hosts/hostmusicbox.py
+++ b/IPTVPlayer/hosts/hostmusicbox.py
@@ -57,7 +57,6 @@ class MusicBox(CBaseHostClass):
     def __init__(self):
         CBaseHostClass.__init__(self)
         self.youtube_api_key = ""
-        self.ytformats = config.plugins.iptvplayer.ytformat.value
         self.ytp = YouTubeParser()
         self.lastfm_username = config.plugins.iptvplayer.MusicBox_login.value
         self.usePremiumAccount = config.plugins.iptvplayer.MusicBox_premium.value

--- a/IPTVPlayer/hosts/hostyoutube.py
+++ b/IPTVPlayer/hosts/hostyoutube.py
@@ -9,12 +9,14 @@ from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, IsExecutable
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.tools.iptvfilehost import IPTVFileHost
 from Plugins.Extensions.IPTVPlayer.libs.youtubeparser import YouTubeParser
+from Plugins.Extensions.IPTVPlayer.libs.youtube_oauth import YouTubeOAuth
 from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote_plus
 from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, buildYoutubeOptions, decorateYoutubeUrl, decorateYoutubeLinkItems
 from Plugins.Extensions.IPTVPlayer.libs.youtubeuserlinks import YouTubeUserLinksManager
 from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
 from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhostmixin import WatchedFlagHostMixin
 from Plugins.Extensions.IPTVPlayer.components.iptvconfigmenu import IsSidecarEnabled
+from Plugins.Extensions.IPTVPlayer.components.asynccall import MainSessionWrapper, AsyncMethod, DelegateToMainThread
 
 ###################################################
 
@@ -52,12 +54,41 @@ config.plugins.iptvplayer.Sciezkaurllist = ConfigDirectory(default="/hdd/")
 config.plugins.iptvplayer.youtube_mkv_chapters = ConfigYesNo(default=True)
 config.plugins.iptvplayer.youtube_enigma2_cuts = ConfigYesNo(default=True)
 config.plugins.iptvplayer.youtube_download_channel_name = ConfigYesNo(default=True)
+# OK-only "action row" for the config screen (see HandleConfigAction); the
+# single choice is never really selected, the value carries no meaning.
+config.plugins.iptvplayer.youtube_account_action = ConfigSelection(default="fake", choices=[("fake", "  ")])
 config.plugins.iptvplayer.youtube_ui_language = ConfigSelection(
     default="system",
     choices=[
         ("system", _("System language")),
+        ("ar", "العربية (Arabic)"),
+        ("bg", "Български (Bulgarian)"),
+        ("cs", "Čeština (Czech)"),
+        ("da", "Dansk (Danish)"),
         ("de", _("German")),
+        ("el", "Ελληνικά (Greek)"),
         ("en", _("English")),
+        ("es", "Español (Spanish)"),
+        ("fi", "Suomi (Finnish)"),
+        ("fr", "Français (French)"),
+        ("he", "עברית (Hebrew)"),
+        ("hr", "Hrvatski (Croatian)"),
+        ("hu", "Magyar (Hungarian)"),
+        ("it", "Italiano (Italian)"),
+        ("ja", "日本語 (Japanese)"),
+        ("ko", "한국어 (Korean)"),
+        ("nl", "Nederlands (Dutch)"),
+        ("no", "Norsk (Norwegian)"),
+        ("pl", "Polski (Polish)"),
+        ("pt", "Português (Portuguese)"),
+        ("ro", "Română (Romanian)"),
+        ("ru", "Русский (Russian)"),
+        ("sk", "Slovenčina (Slovak)"),
+        ("sr", "Српски (Serbian)"),
+        ("sv", "Svenska (Swedish)"),
+        ("tr", "Türkçe (Turkish)"),
+        ("uk", "Українська (Ukrainian)"),
+        ("zh", "中文 (Chinese)"),
     ],
 )
 
@@ -74,14 +105,86 @@ except NameError:
     PY2 = False
 
 
+def HandleConfigAction(session, action, callback=None):
+    # Called by components/confighost.py when the OK-only account row in
+    # GetConfigList() is selected. The device-code sign-in shows a dialog and
+    # then polls Google, which blocks - so it runs on a worker thread and
+    # drives the UI through MainSessionWrapper, exactly like the host thread
+    # does for the same flow from the browse menu.
+    def _finish(*args):
+        # DelegateToMainThread always calls the wrapped function with the
+        # session as its first positional arg (see asynccall.py's
+        # CPQItemDelegate/processQueue); the synchronous logout path below
+        # calls this with no args at all - accept and ignore either.
+        if callable(callback):
+            try:
+                callback()
+            except Exception:
+                printExc()
+
+    if action == "youtube_account_logout":
+        # Runs synchronously on the main thread (called straight from
+        # keyOK()), unlike login below - MainSessionWrapper is only for
+        # delegating from a worker thread and raises BaseException if used
+        # here, so the session passed in is opened directly instead.
+        try:
+            YouTubeOAuth.logout()
+            session.open(MessageBox, _("Signed out of YouTube."), type=MessageBox.TYPE_INFO, timeout=5)
+        except Exception:
+            printExc()
+        _finish()
+        return
+
+    if action == "youtube_account_login":
+        def _worker():
+            try:
+                sessionEx = MainSessionWrapper()
+                oauth = YouTubeOAuth()
+                dc = oauth.requestDeviceCode()
+                if not dc.get("user_code"):
+                    sessionEx.open(MessageBox, _("Could not start the YouTube sign-in."), type=MessageBox.TYPE_ERROR, timeout=8)
+                    return
+                msg = _("To sign in to YouTube:\n\n1. On a phone or computer open:\n     %s\n\n2. Enter this code:\n\n     %s\n\n3. Approve the access, then select OK here.") % (dc["verification_url"], dc["user_code"])
+                ret = sessionEx.waitForFinishOpen(MessageBox, msg, type=MessageBox.TYPE_YESNO, default=True)
+                if not (ret and ret[0]):
+                    return
+                ok = oauth.pollForToken(dc["device_code"], dc["interval"], dc["expires_in"])
+                sessionEx.open(MessageBox, _("Signed in to YouTube.") if ok else _("Sign-in was not completed."),
+                               type=MessageBox.TYPE_INFO if ok else MessageBox.TYPE_ERROR, timeout=6)
+            except Exception:
+                printExc()
+            finally:
+                # _finish() ends up calling confighost.py's _afterConfigAction,
+                # which redraws the config-list widget - like every other GUI
+                # touch in this worker, that must run on the main thread, not
+                # here (same reasoning as MainSessionWrapper above).
+                DelegateToMainThread(_finish)()
+
+        # Must run via AsyncMethod, not a bare threading.Thread: pCommon's
+        # curl path calls asynccall.SetThreadKillable()/IsThreadTerminated(),
+        # which need thread._iptvplayer_ext - only AsyncCall.__call__ sets
+        # that on the thread it spawns. Without it every getPage() call on
+        # this thread silently fails (sts=False), which is what made the
+        # device-code request look like it "could not start".
+        AsyncMethod(_worker)()
+        return
+
+
 def GetConfigList():
     optionList = []
+    if YouTubeOAuth.isLoggedIn():
+        entry = getConfigListEntry(_("Google account") + ":  " + _("signed in") + "  (" + _("select to sign out") + ")", config.plugins.iptvplayer.youtube_account_action)
+        entry[1].iptv_host_action = "youtube_account_logout"
+    else:
+        entry = getConfigListEntry(_("Google account") + ":  " + _("sign in (subscriptions, playlists, age-restricted videos)"), config.plugins.iptvplayer.youtube_account_action)
+        entry[1].iptv_host_action = "youtube_account_login"
+    optionList.append(entry)
     optionList.append(getConfigListEntry(_("Sort by:"), config.plugins.iptvplayer.ytSortBy))
+    optionList.append(getConfigListEntry(_("Search results region:"), config.plugins.iptvplayer.youtube_search_region))
+    optionList.append(getConfigListEntry(_("Safe search (restricted mode):"), config.plugins.iptvplayer.youtube_safe_search))
     optionList.append(getConfigListEntry(_("Path to ytlist.txt, urllist.txt"), config.plugins.iptvplayer.Sciezkaurllist))
-    optionList.append(getConfigListEntry(_("Video format:"), config.plugins.iptvplayer.ytformat))
     optionList.append(getConfigListEntry(_("Default video quality:"), config.plugins.iptvplayer.ytDefaultformat))
     optionList.append(getConfigListEntry(_("Use default video quality:"), config.plugins.iptvplayer.ytUseDF))
-    optionList.append(getConfigListEntry(_("Age-gate bypass:"), config.plugins.iptvplayer.ytAgeGate))
     optionList.append(getConfigListEntry(_("Display language:"), config.plugins.iptvplayer.youtube_ui_language))
     optionList.append(getConfigListEntry(_("Add channel name to downloaded file") + ":", config.plugins.iptvplayer.youtube_download_channel_name))
     optionList.append(getConfigListEntry(_("Create MKV with chapter marks from description") + ":", config.plugins.iptvplayer.youtube_mkv_chapters))
@@ -318,30 +421,16 @@ class Youtube(CBaseHostClass):
             printExc()
 
         try:
-            channel = item.get("channel", "")
+            channel = self._cleanChannelCandidate(item.get("channel", ""), invalidTitles)
             if channel:
-                if isinstance(channel, str):
-                    try:
-                        channel = channel.decode("utf-8")
-                    except Exception:
-                        pass
-                channel = channel.strip()
-                if channel and channel not in invalidTitles:
-                    return channel
+                return channel
         except Exception:
             printExc()
 
         try:
-            channel = defaultChannel or ""
+            channel = self._cleanChannelCandidate(defaultChannel or "", invalidTitles)
             if channel:
-                if isinstance(channel, str):
-                    try:
-                        channel = channel.decode("utf-8")
-                    except Exception:
-                        pass
-                channel = channel.strip()
-                if channel and channel not in invalidTitles:
-                    return channel
+                return channel
         except Exception:
             printExc()
 
@@ -362,6 +451,20 @@ class Youtube(CBaseHostClass):
             printExc()
 
         return ""
+
+    def _cleanChannelCandidate(self, value, invalidTitles):
+        # value may be a PY2 byte-string that needs decoding to text; on PY3
+        # str has no .decode() so this quietly no-ops (AttributeError caught)
+        # - same dance the title/desc checks around this do.
+        if not value:
+            return ""
+        if isinstance(value, str):
+            try:
+                value = value.decode("utf-8")
+            except Exception:
+                pass
+        value = value.strip()
+        return value if (value and value not in invalidTitles) else ""
 
     def _injectChannelNameToItem(self, item, defaultChannel=""):
         try:
@@ -506,10 +609,50 @@ class Youtube(CBaseHostClass):
 
     def listMainMenu(self):
         printDBG("Youtube.listsMainMenu")
-        for item in self.MAIN_GROUPED_TAB:
+        tab = list(self.MAIN_GROUPED_TAB)
+        # Signing in / out lives in the host configuration screen now
+        # (GetConfigList / HandleConfigAction), not in this browse list.
+        if YouTubeOAuth.isLoggedIn():
+            tab += [
+                {"category": "auth_feed", "feed": "subscriptions", "title": _("My subscriptions"), "desc": _("Latest videos from the channels you are subscribed to.")},
+                {"category": "auth_feed", "feed": "watch_later", "title": _("Watch later"), "desc": _("Your 'Watch later' playlist.")},
+                {"category": "auth_feed", "feed": "liked", "title": _("Liked videos"), "desc": _("Videos you have liked.")},
+                {"category": "auth_feed", "feed": "history", "title": _("Watch history"), "desc": _("Videos you have recently watched.")},
+            ]
+        for item in tab:
             params = {"name": "category"}
             params.update(item)
             self.addDir(params)
+
+    def listAuthFeed(self, cItem):
+        printDBG("Youtube.listAuthFeed [%s]" % cItem)
+        feed = cItem.get("feed", "")
+        page = cItem.get("page", "1")
+        # The signed-in feeds only answer to the TVHTML5 InnerTube client, which
+        # returns the living-room "tile" layout - getTvFeed() walks that.
+        browseId = {"subscriptions": "FEsubscriptions",
+                    "watch_later": "VLWL",
+                    "liked": "VLLL",
+                    "history": "FEhistory"}.get(feed, "")
+        if not browseId:
+            return
+        tmp = self.ytp.getTvFeed(browseId, page, cItem)
+        if not tmp:
+            self.addDir({"name": "category", "category": "no_feed", "title": _("(nothing here yet)"),
+                         "desc": _("This feed is empty, or the YouTube sign-in has expired - sign out and in again.")})
+            return
+        self._injectChannelNameToItems(tmp, cItem.get("channel_title", ""))
+        self.watchedHelper.updateHostListFlags(self, tmp, self._getWatchedKeyForItem)
+        for item in tmp:
+            item.update({"name": "category"})
+            if item.get("type", "") == "more":
+                item.update({"category": "auth_feed", "feed": feed, "title": _("Next page")})
+                self.addMore(item)
+            elif item.get("type", "") == "video":
+                self.addVideo(item)
+            else:
+                self.addDir(item)
+
 
     def listCategory(self, cItem, searchMode=False):
         printDBG("Youtube.listCategory cItem[%s]" % cItem)
@@ -583,73 +726,78 @@ class Youtube(CBaseHostClass):
     def listFeeds(self, cItem):
         printDBG("Youtube.listFeeds cItem[%s]" % cItem)
 
-        category = cItem.get("category", "")
-        page = cItem.get("page", "1")
-        url = cItem.get("url", "")
-
-        if category == "feeds_video":
-            pattern = cItem.get("pattern", "")
-            search_type = cItem.get("search_type", "")
-
-            # A New Approach: Search-Based Feeds with Pagination
-            if pattern != "":
-                tmpList = self.ytp.getSearchResult(urllib_quote_plus(pattern), search_type if search_type else "video", page, "search_next_page", config.plugins.iptvplayer.ytSortBy.value, url)
-
-                currentChannel = cItem.get("channel", "")
-                currentContextTitle = cItem.get("context_title", "")
-
-                for item in tmpList:
-                    item.update({"name": "category"})
-
-                    if item.get("type", "") == "video":
-                        if currentChannel and not item.get("channel", ""):
-                            item["channel"] = currentChannel
-                        elif currentContextTitle and not item.get("context_title", ""):
-                            item["context_title"] = currentContextTitle
-                        self._injectChannelNameToItem(item)
-                        self.addVideo(item)
-                    elif item.get("type", "") == "more":
-                        item.update(
-                            {
-                                "title": _("Next page"),
-                                "image_type": "NEXT",
-                                "category": "feeds_video",
-                                "pattern": pattern,
-                                "search_type": search_type if search_type else "video",
-                            }
-                        )
-                        if currentChannel:
-                            item["channel"] = currentChannel
-                        if currentContextTitle:
-                            item["context_title"] = currentContextTitle
-                        self.addMore(item)
-                    else:
-                        if currentChannel and not item.get("channel", ""):
-                            item["channel"] = currentChannel
-                        elif currentContextTitle and not item.get("context_title", ""):
-                            item["context_title"] = currentContextTitle
-                        if item.get("category", "") in ["channel", "playlist", "movie", "traylist"]:
-                            item["good_for_fav"] = True
-                        self.addDir(item)
-                return
-
-            # Legacy approach: retain existing behavior for fixed URLs
-            sts, data = self.cm.getPage(cItem["url"])
-            data2 = self.cm.ph.getAllItemsBeetwenMarkers(data, "videoRenderer", "watchEndpoint")
-            for item in data2:
-                url = "https://www.youtube.com/watch?v=" + self.cm.ph.getDataBeetwenMarkers(item, 'videoId":"', '","thumbnail":', False)[1]
-                icon = self.cm.ph.getDataBeetwenMarkers(item, '},{"url":"', "==", False)[1]
-                title = self.cm.ph.getDataBeetwenMarkers(item, '"title":{"runs":[{"text":"', '"}]', False)[1]
-                desc = E2ColoR("yellow") + _("Channel") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, 'longBylineText":{"runs":[{"text":"', '","navigationEndpoint"', False)[1] + "\n"
-                desc += E2ColoR("yellow") + _("Release") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"publishedTimeText":{"simpleText":"', '"},"lengthText":', False)[1] + "\n"
-                desc += E2ColoR("yellow") + _("Duration") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"lengthText":{"accessibility":{"accessibilityData":{"label":"', '"}},"simpleText":', False)[1] + "\n"
-                desc += E2ColoR("yellow") + _("Views") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"viewCountText":{"simpleText":"', '"},"navigationEndpoint":', False)[1]
-                params = {"title": title, "url": url, "icon": icon, "desc": desc, "video_id": self._extractVideoId(url)}
-                self._injectChannelNameToItem(params)
-                self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
-                self.addVideo(params)
+        if cItem.get("category", "") == "feeds_video":
+            if cItem.get("pattern", "") != "":
+                self._listSearchBasedFeed(cItem)
+            else:
+                self._listLegacyFeedUrl(cItem)
             return
 
+        self._listFeedCategories()
+
+    def _listSearchBasedFeed(self, cItem):
+        # A New Approach: Search-Based Feeds with Pagination
+        pattern = cItem.get("pattern", "")
+        page = cItem.get("page", "1")
+        url = cItem.get("url", "")
+        search_type = cItem.get("search_type", "")
+        tmpList = self.ytp.getSearchResult(urllib_quote_plus(pattern), search_type if search_type else "video", page, "search_next_page", config.plugins.iptvplayer.ytSortBy.value, url)
+
+        currentChannel = cItem.get("channel", "")
+        currentContextTitle = cItem.get("context_title", "")
+
+        for item in tmpList:
+            item.update({"name": "category"})
+
+            if item.get("type", "") == "video":
+                if currentChannel and not item.get("channel", ""):
+                    item["channel"] = currentChannel
+                elif currentContextTitle and not item.get("context_title", ""):
+                    item["context_title"] = currentContextTitle
+                self._injectChannelNameToItem(item)
+                self.addVideo(item)
+            elif item.get("type", "") == "more":
+                item.update(
+                    {
+                        "title": _("Next page"),
+                        "image_type": "NEXT",
+                        "category": "feeds_video",
+                        "pattern": pattern,
+                        "search_type": search_type if search_type else "video",
+                    }
+                )
+                if currentChannel:
+                    item["channel"] = currentChannel
+                if currentContextTitle:
+                    item["context_title"] = currentContextTitle
+                self.addMore(item)
+            else:
+                if currentChannel and not item.get("channel", ""):
+                    item["channel"] = currentChannel
+                elif currentContextTitle and not item.get("context_title", ""):
+                    item["context_title"] = currentContextTitle
+                if item.get("category", "") in ["channel", "playlist", "movie", "traylist"]:
+                    item["good_for_fav"] = True
+                self.addDir(item)
+
+    def _listLegacyFeedUrl(self, cItem):
+        # Legacy approach: retain existing behavior for fixed URLs
+        sts, data = self.cm.getPage(cItem["url"])
+        data2 = self.cm.ph.getAllItemsBeetwenMarkers(data, "videoRenderer", "watchEndpoint")
+        for item in data2:
+            url = "https://www.youtube.com/watch?v=" + self.cm.ph.getDataBeetwenMarkers(item, 'videoId":"', '","thumbnail":', False)[1]
+            icon = self.cm.ph.getDataBeetwenMarkers(item, '},{"url":"', "==", False)[1]
+            title = self.cm.ph.getDataBeetwenMarkers(item, '"title":{"runs":[{"text":"', '"}]', False)[1]
+            desc = E2ColoR("yellow") + _("Channel") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, 'longBylineText":{"runs":[{"text":"', '","navigationEndpoint"', False)[1] + "\n"
+            desc += E2ColoR("yellow") + _("Release") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"publishedTimeText":{"simpleText":"', '"},"lengthText":', False)[1] + "\n"
+            desc += E2ColoR("yellow") + _("Duration") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"lengthText":{"accessibility":{"accessibilityData":{"label":"', '"}},"simpleText":', False)[1] + "\n"
+            desc += E2ColoR("yellow") + _("Views") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"viewCountText":{"simpleText":"', '"},"navigationEndpoint":', False)[1]
+            params = {"title": title, "url": url, "icon": icon, "desc": desc, "video_id": self._extractVideoId(url)}
+            self._injectChannelNameToItem(params)
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
+            self.addVideo(params)
+
+    def _listFeedCategories(self):
         feeds = [
             (_("Movies"), "movies", "video"),
             (_("Music"), "music", "video"),
@@ -795,66 +943,66 @@ class Youtube(CBaseHostClass):
                 return text
 
             releaseLine = _("Release") + ": " + absolutePublished
-
-            releaseLabels = [
-                _("Release"),
-                _("Published"),
-                _("Streamed"),
-                "Release",
-                "Published",
-                "Streamed",
-                "Veröffentlicht",
-                "Premiere",
-                "Live",
-            ]
-
-            relPattern = re.compile(r"(" r"\b\d+\s+(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)\s+ago\b|" r"\bvor\s+\d+\s+(sekunde|sekunden|minute|minuten|stunde|stunden|tag|tage|woche|wochen|monat|monate|jahr|jahre)\b|" r"\b\d+\s+(sekunde|sekunden|minute|minuten|stunde|stunden|tag|tage|woche|wochen|monat|monate|jahr|jahre)\s+zuvor\b" r")", re.IGNORECASE)
-            streamedPattern = re.compile(r"\b(gestreamt|streamed|live übertragen|streamed live)\b", re.IGNORECASE)
-
-            lines = text.split("\n")
-            out = []
-            replaced = False
-
-            for line in lines:
-                originalLine = line
-                stripped = originalLine.strip()
-
-                if not stripped or replaced:
-                    out.append(originalLine)
-                    continue
-
-                shouldReplace = False
-
-                for label in releaseLabels:
-                    if not label:
-                        continue
-
-                    pattern = r"^.*?\b%s\b\s*:\s*[^\n\r]*$" % re.escape(label)
-                    if re.search(pattern, originalLine, re.IGNORECASE):
-                        shouldReplace = True
-                        printDBG("Youtube._replacePublishedLineInDesc exact label replaced")
-                        break
-
-                if not shouldReplace and (relPattern.search(originalLine) or streamedPattern.search(originalLine)):
-                    shouldReplace = True
-                    printDBG("Youtube._replacePublishedLineInDesc relative-time line replaced")
-
-                if shouldReplace:
-                    out.append(releaseLine)
-                    replaced = True
-                else:
-                    out.append(originalLine)
-
-            if not replaced:
-                out.insert(0, releaseLine)
-                printDBG("Youtube._replacePublishedLineInDesc release line inserted")
-
+            out = self._replaceOrInsertReleaseLine(text.split("\n"), releaseLine)
             return "\n".join(out)
 
         except Exception:
             printExc()
 
         return text
+
+    def _replaceOrInsertReleaseLine(self, lines, releaseLine):
+        # Swaps the first line that looks like a "published"/"streamed"
+        # line for releaseLine; if none of the lines qualify, releaseLine
+        # is inserted at the top instead.
+        releaseLabels = [
+            _("Release"),
+            _("Published"),
+            _("Streamed"),
+            "Release",
+            "Published",
+            "Streamed",
+            "Veröffentlicht",
+            "Premiere",
+            "Live",
+        ]
+        relPattern = re.compile(r"(" r"\b\d+\s+(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)\s+ago\b|" r"\bvor\s+\d+\s+(sekunde|sekunden|minute|minuten|stunde|stunden|tag|tage|woche|wochen|monat|monate|jahr|jahre)\b|" r"\b\d+\s+(sekunde|sekunden|minute|minuten|stunde|stunden|tag|tage|woche|wochen|monat|monate|jahr|jahre)\s+zuvor\b" r")", re.IGNORECASE)
+        streamedPattern = re.compile(r"\b(gestreamt|streamed|live übertragen|streamed live)\b", re.IGNORECASE)
+
+        out = []
+        replaced = False
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or replaced:
+                out.append(line)
+                continue
+
+            if self._looksLikePublishedLine(line, releaseLabels, relPattern, streamedPattern):
+                out.append(releaseLine)
+                replaced = True
+            else:
+                out.append(line)
+
+        if not replaced:
+            out.insert(0, releaseLine)
+            printDBG("Youtube._replacePublishedLineInDesc release line inserted")
+
+        return out
+
+    def _looksLikePublishedLine(self, line, releaseLabels, relPattern, streamedPattern):
+        for label in releaseLabels:
+            if not label:
+                continue
+            pattern = r"^.*?\b%s\b\s*:\s*[^\n\r]*$" % re.escape(label)
+            if re.search(pattern, line, re.IGNORECASE):
+                printDBG("Youtube._replacePublishedLineInDesc exact label replaced")
+                return True
+
+        if relPattern.search(line) or streamedPattern.search(line):
+            printDBG("Youtube._replacePublishedLineInDesc relative-time line replaced")
+            return True
+
+        return False
 
     def _normalizePublishedDate(self, value):
         try:
@@ -871,61 +1019,18 @@ class Youtube(CBaseHostClass):
         try:
             title = str(cItem.get("title", "") or "")
             shortText = str(self._getYouTubeInfoText(cItem) or "")
-            text = shortText
             icon = str(cItem.get("icon", "") or "")
             videoId = self._getVideoIdFromItem(cItem)
-            absolutePublished = ""
-            channelName = ""
+            channelName = self._getInitialChannelName(cItem)
 
-            if cItem.get("channel", ""):
-                channelName = cItem.get("channel", "")
-            elif cItem.get("channel_title", ""):
-                channelName = cItem.get("channel_title", "")
-            elif cItem.get("context_title", ""):
-                channelName = cItem.get("context_title", "")
-
-            if videoId:
-                try:
-                    watchData = self.ytp._getWatchPageData(videoId)
-                    fullText = str(watchData.get("fullDescription", "") or "")
-                    absolutePublished = self._normalizePublishedDate(watchData.get("absolutePublished", ""))
-                    parserChannelName = str(watchData.get("channelName", "") or "")
-
-                    if not channelName and parserChannelName:
-                        channelName = parserChannelName
-
-                    if absolutePublished:
-                        printDBG("Youtube.getArticleContent absolutePublished[%s]" % absolutePublished)
-                        shortText = self._replacePublishedLineInDesc(shortText, absolutePublished)
-                        text = shortText
-
-                    if fullText:
-                        printDBG("Youtube.getArticleContent fullText FOUND len[%s]" % len(fullText))
-                        if shortText:
-                            text = shortText + "\n\n" + fullText
-                        else:
-                            text = fullText
-                    else:
-                        printDBG("Youtube.getArticleContent fullText EMPTY")
-                except Exception:
-                    printDBG("Youtube.getArticleContent _getWatchPageData EXCEPTION")
-                    printExc()
+            channelName, absolutePublished, text = self._enrichArticleFromWatchPage(videoId, channelName, shortText)
 
             channelName = str(channelName or "")
             text = str(text or "")
             if channelName:
                 text = channelName + "\n" + text
 
-            richDescParams = {}
-            if absolutePublished:
-                richDescParams["published"] = absolutePublished
-            elif cItem.get("time", ""):
-                richDescParams["published"] = self._normalizePublishedDate(cItem.get("time", ""))
-
-            if videoId:
-                richDescParams["videoid"] = str(videoId or "")
-            if channelName:
-                richDescParams["channel_name"] = channelName
+            richDescParams = self._buildArticleRichDescParams(absolutePublished, cItem, videoId, channelName)
 
             images = []
             if icon:
@@ -938,6 +1043,65 @@ class Youtube(CBaseHostClass):
             printExc()
 
         return retTab
+
+    def _getInitialChannelName(self, cItem):
+        if cItem.get("channel", ""):
+            return cItem.get("channel", "")
+        if cItem.get("channel_title", ""):
+            return cItem.get("channel_title", "")
+        if cItem.get("context_title", ""):
+            return cItem.get("context_title", "")
+        return ""
+
+    def _enrichArticleFromWatchPage(self, videoId, channelName, shortText):
+        # Returns (channelName, absolutePublished, text): text starts as
+        # shortText and gets the release line patched in / the full
+        # description appended once the watch page data comes back.
+        text = shortText
+        absolutePublished = ""
+        if not videoId:
+            return channelName, absolutePublished, text
+
+        try:
+            watchData = self.ytp._getWatchPageData(videoId)
+            fullText = str(watchData.get("fullDescription", "") or "")
+            absolutePublished = self._normalizePublishedDate(watchData.get("absolutePublished", ""))
+            parserChannelName = str(watchData.get("channelName", "") or "")
+
+            if not channelName and parserChannelName:
+                channelName = parserChannelName
+
+            if absolutePublished:
+                printDBG("Youtube.getArticleContent absolutePublished[%s]" % absolutePublished)
+                shortText = self._replacePublishedLineInDesc(shortText, absolutePublished)
+                text = shortText
+
+            if fullText:
+                printDBG("Youtube.getArticleContent fullText FOUND len[%s]" % len(fullText))
+                if shortText:
+                    text = shortText + "\n\n" + fullText
+                else:
+                    text = fullText
+            else:
+                printDBG("Youtube.getArticleContent fullText EMPTY")
+        except Exception:
+            printDBG("Youtube.getArticleContent _getWatchPageData EXCEPTION")
+            printExc()
+
+        return channelName, absolutePublished, text
+
+    def _buildArticleRichDescParams(self, absolutePublished, cItem, videoId, channelName):
+        richDescParams = {}
+        if absolutePublished:
+            richDescParams["published"] = absolutePublished
+        elif cItem.get("time", ""):
+            richDescParams["published"] = self._normalizePublishedDate(cItem.get("time", ""))
+
+        if videoId:
+            richDescParams["videoid"] = str(videoId or "")
+        if channelName:
+            richDescParams["channel_name"] = channelName
+        return richDescParams
 
     def getFavouriteData(self, cItem):
         printDBG("Youtube.getFavouriteData")
@@ -975,6 +1139,10 @@ class Youtube(CBaseHostClass):
         self.currList = []
 
         if None is name:
+            self.listMainMenu()
+        elif "auth_feed" == category:
+            self.listAuthFeed(self.currItem)
+        elif "no_feed" == category:
             self.listMainMenu()
         elif "from_file" == category:
             self.listCategory(self.currItem)

--- a/IPTVPlayer/iptvdm/ffmpegdownloader.py
+++ b/IPTVPlayer/iptvdm/ffmpegdownloader.py
@@ -32,6 +32,7 @@ from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, ip
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.iptvdm.basedownloader import BaseDownloader
 from Plugins.Extensions.IPTVPlayer.iptvdm.iptvdh import DMHelper
+from Plugins.Extensions.IPTVPlayer.iptvdm.downloaderhelpers import SidecarMixin
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 ###################################################
 from Plugins.Extensions.IPTVPlayer.p2p3.manipulateStrings import strDecode
@@ -50,7 +51,7 @@ import datetime
 ###################################################
 
 
-class FFMPEGDownloader(BaseDownloader):
+class FFMPEGDownloader(BaseDownloader, SidecarMixin):
 
     # a download counts as complete once this fraction of the known duration is
     # reached - ffmpeg's segment-summed duration and its final time= often differ
@@ -75,6 +76,7 @@ class FFMPEGDownloader(BaseDownloader):
         # instance of E2 console
         self.console = None
         self.iptv_sys = None
+        self._initSidecarState()
         self.totalDuration = 0
         self.downloadDuration = 0
         self.liveStream = False
@@ -130,6 +132,7 @@ class FFMPEGDownloader(BaseDownloader):
 
         cmdTab = [DMHelper.GET_FFMPEG_PATH(), '-y']
         tmpUri = strwithmeta(url)
+        self._prepareSidecarData(tmpUri.meta)
 
         if 'iptv_video_rep_idx' in tmpUri.meta:
             cmdTab.extend(['-video_rep_index', str(tmpUri.meta['iptv_video_rep_idx'])])
@@ -295,6 +298,7 @@ class FFMPEGDownloader(BaseDownloader):
 
     def _terminate(self):
         printDBG("FFMPEGDownloader._terminate")
+        self._terminateSidecar()
         if None is not self.iptv_sys:
             self.iptv_sys.kill()
             self.iptv_sys = None
@@ -337,7 +341,23 @@ class FFMPEGDownloader(BaseDownloader):
             # ffmpeg has stopped writing -> name the file after its real container,
             # even for a partial (an incomplete .mkv is still an .mkv)
             self._fixFileExtension()
+            # sidecar (.txt/.jpg) only for a real, complete DM download -
+            # allowFinalRename is unset for buffered playback, which must not
+            # wait on an image download before the player can proceed
+            if self.allowFinalRename and self.sidecarEnabled and DMHelper.STS.DOWNLOADED == self.status:
+                self._writeTxtSidecar(self.filePath)
+                if self.sidecarImg:
+                    self._startImgSidecarDownload(self.filePath)
+                    return
+                self._finishDownloadFlow()
+                return
             self.onFinish()
+
+    def _cleanUp(self):
+        # required by SidecarMixin._finishDownloadFlow(); the .iptv.cmd temp
+        # file is already removed at the top of _cmdFinished, nothing else
+        # to do here
+        pass
 
     def _outContainer(self):
         # the container passed to ffmpeg's -f; it also drives the final file

--- a/IPTVPlayer/iptvdm/iptvdmapi.py
+++ b/IPTVPlayer/iptvdm/iptvdmapi.py
@@ -355,7 +355,7 @@ class IPTVDMApi():
         self.queueUD[listUDIdx].originalFileName = item.fileName
 
         url, downloaderParams = DMHelper.getDownloaderParamFromUrl(item.url)
-        self.queueUD[listUDIdx].downloader = DownloaderCreator(url)
+        self.queueUD[listUDIdx].downloader = DownloaderCreator(url, forDownload=True)
         # this is a real download (not buffered playback) -> the downloader may
         # rename the finished file to its true container extension
         try:

--- a/IPTVPlayer/iptvdm/iptvdownloadercreator.py
+++ b/IPTVPlayer/iptvdm/iptvdownloadercreator.py
@@ -51,7 +51,7 @@ def IsHlsLikeUrl(url):
     return False
 
 
-def DownloaderCreator(url):
+def DownloaderCreator(url, forDownload=False):
     printDBG("DownloaderCreator url[%r]" % url)
     downloader = None
     downloaderParams = {}
@@ -114,8 +114,55 @@ def DownloaderCreator(url):
         useFFmpeg = False
 
     printDBG("DownloaderCreator url[%s]" % url)
-    printDBG("DownloaderCreator iptv_proto[%s] iptv_use_ffmpeg[%s] iptv_ffmpeg_case[%s]" % (proto, useFFmpeg, ffmpegCase))
+    printDBG("DownloaderCreator iptv_proto[%s] iptv_use_ffmpeg[%s] iptv_ffmpeg_case[%s] forDownload[%s]" % (proto, useFFmpeg, ffmpegCase, forDownload))
     printDBG("DownloaderCreator downloaderParams[%s]" % downloaderParams)
+
+    #################################################
+    # merge:// with HLS/DASH components (separate
+    # audio+video renditions, e.g. Arte CMAF, Apple
+    # bipbop) must be muxed with ffmpeg regardless of
+    # caller. HLSDownloader's "-a" alt-audio path only
+    # naively interleaves TS packets and yields an
+    # unplayable file for fMP4, and MergeDownloader wgets
+    # each component whole (fine for progressive URLs,
+    # wrong for .m3u8/.mpd playlists).
+    #################################################
+    mergeNeedsFFmpeg = False
+    try:
+        if isinstance(url, str) and url.startswith('merge://'):
+            compUrls = []
+            try:
+                for key in url.split('merge://', 1)[1].split('|'):
+                    compUrls.append(str(urlMeta.get(key, key)))
+            except Exception:
+                printExc()
+            mergeNeedsFFmpeg = any((IsHlsLikeUrl(u) or '.mpd' in u.lower()) for u in compUrls)
+    except Exception:
+        printExc()
+
+    #################################################
+    # A real Download Manager download of a YouTube merge://
+    # (progressive audio+video, identified by the youtube_id
+    # meta key youtubeparser.py/urlparser.py always stamp on
+    # these URLs) prefers MergeDownloader over the
+    # iptv_use_ffmpeg force below: it has sidecar (.txt/.jpg)
+    # and MKV-chapter support FFMPEGDownloader lacks, plus its
+    # own hardened completeness check for exactly this case.
+    # iptv_use_ffmpeg on these URLs exists only to speed up
+    # buffered *playback* (progressive muxing instead of
+    # download-then-play) and must not steer a real download
+    # away from MergeDownloader too. Scoped to youtube_id (not
+    # merge:// in general) so other iptv_use_ffmpeg merge://
+    # users - e.g. ARTE's split CMAF/fMP4 renditions, which
+    # genuinely need ffmpeg for both playback and download -
+    # are untouched.
+    #################################################
+    if forDownload and proto == 'merge' and urlMeta.get('youtube_id') and not mergeNeedsFFmpeg:
+        printDBG("DownloaderCreator: real download of YouTube merge:// -> MergeDownloader")
+        try:
+            return MergeDownloader()
+        except Exception:
+            printExc()
 
     #################################################
     # IMPORTANT: If iptv_use_ffmpeg=True is set,
@@ -130,28 +177,12 @@ def DownloaderCreator(url):
             printExc()
             downloader = None
 
-    #################################################
-    # merge:// with HLS/DASH components (separate
-    # audio+video renditions, e.g. Arte CMAF, Apple
-    # bipbop) must be muxed with ffmpeg. HLSDownloader's
-    # "-a" alt-audio path only naively interleaves TS
-    # packets and yields an unplayable file for fMP4,
-    # and MergeDownloader wgets each component (fine for
-    # progressive URLs, wrong for .m3u8/.mpd playlists).
-    #################################################
-    try:
-        if isinstance(url, str) and url.startswith('merge://'):
-            compUrls = []
-            try:
-                for key in url.split('merge://', 1)[1].split('|'):
-                    compUrls.append(str(urlMeta.get(key, key)))
-            except Exception:
-                printExc()
-            if any((IsHlsLikeUrl(u) or '.mpd' in u.lower()) for u in compUrls):
-                printDBG("DownloaderCreator: merge:// with HLS/DASH components -> FFMPEGDownloader")
-                return FFMPEGDownloader()
-    except Exception:
-        printExc()
+    if mergeNeedsFFmpeg:
+        printDBG("DownloaderCreator: merge:// with HLS/DASH components -> FFMPEGDownloader")
+        try:
+            return FFMPEGDownloader()
+        except Exception:
+            printExc()
 
     #################################################
     # Default assignment by protocol

--- a/IPTVPlayer/libs/urlparser.py
+++ b/IPTVPlayer/libs/urlparser.py
@@ -1253,19 +1253,15 @@ class pageParser(CaptchaHelper):
 
         if None is not self.getYTParser():
             try:
-                formats = config.plugins.iptvplayer.ytformat.value
                 height = config.plugins.iptvplayer.ytDefaultformat.value
                 dash = self.getYTParser().isDashAllowed()
                 vp9 = self.getYTParser().isVP9Allowed()
-                age = self.getYTParser().isAgeGateAllowed()
             except Exception:
-                printDBG("parserYOUTUBE default ytformat or ytDefaultformat not available here")
-                formats = "mp4"
+                printDBG("parserYOUTUBE default ytDefaultformat not available here")
                 height = "360"
                 dash = False
                 vp9 = False
-                age = False
-            tmpTab, dashTab = self.getYTParser().getDirectLinks(url, formats, dash, dashSepareteList=True, allowVP9=vp9, allowAgeGate=age)
+            tmpTab, dashTab = self.getYTParser().getDirectLinks(url, dash, dashSepareteList=True, allowVP9=vp9)
             videoUrls = []
             for item in tmpTab:
                 url = strwithmeta(item["url"], {"youtube_id": item.get("id", "")})

--- a/IPTVPlayer/libs/youtube_dl/extractor/youtube.py
+++ b/IPTVPlayer/libs/youtube_dl/extractor/youtube.py
@@ -5,9 +5,6 @@ import re
 import time
 from urllib.parse import urlparse, urlunparse, unquote as _unquote
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _, SetIPTVPlayerLastHostError
-from Plugins.Extensions.IPTVPlayer.libs.youtube_dl.utils import *
-
-# from Plugins.Extensions.IPTVPlayer.libs.youtube_dl.utils import _unquote
 from Plugins.Extensions.IPTVPlayer.libs.pCommon import common
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, GetDefaultLang, byteify, GetCookieDir
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
@@ -17,6 +14,21 @@ from Plugins.Extensions.IPTVPlayer.libs import ph
 from Plugins.Extensions.IPTVPlayer.tools.e2ijs import js_execute_ext, is_js_cached
 
 from Plugins.Extensions.IPTVPlayer.p2p3.manipulateStrings import ensure_str
+
+# InnerTube ANDROID player client. It hands unthrottled, un-ciphered
+# progressive/adaptive URLs to an anonymous caller (verified: no &n=
+# throttle param, full CDN speed), so no player-JS / signature / nsig
+# work is needed on this path.
+#
+# Deliberately NOT yt-dlp's current fingerprint (21.x + androidSdkVersion
+# 30 + Android 11 + contentCheckOk/racyCheckOk): YouTube challenges that
+# exact combo with the "sign in to confirm you're not a bot" wall within
+# a handful of requests. These are the older values the plain python3
+# host has used for months without ever tripping it - keep them in step
+# with origin/python3, do not chase yt-dlp here.
+YT_ANDROID_CLIENT_VERSION = "20.32.35"
+YT_ANDROID_SDK_VERSION = 35
+YT_ANDROID_OS_VERSION = "15"
 
 
 class CYTSignAlgoExtractor:
@@ -168,7 +180,11 @@ class CYTSignAlgoExtractor:
         return decSignatures
 
 
-def ExtractorError(text):
+def reportExtractorError(text):
+    # Not an exception. This used to be named ExtractorError, shadowing the
+    # real class from youtube_dl.utils, so `raise ExtractorError(...)` raised
+    # None -> a spurious TypeError on every deep failure. It only surfaces
+    # the message now; callers return an empty result themselves.
     printDBG(text)
     SetIPTVPlayerLastHostError(_(text))
 
@@ -195,70 +211,8 @@ class YoutubeIE(object):
                      ([0-9A-Za-z_-]+)                                         # here is it! the YouTube video ID
                      (?(1).+)?                                                # if we found the ID, everything can follow
                      $"""
-    _LANG_URL = r"https://www.youtube.com/?hl=en&persist_hl=1&gl=US&persist_gl=1&opt_out_ackd=1"
-    _LOGIN_URL = "https://accounts.google.com/ServiceLogin"
-    _AGE_URL = "https://www.youtube.com/verify_age?next_url=/&gl=US&hl=en"
     _NEXT_URL_RE = r"[\?&]next_url=([^&]+)"
-    _NETRC_MACHINE = "youtube"
     # Listed in order of quality
-    _available_formats = [
-        "38",
-        "37",
-        "46",
-        "22",
-        "45",
-        "35",
-        "44",
-        "34",
-        "18",
-        "43",
-        "6",
-        "5",
-        "36",
-        "17",
-        "13",
-        # Apple HTTP Live Streaming
-        "96",
-        "95",
-        "94",
-        "93",
-        "92",
-        "132",
-        "151",
-        # 3D
-        "85",
-        "84",
-        "102",
-        "83",
-        "101",
-        "82",
-        "100",
-        # Dash video
-        "138",
-        "137",
-        "248",
-        "136",
-        "247",
-        "135",
-        "246",
-        "245",
-        "244",
-        "134",
-        "243",
-        "133",
-        "242",
-        "160",
-        "298",
-        "299",
-        "313",
-        "271",
-        # Dash audio
-        "141",
-        "172",
-        "140",
-        "171",
-        "139",
-    ]
     _available_formats_prefer_free = [
         "38",
         "46",
@@ -316,42 +270,6 @@ class YoutubeIE(object):
         "139",
     ]
 
-    _supported_formats = [
-        "18",
-        "22",
-        "37",
-        "38",  # mp4
-        "82",
-        "83",
-        "84",
-        "85",  # mp4 3D
-        "92",
-        "93",
-        "94",
-        "95",
-        "96",
-        "132",
-        "151",  # Apple HTTP Live Streaming
-        "133",
-        "134",
-        "135",
-        "136",
-        "137",
-        "138",
-        "160",
-        "298",
-        "299",  # Dash mp4
-        "139",
-        "140",
-        "141",  # Dash mp4 audio
-    ]
-
-    _video_formats_map = {
-        "flv": ["35", "34", "6", "5"],
-        "3gp": ["36", "17", "13"],
-        "mp4": ["38", "37", "22", "18"],
-        "webm": ["46", "45", "44", "43"],
-    }
     _video_extensions = {
         "13": "3gp",
         "17": "3gp",
@@ -463,38 +381,6 @@ class YoutubeIE(object):
         "313": "2160p",
     }
 
-    _special_itags = {
-        "82": "3D",
-        "83": "3D",
-        "84": "3D",
-        "85": "3D",
-        "100": "3D",
-        "101": "3D",
-        "102": "3D",
-        "133": "DASH Video",
-        "134": "DASH Video",
-        "135": "DASH Video",
-        "136": "DASH Video",
-        "137": "DASH Video",
-        "138": "DASH Video",
-        "139": "DASH Audio",
-        "140": "DASH Audio",
-        "141": "DASH Audio",
-        "160": "DASH Video",
-        "171": "DASH Audio",
-        "172": "DASH Audio",
-        "242": "DASH Video",
-        "243": "DASH Video",
-        "244": "DASH Video",
-        "245": "DASH Video",
-        "246": "DASH Video",
-        "247": "DASH Video",
-        "248": "DASH Video",
-        "298": "DASH Video",
-        "299": "DASH Video",
-        "271": "DASH Video",
-        "313": "DASH Video",
-    }
     IE_NAME = "youtube"
 
     def __init__(self, params={}):
@@ -518,22 +404,44 @@ class YoutubeIE(object):
     def _extract_yt_initial_variable(self, webpage, regex, video_id, name):
         return json_loads(self._search_regex((r"%s\s*%s" % (regex, self._YT_INITIAL_BOUNDARY_RE), regex), webpage, name, default="{}"))
 
-    def _get_automatic_captions(self, video_id, webpage=None):
-        sub_tracks = []
-        if None is webpage:
-            url = "https://www.youtube.com/watch?v=%s&hl=%s&has_verified=1" % (video_id, GetDefaultLang())
-            sts, webpage = self.cm.getPage(url)
-            player_response = self._extract_yt_initial_variable(webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE, video_id, "initial player response")
+    def _extract_caption_tracks(self, video_id, source=None):
+        # source may be a player_response dict, a watch-page HTML string, or
+        # None (fetch the watch page). YouTube dropped the old
+        # api/timedtext?type=list endpoint; captionTracks in the player
+        # response is the only listing now.
+        if isinstance(source, dict):
+            player_response = source
         else:
-            player_response = webpage
+            webpage = source
+            if webpage is None:
+                url = "https://www.youtube.com/watch?v=%s&hl=%s&has_verified=1" % (video_id, GetDefaultLang())
+                sts, webpage = self.cm.getPage(url)
+                if not sts:
+                    return []
+            player_response = self._extract_yt_initial_variable(webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE, video_id, "initial player response")
         try:
-            player_captions = player_response["captions"]["playerCaptionsTracklistRenderer"]["captionTracks"]
+            return player_response["captions"]["playerCaptionsTracklistRenderer"]["captionTracks"] or []
         except Exception:
-            printDBG("youtube - _get_automatic_captions(): [captionTracks] NOT found in player_response")
-            return sub_tracks
-        try:
-            for lang in player_captions:
-                printDBG("_get_automatic_captions %s" % lang)
+            printDBG("youtube - captionTracks not found in player response")
+            return []
+
+    @staticmethod
+    def _caption_track_name(lang):
+        name = lang.get("name", {})
+        if isinstance(name, dict):
+            if name.get("simpleText"):
+                return name["simpleText"]
+            for run in name.get("runs", []):
+                if run.get("text"):
+                    return run["text"]
+        return lang.get("languageCode", "")
+
+    def _caption_tracks_to_subs(self, tracks, want_asr, start_idx=0):
+        sub_tracks = []
+        for lang in tracks or []:
+            try:
+                if (lang.get("kind") == "asr") != want_asr:
+                    continue
                 sub_url = urllib.parse.unquote_plus(lang["baseUrl"])
                 sub_format = self.cm.ph.getSearchGroups(sub_url + "&", r"[\?&]fmt=([^\?^&]+)[\?&]")[0]
                 if sub_format != "":
@@ -541,112 +449,169 @@ class YoutubeIE(object):
                 else:
                     sub_url = sub_url + "&fmt=vtt"
                 sub_lang = lang["languageCode"]
-                sub_tracks.append({"title": sub_lang.encode("utf-8"), "url": sub_url, "lang": sub_lang.encode("utf-8"), "ytid": len(sub_tracks), "format": "vtt"})
-        except Exception:
-            printExc()
+                sub_tracks.append({"title": self._caption_track_name(lang) or sub_lang, "url": sub_url, "lang": sub_lang, "ytid": start_idx + len(sub_tracks), "format": "vtt"})
+            except Exception:
+                printExc()
         return sub_tracks
 
-    def _get_subtitles(self, video_id):
-        sub_tracks = []
-        try:
-            url = "https://www.youtube.com/api/timedtext?hl=%s&type=list&v=%s" % (GetDefaultLang(), video_id)
-            sts, data = self.cm.getPage(url)
-            if not sts:
-                return sub_tracks
+    def _get_automatic_captions(self, video_id, webpage=None):
+        # ASR (auto-generated) caption tracks
+        return self._caption_tracks_to_subs(self._extract_caption_tracks(video_id, webpage), want_asr=True)
 
-            encoding = self.cm.ph.getDataBeetwenMarkers(data, 'encoding="', '"', False)[1]
+    def _get_subtitles(self, video_id, source=None):
+        # manually authored / community caption tracks
+        return self._caption_tracks_to_subs(self._extract_caption_tracks(video_id, source), want_asr=False)
 
-            def getArg(item, name):
-                val = self.cm.ph.getDataBeetwenMarkers(item, '%s="' % name, '"', False)[1]
-                return val.decode(encoding).encode(encoding)
+    def _real_extract(self, url, allowVP9=False, authHeader=None):
+        # authHeader: {"Authorization": "Bearer ..."} when the user is signed
+        # in - lets the player request reach members-only / age-restricted
+        # content. Broken into named steps below (was one 250+ line function);
+        # each step's inputs/outputs are just what's in its signature/return.
+        authHeader = authHeader or {}
+        url = self._followNextUrlRedirect(url)
+        video_id = self._extract_id(url)
 
-            data = data.split("/>")
-            for item in data:
-                if "lang_code" not in item:
-                    continue
-                id = getArg(item, "id")
-                name = getArg(item, "name")
-                lang_code = getArg(item, "lang_code")
-                lang_original = getArg(item, "lang_original")
-                lang_translated = getArg(item, "lang_translated")
+        isGoogleDoc, video_id, sts, video_webpage, player_response, cookieFile = \
+            self._resolvePlayerResponse(url, video_id, authHeader)
 
-                title = (name + " " + lang_translated).strip()
-                params = {"lang": lang_code, "v": video_id, "fmt": "vtt", "name": name}
-                url = "https://www.youtube.com/api/timedtext?" + urllib.parse.urlencode(params)
-                sub_tracks.append({"title": title, "url": url, "lang": lang_code, "ytid": id, "format": "vtt"})
-        except Exception:
-            printExc()
-        printDBG(sub_tracks)
-        return sub_tracks
+        if isGoogleDoc and not sts:
+            reportExtractorError("Unable to download video webpage")
+            return []
+        if not player_response:
+            reportExtractorError("Unable to get player response")
+            return []
 
-    def _real_extract(self, url, allowVP9=False, allowAgeGate=False):
-        # Extract original video URL from URL with redirection, like age verification, using next_url parameter
+        video_info = player_response.get("videoDetails", {})
+        video_duration = video_info.get("lengthSeconds", "")
 
+        video_url_list, is_m3u8 = self._extractFormatUrls(player_response, video_info, video_id, allowVP9)
+        if not video_url_list:
+            return []
+
+        if not self._decryptSignedUrls(video_url_list, video_webpage, video_id):
+            return []
+
+        cookieHeader = self.cm.getCookieHeader(cookieFile) if isGoogleDoc else None
+        return self._buildResults(video_id, player_response, video_url_list, video_duration, is_m3u8, isGoogleDoc, cookieHeader)
+
+    def _followNextUrlRedirect(self, url):
+        # follow a next_url= redirect (old age-verification style link) if present
         mobj = re.search(self._NEXT_URL_RE, url)
         if mobj:
             # https
-            url = "https://www.youtube.com/" + _unquote(mobj.group(1)).lstrip("/")
-        video_id = self._extract_id(url)
+            return "https://www.youtube.com/" + _unquote(mobj.group(1)).lstrip("/")
+        return url
 
+    def _resolvePlayerResponse(self, url, video_id, authHeader):
+        # Resolves the player response for a video, or for a legacy embedded
+        # Google Doc ("yt-video-id" placeholder). Returns (isGoogleDoc,
+        # video_id, sts, video_webpage, player_response, cookieFile) -
+        # player_response is None when nothing playable was found.
         player_response = None
         if "yt-video-id" == video_id:
             video_id = self.cm.ph.getSearchGroups(url + "&", r"[\?&]docid=([^\?^&]+)[\?&]")[0]
             isGoogleDoc = True
-            url = url
-            videoKey = "docid"
-            COOKIE_FILE = GetCookieDir("docs.google.com.cookie")
-            videoInfoparams = {"cookiefile": COOKIE_FILE, "use_cookie": True, "load_cookie": False, "save_cookie": True}
+            cookieFile = GetCookieDir("docs.google.com.cookie")
             sts, video_webpage = self.cm.getPage(url)
-        else:
-            tries = 0
-            while tries < 3:
-                tries += 1
-                url = "https://www.youtube.com/youtubei/v1/player?prettyPrint=false"
-                isGoogleDoc = False
-                videoKey = "video_id"
-                videoInfoparams = {}
+            return isGoogleDoc, video_id, sts, video_webpage, player_response, cookieFile
 
-                http_params = {"header": {"User-Agent": "com.google.android.youtube/20.32.35(Linux; U; Android 15) gzip", "Content-Type": "application/json", "Origin": "https://www.youtube.com", "X-YouTube-Client-Name": "3", "X-YouTube-Client-Version": "20.32.35"}}
-                http_params["raw_post_data"] = True
-                post_data = "{'videoId': '%s', 'params': '2AMB', 'context': {'client': {'hl': '%s', 'clientVersion': '20.32.35', 'clientName': 'ANDROID', 'androidSdkVersion': 35, 'osName': 'Android', 'osVersion': '15',}}}" % (video_id, GetDefaultLang())
-                sts, video_webpage = self.cm.getPage(url, http_params, post_data)
-                if sts:
-                    if allowAgeGate and "LOGIN_REQUIRED" in video_webpage:
-                        http_params["header"]["X-YouTube-Client-Name"] = "85"
-                        post_data = "{'videoId': '%s', 'thirdParty': 'https://www.youtube.com/', 'context': {'client': {'clientName': 'TVHTML5_SIMPLY_EMBEDDED_PLAYER', 'clientVersion': '2.0', 'clientScreen': 'EMBED'}}}" % video_id
-                        sts, video_webpage = self.cm.getPage(url, http_params, post_data)
-                    player_response = json_loads(video_webpage)
-                else:
-                    url = "https://www.youtube.com/watch?v=%s&bpctr=9999999999&has_verified=1&" % video_id
-                    sts, video_webpage = self.cm.getPage(url)
-                    if sts:
-                        player_response = self._extract_yt_initial_variable(video_webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE, video_id, "initial player response")
-                printDBG("_real_extract tries %s" % tries)
-                if player_response and player_response.get("streamingData"):
-                    break
+        isGoogleDoc = False
+        cookieFile = None
+        playerRequestUrl = "https://www.youtube.com/youtubei/v1/player?prettyPrint=false"
+        lang = GetDefaultLang()
+        # Anonymous: ANDROID only, one request per video - the same
+        # footprint the plain python3 host runs at without ever tripping
+        # the bot wall. No IOS second request (also a yt-dlp fingerprint).
+        it_clients = [
+            ("3", YT_ANDROID_CLIENT_VERSION, False,
+             "com.google.android.youtube/%s(Linux; U; Android %s) gzip" % (YT_ANDROID_CLIENT_VERSION, YT_ANDROID_OS_VERSION),
+             "'clientVersion': '%s', 'clientName': 'ANDROID', 'androidSdkVersion': %s, 'osName': 'Android', 'osVersion': '%s'" % (YT_ANDROID_CLIENT_VERSION, YT_ANDROID_SDK_VERSION, YT_ANDROID_OS_VERSION)),
+        ]
+        video_webpage = ""
+        ageReason = ""
+        if authHeader:
+            # Signed in: InnerTube only accepts the OAuth bearer token on
+            # the TVHTML5 client (ANDROID/IOS/WEB + bearer -> HTTP 400), so
+            # it is added as a last-resort client and is the only one the
+            # token is attached to. It honours the token for age-restricted
+            # / members content and gets past the bot wall (authenticated),
+            # so it is tried even after an anonymous LOGIN_REQUIRED.
+            it_clients.append(("7", "7.20250101.10.00", True,
+                               "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version",
+                               "'clientName': 'TVHTML5', 'clientVersion': '7.20250101.10.00'"))
+        botWalled = False
+        sts = False
+        for cname, cver, extraChecks, ua, client_ctx in it_clients:
+            header = {"User-Agent": ua, "Content-Type": "application/json", "Origin": "https://www.youtube.com", "X-YouTube-Client-Name": cname, "X-YouTube-Client-Version": cver}
+            if cname == "7":
+                header.update(authHeader)
+            http_params = {"header": header, "raw_post_data": True}
+            # contentCheckOk/racyCheckOk only on the authenticated client -
+            # sending them anonymously is part of the yt-dlp fingerprint
+            checks = " 'contentCheckOk': true, 'racyCheckOk': true," if extraChecks else ""
+            post_data = "{'videoId': '%s',%s 'params': '2AMB', 'context': {'client': {'hl': '%s', %s,}}}" % (video_id, checks, lang, client_ctx)
+            sts, data = self.cm.getPage(playerRequestUrl, http_params, post_data)
+            if not sts:
+                continue
+            try:
+                pr = json_loads(data)
+            except Exception:
+                continue
+            status = pr.get("playabilityStatus", {}).get("status", "") if isinstance(pr, dict) else ""
+            printDBG("_real_extract: player client %s -> %s" % (cname, status or "no status"))
+            if isinstance(pr, dict) and pr.get("streamingData"):
+                player_response, video_webpage = pr, data
+                break
+            if status in ("LOGIN_REQUIRED", "ERROR", "UNPLAYABLE", "AGE_VERIFICATION_REQUIRED"):
+                player_response = pr
+                ageReason = pr.get("playabilityStatus", {}).get("reason", "") or ageReason
+                reason = (pr.get("playabilityStatus", {}).get("reason", "") or "").lower()
+                if status == "LOGIN_REQUIRED" and ("bot" in reason or "sign in to confirm" in reason):
+                    # YouTube's "sign in to confirm you're not a bot" wall.
+                    # Every anonymous client and the watch page is gated the
+                    # same way from the same IP, so hammering the rest just
+                    # piles more flagged requests on and deepens the block.
+                    # Anonymous -> stop now. Signed in -> keep going so the
+                    # authenticated TVHTML5 client (7) still gets its try.
+                    botWalled = True
+                    if not authHeader:
+                        break
 
-        if not sts:
-            raise ExtractorError("Unable to download video webpage")
+        # last resort: the watch page's ytInitialPlayerResponse (its URLs
+        # need sig + nsig descrambling, so worse quality, but sometimes the
+        # only thing left) - skip it when we're already bot-walled, it is
+        # gated too and only adds another flagged request
+        if not botWalled and not (player_response and player_response.get("streamingData")):
+            sts, wp = self.cm.getPage("https://www.youtube.com/watch?v=%s&bpctr=9999999999&has_verified=1&" % video_id)
+            if sts:
+                video_webpage = wp
+                wr = self._extract_yt_initial_variable(wp, self._YT_INITIAL_PLAYER_RESPONSE_RE, video_id, "initial player response")
+                if wr and wr.get("streamingData"):
+                    player_response = wr
 
-        if not player_response:
-            raise ExtractorError("Unable to get player response")
+        if not (player_response and player_response.get("streamingData")):
+            # nothing playable - almost always an age / sign-in wall, which
+            # no anonymous YouTube client can pass any more
+            SetIPTVPlayerLastHostError(ageReason or _("This video requires you to sign in to a YouTube account."))
 
-        video_info = player_response.get("videoDetails", {})
-        # subtitles
-        video_duration = video_info.get("lengthSeconds", "")
+        return isGoogleDoc, video_id, sts, video_webpage, player_response, cookieFile
 
+    def _extractFormatUrls(self, player_response, video_info, video_id, allowVP9):
+        # Returns (video_url_list, is_m3u8) built from streamingData's
+        # formats/adaptiveFormats (with cipher/signatureCipher decoding), or
+        # from the HLS manifest instead when it's a live broadcast or nothing
+        # else was playable.
         url_map = {}
         video_url_list = {}
 
         try:
             is_m3u8 = "no"
             cipher = {}
-            url_data_str = []
-            url_data_str = player_response["streamingData"]["formats"]
-            try:
-                url_data_str += player_response["streamingData"]["adaptiveFormats"]
-            except Exception:
-                printExc()
+            streaming_data = player_response.get("streamingData", {}) or {}
+            # some clients (TVHTML5, a few age/members responses) return only
+            # adaptiveFormats and no muxed "formats" list at all
+            url_data_str = list(streaming_data.get("formats", []) or [])
+            url_data_str += list(streaming_data.get("adaptiveFormats", []) or [])
 
             for url_data in url_data_str:
 
@@ -659,10 +624,10 @@ class YoutubeIE(object):
                     printDBG(cipher)
 
                     cipher = cipher.split("&")
+                    sig_item = ""
+                    s_item = ""
+                    sp_item = ""
                     for item in cipher:
-                        # sig_item = ''
-                        # s_item = ''
-                        # sp_item = ''
                         if "url=" in item:
                             url_item = {"url": _unquote(item.replace("url=", ""), None)}
                         if "sig=" in item:
@@ -671,7 +636,7 @@ class YoutubeIE(object):
                             s_item = item.replace("s=", "")
                         if "sp=" in item:
                             sp_item = item.replace("sp=", "")
-                    if "sig" in cipher:
+                    if sig_item:
                         signature = sig_item
                         url_item["url"] += "&signature=" + signature
                     elif len(s_item):
@@ -688,15 +653,30 @@ class YoutubeIE(object):
         except Exception:
             printExc()
 
-        if video_info.get("isLive", True) and not video_url_list:  # j00zek needs verification if default value should be True or False, for now assuming yes
-            is_m3u8 = "yes"
-            manifest_url = _unquote(player_response["streamingData"]["hlsManifestUrl"], None)
-            url_map = self._extract_from_m3u8(manifest_url, video_id)
-            video_url_list = self._get_video_url_list(url_map, allowVP9)
+        # A currently-running live stream is served as server-side fragmented
+        # DASH from googlevideo - a plain GET of those adaptiveFormats URLs
+        # yields a stream exteplayer3/ffmpeg cannot demux (and the merge://
+        # A/V downloader only ever grabs one fragment), so for a live video
+        # the HLS manifest is the only thing that actually plays. Prefer it
+        # even though adaptiveFormats are present. isLive is only set while
+        # the broadcast is live; a finished stream's VOD has isLive absent
+        # and keeps the normal DASH path.
+        is_live = bool(video_info.get("isLive"))
+        manifest_url = player_response.get("streamingData", {}).get("hlsManifestUrl")
+        if manifest_url and (not video_url_list or is_live):
+            hls_url_map = self._extract_from_m3u8(_unquote(manifest_url, None), video_id)
+            hls_url_list = self._get_video_url_list(hls_url_map, allowVP9)
+            if hls_url_list:
+                is_m3u8 = "yes"
+                video_url_list = hls_url_list
 
-        if not video_url_list:
-            return []
+        return video_url_list, is_m3u8
 
+    def _decryptSignedUrls(self, video_url_list, video_webpage, video_id):
+        # Fills signItems' final URLs in place (dicts are mutable, so this
+        # propagates straight into video_url_list). Returns False when the
+        # caller should abort extraction with [], True otherwise (including
+        # the common case of no ciphered formats at all).
         signItems = []
         signatures = []
         for idx in range(len(video_url_list)):
@@ -704,35 +684,44 @@ class YoutubeIE(object):
                 signItems.append(video_url_list[idx][1])
                 signatures.append(video_url_list[idx][1]["esign"])
 
-        if len(signatures):
-            # decrypt signatures
-            printDBG("signatures: %s" % signatures)
-            playerUrl = ""
-            tmp = ph.find(video_webpage, ("<script", ">", "player/base"))[1]
-            playerUrl = ph.getattr(tmp, "src")
-            if not playerUrl:
-                for reObj in [r'"assets"\:[^\}]+?"js"\s*:\s*"([^"]+?)"', 'src="([^"]+?)"[^>]+?name="player.*?/base"', '"jsUrl":"([^"]+?)"']:
-                    playerUrl = ph.search(video_webpage, reObj)[0]
-                    if playerUrl:
-                        break
-            playerUrl = self.cm.getFullUrl(playerUrl.replace("\\", ""), self.cm.meta["url"])
-            if playerUrl:
-                decSignatures = CYTSignAlgoExtractor(self.cm).decryptSignatures(signatures, playerUrl)
-                if len(signatures) == len(signItems):
-                    try:
-                        for idx in range(len(signItems)):
-                            signItems[idx]["url"] = signItems[idx]["url"].format(decSignatures[idx])
-                    except Exception:
-                        printExc()
-                        SetIPTVPlayerLastHostError(_("Decrypt Signatures Error"))
-                        return []
-                else:
-                    return []
+        if not signatures:
+            return True
 
-        if isGoogleDoc:
-            cookieHeader = self.cm.getCookieHeader(COOKIE_FILE)
+        # decrypt signatures
+        printDBG("signatures: %s" % signatures)
+        playerUrl = ""
+        tmp = ph.find(video_webpage, ("<script", ">", "player/base"))[1]
+        playerUrl = ph.getattr(tmp, "src")
+        if not playerUrl:
+            for reObj in [r'"assets"\:[^\}]+?"js"\s*:\s*"([^"]+?)"', 'src="([^"]+?)"[^>]+?name="player.*?/base"', '"jsUrl":"([^"]+?)"']:
+                playerUrl = ph.search(video_webpage, reObj)[0]
+                if playerUrl:
+                    break
+        if not playerUrl:
+            # video_webpage is the InnerTube JSON, not HTML - grab base.js
+            # from the watch page instead
+            sts, wp = self.cm.getPage("https://www.youtube.com/watch?v=%s" % video_id)
+            if sts:
+                playerUrl = self._search_regex([r'"jsUrl":"([^"]+?)"', r'"(?:PLAYER_JS_URL|jsUrl)"\s*:\s*"([^"]+base\.js)"'], wp, "player URL", default="")
+        playerUrl = self.cm.getFullUrl(playerUrl.replace("\\", ""), self.cm.meta["url"])
+        if playerUrl:
+            decSignatures = CYTSignAlgoExtractor(self.cm).decryptSignatures(signatures, playerUrl)
+            if len(signatures) == len(signItems):
+                try:
+                    for idx in range(len(signItems)):
+                        signItems[idx]["url"] = signItems[idx]["url"].format(decSignatures[idx])
+                except Exception:
+                    printExc()
+                    SetIPTVPlayerLastHostError(_("Decrypt Signatures Error"))
+                    return False
+            else:
+                return False
+        return True
 
-        sub_tracks = self._get_automatic_captions(video_id, player_response)
+    def _buildResults(self, video_id, player_response, video_url_list, video_duration, is_m3u8, isGoogleDoc, cookieHeader):
+        caption_tracks = self._extract_caption_tracks(video_id, player_response)
+        manual_sub_tracks = self._caption_tracks_to_subs(caption_tracks, False)
+        sub_tracks = manual_sub_tracks + self._caption_tracks_to_subs(caption_tracks, True, start_idx=len(manual_sub_tracks))
         results = []
         for format_param, url_item in video_url_list:
             # Extension
@@ -773,14 +762,17 @@ class YoutubeIE(object):
             return urls
 
         sts, manifest = self.cm.getPage(manifest_url)
-        formats_urls = _get_urls(manifest)
-        for format_url in formats_urls:
-            itag = self._search_regex(r"itag/(\d+?)/", format_url, "itag")
-            url_map[itag] = {"url": format_url}
+        if not sts:
+            return url_map
+        for format_url in _get_urls(manifest):
+            itag = self._search_regex(r"itag/(\d+?)/", format_url, "itag", default="")
+            if itag:
+                url_map[itag] = {"url": format_url}
         return url_map
 
     def _search_regex(self, pattern, string, name, default=None, fatal=True, flags=0):
         compiled_regex_type = type(re.compile(""))
+        mobj = None
         if isinstance(pattern, (str, compiled_regex_type)):
             mobj = re.search(pattern, string, flags)
         else:
@@ -795,10 +787,9 @@ class YoutubeIE(object):
         elif default is not None:
             return default
         elif fatal:
-            printDBG("Unable to extract %s" % name)
-            raise
+            raise Exception("Unable to extract %s" % name)
         else:
-            printDBG("unable to extract %s; please report this issue on http://yt-dl.org/bug" % name)
+            printDBG("unable to extract %s" % name)
             return None
 
     def _get_video_url_list(self, url_map, allowVP9=False):

--- a/IPTVPlayer/libs/youtube_oauth.py
+++ b/IPTVPlayer/libs/youtube_oauth.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+#
+# Google account sign-in for the YouTube host, via the OAuth 2.0 "limited
+# input device" (device-code) flow - the same flow the YouTube app on a TV
+# uses, so it needs no browser on the box.
+#
+# It uses the long-known public YouTube-on-TV client credentials (the same
+# ones yt-dlp / Kodi's YouTube plugin / invidious use). A box can override
+# them with /etc/enigma2/YouTube.key:
+#     API_KEY = ...
+#     CLIENT_ID = ...
+#     CLIENT_SECRET = ...
+#
+# The bearer token is sent as `Authorization: Bearer ...` on the InnerTube
+# requests - that is what unlocks age-restricted videos and the personal
+# feeds (subscriptions / liked / watch later / playlists).
+
+import time
+from os.path import isfile
+
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
+from Plugins.Extensions.IPTVPlayer.libs.pCommon import common
+from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
+from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_urlencode
+from Components.config import config, ConfigText
+
+config.plugins.iptvplayer.youtube_oauth_refresh_token = ConfigText(default="", fixed_size=False)
+
+_CLIENT_ID = "861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com"
+_CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT"
+# OAuth scope identifiers, not fetched URLs - "http://gdata.youtube.com" is
+# Google's own legacy scope name (same string yt-dlp / Kodi use)
+_SCOPE = "http://gdata.youtube.com https://www.googleapis.com/auth/youtube"  # NOSONAR
+
+_DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+# the legacy TV client only accepts the old device grant type (a URN-style
+# identifier defined by the OAuth device-flow spec, never dereferenced)
+_DEVICE_GRANT = "http://oauth.net/grant_type/device/1.0"  # NOSONAR
+_KEY_FILE = "/etc/enigma2/YouTube.key"
+
+
+def _loadKeyFile():
+    global _CLIENT_ID, _CLIENT_SECRET
+    if not isfile(_KEY_FILE):
+        return
+    try:
+        for line in open(_KEY_FILE).read().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            name, _sep, value = line.partition("=")
+            name = name.strip().upper()
+            value = value.strip().strip('"').strip("'")
+            if len(value) < 10:
+                continue
+            if name == "CLIENT_ID":
+                _CLIENT_ID = value
+            elif name == "CLIENT_SECRET":
+                _CLIENT_SECRET = value
+    except Exception:
+        printExc()
+
+
+_loadKeyFile()
+
+
+class YouTubeOAuth(object):
+    # process-wide access-token cache: (token, expiry_epoch)
+    _accessToken = ("", 0)
+
+    HEADER = {"User-Agent": "Mozilla/5.0", "Content-Type": "application/x-www-form-urlencoded"}
+
+    def __init__(self):
+        self._cm = None
+
+    # ---------------------------------------------------------------- helpers
+    def _post(self, url, data):
+        # google returns the JSON body with a 4xx too (authorization_pending
+        # is a 428), so parse it regardless of the sts flag
+        if self._cm is None:
+            self._cm = common()
+        params = {"header": dict(self.HEADER), "raw_post_data": True}
+        sts, out = self._cm.getPage(url, params, urllib_urlencode(data))
+        try:
+            return json_loads(out)
+        except Exception:
+            if not sts:
+                printDBG("YouTubeOAuth._post failed: %s" % url)
+            else:
+                printExc()
+            return {}
+
+    @staticmethod
+    def isLoggedIn():
+        return bool(config.plugins.iptvplayer.youtube_oauth_refresh_token.value)
+
+    @staticmethod
+    def logout():
+        YouTubeOAuth._accessToken = ("", 0)
+        config.plugins.iptvplayer.youtube_oauth_refresh_token.value = ""
+        config.plugins.iptvplayer.youtube_oauth_refresh_token.save()
+
+    # ---------------------------------------------------------------- device flow
+    def requestDeviceCode(self):
+        # -> dict with verification_url, user_code, device_code, interval, expires_in
+        res = self._post(_DEVICE_CODE_URL, {"client_id": _CLIENT_ID, "scope": _SCOPE})
+        return {
+            "verification_url": res.get("verification_url") or "https://www.google.com/device",
+            "user_code": res.get("user_code", ""),
+            "device_code": res.get("device_code", ""),
+            "interval": int(res.get("interval", 5) or 5),
+            "expires_in": int(res.get("expires_in", 1800) or 1800),
+        }
+
+    def pollForToken(self, deviceCode, interval, expiresIn, shouldStop=None):
+        # blocks until the user approves on another device (or it expires).
+        # shouldStop() may be passed to bail out early. Returns True on success.
+        deadline = time.time() + min(int(expiresIn or 1800), 1800)
+        wait = max(int(interval or 5), 5)
+        while time.time() < deadline:
+            if shouldStop is not None and shouldStop():
+                return False
+            time.sleep(wait)
+            res = self._post(_TOKEN_URL, {
+                "client_id": _CLIENT_ID,
+                "client_secret": _CLIENT_SECRET,
+                "code": deviceCode,
+                "grant_type": _DEVICE_GRANT,
+            })
+            err = res.get("error", "")
+            if err == "authorization_pending":
+                continue
+            if err == "slow_down":
+                wait += 5
+                continue
+            if res.get("refresh_token"):
+                config.plugins.iptvplayer.youtube_oauth_refresh_token.value = res["refresh_token"]
+                config.plugins.iptvplayer.youtube_oauth_refresh_token.save()
+                if res.get("access_token"):
+                    YouTubeOAuth._accessToken = (res["access_token"], time.time() + int(res.get("expires_in", 3600)) - 60)
+                return True
+            # access_denied / expired_token / anything else -> give up
+            printDBG("YouTubeOAuth.pollForToken stop: %s" % (err or res))
+            return False
+        return False
+
+    # ---------------------------------------------------------------- token use
+    def getAccessToken(self):
+        token, expiry = YouTubeOAuth._accessToken
+        if token and time.time() < expiry:
+            return token
+        refresh = config.plugins.iptvplayer.youtube_oauth_refresh_token.value
+        if not refresh:
+            return ""
+        res = self._post(_TOKEN_URL, {
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+            "refresh_token": refresh,
+            "grant_type": "refresh_token",
+        })
+        if res.get("access_token"):
+            YouTubeOAuth._accessToken = (res["access_token"], time.time() + int(res.get("expires_in", 3600)) - 60)
+            return res["access_token"]
+        if res.get("error") in ("invalid_grant", "unauthorized_client"):
+            # refresh token revoked / no longer valid - drop it
+            printDBG("YouTubeOAuth: refresh token rejected (%s), signing out" % res.get("error"))
+            YouTubeOAuth.logout()
+        return ""
+
+    def getAuthHeader(self):
+        token = self.getAccessToken()
+        return {"Authorization": "Bearer %s" % token} if token else {}

--- a/IPTVPlayer/libs/youtubeparser.py
+++ b/IPTVPlayer/libs/youtubeparser.py
@@ -2,11 +2,12 @@
 # Last Modified: 01.07.2026 - Change: configurable YouTube display language, configurable channel name for downloaded files, absolute published date in info view
 # LOCAL import
 from Plugins.Extensions.IPTVPlayer.libs.youtube_dl.extractor.youtube import YoutubeIE
+from Plugins.Extensions.IPTVPlayer.libs.youtube_oauth import YouTubeOAuth
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, IsExecutable
 from Plugins.Extensions.IPTVPlayer.libs.pCommon import common
 from Plugins.Extensions.IPTVPlayer.components.iptvplayerinit import TranslateTXT as _
 from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import decorateUrl
-from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getDirectM3U8Playlist, getMPDLinksWithMeta
+from Plugins.Extensions.IPTVPlayer.libs.urlparserhelper import getMPDLinksWithMeta
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads, dumps as json_dumps
 from Plugins.Extensions.IPTVPlayer.libs import ph
@@ -22,29 +23,85 @@ from Components.Language import language
 from Components.config import config, ConfigSelection, ConfigYesNo
 
 # Config options for HOST
-config.plugins.iptvplayer.ytformat = ConfigSelection(default="mp4", choices=[("flv, mp4", "flv, mp4"), ("flv", "flv"), ("mp4", "mp4")])
 config.plugins.iptvplayer.ytDefaultformat = ConfigSelection(default="720", choices=[("0", _("the worst")), ("144", "144p"), ("240", "240p"), ("360", "360p"), ("720", "720p"), ("1080", "1080p"), ("1440", "1440p"), ("2160", "2160p"), ("9999", _("the best"))])
 config.plugins.iptvplayer.ytUseDF = ConfigYesNo(default=True)
-config.plugins.iptvplayer.ytAgeGate = ConfigYesNo(default=False)
 config.plugins.iptvplayer.ytVP9 = ConfigYesNo(default=False)
 config.plugins.iptvplayer.ytShowDash = ConfigSelection(default="auto", choices=[("auto", _("Auto")), ("true", _("Yes")), ("false", _("No"))])
 config.plugins.iptvplayer.ytSortBy = ConfigSelection(default="A", choices=[("A", _("Relevance")), ("I", _("Upload date")), ("M", _("View count")), ("E", _("Rating"))])
+config.plugins.iptvplayer.youtube_search_region = ConfigSelection(default="auto", choices=[("auto", _("Automatic"))] + [(c, c) for c in ("US", "GB", "DE", "AT", "CH", "FR", "IT", "ES", "PL", "NL", "BE", "CZ", "RU", "UA", "TR", "GR", "SE", "PT", "BR", "MX", "IN", "JP", "KR", "CA", "AU")])
+config.plugins.iptvplayer.youtube_safe_search = ConfigYesNo(default=False)
+
+# InnerTube WEB client. The API key is the long-lived public youtube.com one
+# (unchanged for years, also used by yt-dlp); the client version and
+# visitorData rot and are refreshed at runtime from ytcfg - see
+# YouTubeParser._absorbPageConfig() / _getYtConfig(). These are only the
+# fallbacks for when that scrape fails.
+YT_INNERTUBE_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+YT_CLIENT_VERSION_FALLBACK = "2.20260904.01.00"
+
+# Fallback region (YouTube gl=) per selectable UI language - only the codes
+# where it isn't simply the language code upper-cased.
+_YT_LANG_DEFAULT_REGION = {
+    "en": "US", "cs": "CZ", "el": "GR", "da": "DK", "sv": "SE", "uk": "UA",
+    "ja": "JP", "ko": "KR", "zh": "CN", "ar": "SA", "sr": "RS", "he": "IL",
+    "hi": "IN", "no": "NO", "nb": "NO", "sl": "SI", "et": "EE",
+}
 
 
 class YouTubeParser:
+
+    # process-wide cache: {"client_version": str, "api_key": str, "visitor_data": str}
+    _ytConfig = None
 
     def __init__(self):
         self.cm = common()
         self.HTTP_HEADER = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
             "X-YouTube-Client-Name": "1",
-            "X-YouTube-Client-Version": "2.20201112.04.01",
+            "X-YouTube-Client-Version": YT_CLIENT_VERSION_FALLBACK,
             "X-Requested-With": "XMLHttpRequest"
         }
         self.http_params = {"header": self.HTTP_HEADER, "return_data": True}
         self.postdata = {}
         self.sessionToken = ""
         return
+
+    def _absorbPageConfig(self, data):
+        # every youtube.com HTML page carries the full ytcfg; harvest the
+        # bits that go stale so continuation POSTs stay current for free.
+        try:
+            data = ensure_str(data)
+        except Exception:
+            return
+        cfg = dict(YouTubeParser._ytConfig or {})
+        m = re.search(r'"INNERTUBE_(?:CONTEXT_)?CLIENT_VERSION":"([0-9.]+)"', data)
+        if m:
+            cfg["client_version"] = m.group(1)
+        m = re.search(r'"INNERTUBE_API_KEY":"([A-Za-z0-9_\-]+)"', data)
+        if m:
+            cfg["api_key"] = m.group(1)
+        m = re.search(r'"visitorData":"([^"\\]{20,2000})"', data)
+        if m:
+            cfg["visitor_data"] = m.group(1)
+        if cfg:
+            YouTubeParser._ytConfig = cfg
+
+    def _getYtConfig(self, fetchIfMissing=False):
+        if fetchIfMissing and not (YouTubeParser._ytConfig or {}).get("client_version"):
+            # continuation-only flow with nothing harvested yet - one cheap
+            # fetch of the home page, else fall through to the constants
+            try:
+                sts, data = self.cm.getPage("https://www.youtube.com/", self.http_params)
+                if sts and data:
+                    self._absorbPageConfig(data)
+            except Exception:
+                printExc()
+        cfg = YouTubeParser._ytConfig or {}
+        return {
+            "client_version": cfg.get("client_version") or YT_CLIENT_VERSION_FALLBACK,
+            "api_key": cfg.get("api_key") or YT_INNERTUBE_API_KEY,
+            "visitor_data": cfg.get("visitor_data") or "",
+        }
 
     @staticmethod
     def isDashAllowed():
@@ -65,13 +122,8 @@ class YouTubeParser:
         printDBG("2. ALLOW VP9: >> %s" % value)
         return value
 
-    @staticmethod
-    def isAgeGateAllowed():
-        value = config.plugins.iptvplayer.ytAgeGate.value
-        printDBG("ALLOW Age-Gate bypass: >> %s" % value)
-        return value
-
     def checkSessionToken(self, data):
+        self._absorbPageConfig(data)
         if not self.sessionToken:
             token = self.cm.ph.getSearchGroups(data, '''"XSRF_TOKEN":"([^"]+?)"''')[0]
             if token:
@@ -80,9 +132,37 @@ class YouTubeParser:
                 self.postdata = {"session_token": token}
 
     # DIRECT LINK RESOLUTION
-    def getDirectLinks(self, url, formats="flv, mp4", dash=True, dashSepareteList=False, allowVP9=None, allowAgeGate=None):
+    def getDirectLinks(self, url, dash=True, dashSepareteList=False, allowVP9=None):
         printDBG("YouTubeParser.getDirectLinks")
-        linksList = []
+        linksList = self._resolveVideoLinks(url, allowVP9)
+        if linksList is None:
+            return ([], []) if dashSepareteList else []
+
+        dashAudioLists, dashVideoLists, dashList = self._splitDashLists(linksList) if dash else ([], [], [])
+        retList, retHLSList = self._filterFormatLists(linksList)
+        dashList = self._appendMergedDashItems(dashAudioLists, dashVideoLists, dashList)
+
+        # no progressive/muxed format survived - fall back to the HLS list
+        # (_real_extract already resolves hlsManifestUrl and the DASH
+        # adaptiveFormats; the old "hlsvp"/"dashmpd" watch-page keys this
+        # used to scrape were removed by YouTube years ago)
+        if 0 == len(retList):
+            retList = retHLSList
+
+        for idx in range(len(retList)):
+            if retList[idx].get("m3u8", False):
+                retList[idx]["url"] = strwithmeta(retList[idx]["url"], {"iptv_m3u8_live_start_index": -30})
+
+        if dashSepareteList:
+            return retList, dashList
+        else:
+            retList.extend(dashList)
+            return retList
+
+    def _resolveVideoLinks(self, url, allowVP9):
+        # Resolves a /channel/.../live URL to its live video's watch URL,
+        # then runs the real extractor. None on failure (the caller returns
+        # the dashSepareteList-appropriate empty result for that).
         try:
             if self.cm.isValidUrl(url) and "/channel/" in url and url.endswith("/live"):
                 sts, data = self.cm.getPage(url)
@@ -92,52 +172,54 @@ class YouTubeParser:
                         videoId = self.cm.ph.getSearchGroups(data, r"""['"]REDIRECT_TO_VIDEO['"]\s*\,\s*['"]([^'^"]+?)['"]""")[0]
                     if videoId != "":
                         url = "https://www.youtube.com/watch?v=" + videoId
-            linksList = YoutubeIE()._real_extract(url, allowVP9=allowVP9, allowAgeGate=allowAgeGate)
+            return YoutubeIE()._real_extract(url, allowVP9=allowVP9, authHeader=self._getAuthHeader())
         except Exception:
             printExc()
-            if dashSepareteList:
-                return [], []
-            else:
-                return []
+            return None
 
+    def _splitDashLists(self, linksList):
+        # Separates the audio-only / video-only DASH renditions (best
+        # quality first); mpd items are expanded into a dash-tagged list of
+        # their own straight away.
         reNum = re.compile("([0-9]+)")
-        retHLSList = []
-        retList = []
-        dashList = []
-        # filter dash
         dashAudioLists = []
         dashVideoLists = []
-        if dash:
-            # separete audio and video links
-            for item in linksList:
-                if "mp4a" == item["ext"]:
-                    dashAudioLists.append(item)
-                elif item["ext"] in ("mp4v", "webmv"):
-                    dashVideoLists.append(item)
-                elif "mpd" == item["ext"]:
-                    tmpList = getMPDLinksWithMeta(ensure_str(item["url"]), checkExt=False)
-                    printDBG(tmpList)
-                    for idx in range(len(tmpList)):
-                        tmpList[idx]["format"] = "%sx%s" % (tmpList[idx].get("height", 0), tmpList[idx].get("width", 0))
-                        tmpList[idx]["ext"] = "mpd"
-                        tmpList[idx]["dash"] = True
-                    dashList.extend(tmpList)
-            # sort by quality -> format
+        dashList = []
+        for item in linksList:
+            if "mp4a" == item["ext"]:
+                dashAudioLists.append(item)
+            elif item["ext"] in ("mp4v", "webmv"):
+                dashVideoLists.append(item)
+            elif "mpd" == item["ext"]:
+                tmpList = getMPDLinksWithMeta(ensure_str(item["url"]), checkExt=False)
+                printDBG(tmpList)
+                for idx in range(len(tmpList)):
+                    tmpList[idx]["format"] = "%sx%s" % (tmpList[idx].get("height", 0), tmpList[idx].get("width", 0))
+                    tmpList[idx]["ext"] = "mpd"
+                    tmpList[idx]["dash"] = True
+                dashList.extend(tmpList)
 
-            def _key(x):
-                if x["format"].startswith(">"):
-                    return int(x["format"][1:-1])
-                else:
-                    return int(ph.search(x["format"], reNum)[0])
+        def _key(x):
+            if x["format"].startswith(">"):
+                return int(x["format"][1:-1])
+            else:
+                return int(ph.search(x["format"], reNum)[0])
 
-            dashAudioLists = sorted(dashAudioLists, key=_key, reverse=True)
-            dashVideoLists = sorted(dashVideoLists, key=_key, reverse=True)
+        dashAudioLists = sorted(dashAudioLists, key=_key, reverse=True)
+        dashVideoLists = sorted(dashVideoLists, key=_key, reverse=True)
+        return dashAudioLists, dashVideoLists, dashList
 
+    def _filterFormatLists(self, linksList):
+        # Progressive/muxed mp4 formats, split into plain (retList) and
+        # HLS (retHLSList). mp4 is the only progressive container YouTube
+        # still serves (webm/3gp progressive formats died years ago).
+        retHLSList = []
+        retList = []
         for item in linksList:
             printDBG(">>>>>>>>>>>>>>>>>>>>>")
             printDBG(str(item))
             printDBG("<<<<<<<<<<<<<<<<<<<<<")
-            if -1 < formats.find(item["ext"]):
+            if "mp4" == item["ext"]:
                 if "yes" == item["m3u8"]:
                     format = re.search("([0-9]+?)p$", item["format"])
                     if format is not None:
@@ -151,68 +233,30 @@ class YouTubeParser:
                         item["format"] = format.group(1)
                         item["url"] = decorateUrl(ensure_str(item["url"]))
                         retList.append(item)
+        return retList, retHLSList
 
+    def _appendMergedDashItems(self, dashAudioLists, dashVideoLists, dashList):
         if len(dashAudioLists):
             # use best audio
             for item in dashVideoLists:
                 item = dict(item)
-                item["url"] = decorateUrl("merge://audio_url|video_url", {"audio_url": dashAudioLists[0]["url"], "video_url": ensure_str(item["url"])})
-                dashList.append(item)
-
-        # try to get hls format with alternative method
-        if 0 == len(retList):
-            try:
-                video_id = YoutubeIE()._extract_id(url)
-                url = "http://www.youtube.com/watch?v=%s&gl=US&hl=en&has_verified=1" % video_id
-                sts, data = self.cm.getPage(url, {"header": {"User-agent": "Mozilla/5.0 (iPad; CPU OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/146.0.7680.38 Mobile/15E148 Safari/604.1"}})
-                if sts:
-                    data = data.replace('\\"', '"').replace("\\\\\\/", "/")
-                    hlsUrl = self.cm.ph.getSearchGroups(data, r'''"hlsvp"\s*:\s*"(https?://[^"]+?)"''')[0]
-                    hlsUrl = json_loads('"%s"' % hlsUrl)
-                    if self.cm.isValidUrl(hlsUrl):
-                        hlsList = getDirectM3U8Playlist(hlsUrl)
-                        if len(hlsList):
-                            dashList = []
-                            for item in hlsList:
-                                item["format"] = "%sx%s" % (item.get("width", 0), item.get("height", 0))
-                                item["ext"] = "m3u8"
-                                item["m3u8"] = True
-                                retList.append(item)
-            except Exception:
-                printExc()
-            if 0 == len(retList):
-                retList = retHLSList
-
-            if dash:
+                # iptv_use_ffmpeg: mux the two renditions with ffmpeg
+                # (FFMPEGDownloader, progressive) rather than wget-both-then-mux
+                # (MergeDownloader), which downloaded the whole file before
+                # playback could start. Only the buffered path reads this flag;
+                # no-buffer playback hands exteplayer3 the two URLs via -x.
+                mergeMeta = {"audio_url": dashAudioLists[0]["url"], "video_url": ensure_str(item["url"]), "iptv_use_ffmpeg": True}
+                # carry the caption tracks over - decorateUrl on the literal
+                # "merge://" string would otherwise drop them
                 try:
-                    sts, data = self.cm.getPage(url, {"header": {"User-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"}})
-                    data = data.replace('\\"', '"').replace("\\\\\\/", "/").replace("\\/", "/")
-                    dashUrl = self.cm.ph.getSearchGroups(data, r'''"dashmpd"\s*:\s*"(https?://[^"]+?)"''')[0]
-                    dashUrl = json_loads('"%s"' % dashUrl)
-                    if "?" not in dashUrl:
-                        dashUrl += "?mpd_version=5"
-                    else:
-                        dashUrl += "&mpd_version=5"
-                    printDBG("DASH URL >> [%s]" % dashUrl)
-                    if self.cm.isValidUrl(dashUrl):
-                        dashList = getMPDLinksWithMeta(dashUrl, checkExt=False)
-                        printDBG(dashList)
-                        for idx in range(len(dashList)):
-                            dashList[idx]["format"] = "%sx%s" % (dashList[idx].get("height", 0), dashList[idx].get("width", 0))
-                            dashList[idx]["ext"] = "mpd"
-                            dashList[idx]["dash"] = True
+                    subs = strwithmeta(item["url"]).meta.get("external_sub_tracks", [])
+                    if subs:
+                        mergeMeta["external_sub_tracks"] = subs
                 except Exception:
                     printExc()
-
-        for idx in range(len(retList)):
-            if retList[idx].get("m3u8", False):
-                retList[idx]["url"] = strwithmeta(retList[idx]["url"], {"iptv_m3u8_live_start_index": -30})
-
-        if dashSepareteList:
-            return retList, dashList
-        else:
-            retList.extend(dashList)
-            return retList
+                item["url"] = decorateUrl("merge://audio_url|video_url", mergeMeta)
+                dashList.append(item)
+        return dashList
 
     def updateQueryUrl(self, url, queryDict):
         urlParts = urlparse(url)
@@ -249,17 +293,10 @@ class YouTubeParser:
         url = url.strip()
         if url.startswith("//"):
             url = "https:" + url
-        if url.startswith("http://yt3.googleusercontent.com/"):
-            url = "https://" + url[len("http://"):]
-        elif url.startswith("http://yt3.ggpht.com/"):
-            url = "https://" + url[len("http://"):]
-        elif url.startswith("http://i.ytimg.com/"):
-            url = "https://" + url[len("http://"):]
-        elif url.startswith("http://"):
-            parsed = urlparse(url)
-            host = parsed.netloc.lower()
-            if host.endswith("googleusercontent.com") or host.endswith("ggpht.com") or host.endswith("ytimg.com"):
-                url = "https://" + url[len("http://"):]
+        if url.startswith("http:") and not url.startswith("https:"):
+            host = urlparse(url).netloc.lower()
+            if host.endswith(("googleusercontent.com", "ggpht.com", "ytimg.com")):
+                url = "https:" + url[5:]
         if "?" in url:
             url = url.split("?", 1)[0]
         url = re.sub(r"=s([0-9]+)(?:-c)?(?:-k-c0x00ffffff)?(?:-no-rj)?(?:-mo)?$", "", url, flags=re.IGNORECASE)
@@ -397,11 +434,12 @@ class YouTubeParser:
             if not videoId:
                 return retData
             url = "https://www.youtube.com/watch?v=%s" % videoId
-            sts, data = self.cm.getPage(url, self.http_params)
+            sts, data = self.cm.getPage(url, self._applyYoutubeHeaders())
             if not sts or not data:
                 printDBG("YouTubeParser._getWatchPageData getPage FAILED")
                 return retData
             data = ensure_str(data)
+            self._absorbPageConfig(data)
             publishDate = ""
             m = re.search(r'"publishDate":"([^"]+)"', data, re.IGNORECASE)
             if m:
@@ -482,7 +520,7 @@ class YouTubeParser:
         videoId = videoJson.get("videoId", "")
         if not videoId:
             return {}
-        url = "http://www.youtube.com/watch?v=%s" % videoId
+        url = "https://www.youtube.com/watch?v=%s" % videoId
         try:
             title = self._getSimpleText(videoJson.get("title", {}))
             if not title:
@@ -690,7 +728,7 @@ class YouTubeParser:
         # Videos only, no other types
         if lockupJson.get("contentType") != "LOCKUP_CONTENT_TYPE_VIDEO":
             return {}
-        url = "http://www.youtube.com/watch?v=%s" % videoId
+        url = "https://www.youtube.com/watch?v=%s" % videoId
         try:
             title = lockupJson["metadata"]["lockupMetadataViewModel"]["title"]["content"]
             title = self._normalizeText(title)
@@ -758,14 +796,22 @@ class YouTubeParser:
 
     # LOCALE HELPERS
     def _getDefaultLangAndRegion(self):
+        lang, region = self._deriveLangAndRegion()
+        try:
+            searchRegion = ensure_str(config.plugins.iptvplayer.youtube_search_region.value)
+            if searchRegion and searchRegion != "auto":
+                region = searchRegion
+        except Exception:
+            printExc()
+        return lang, region
+
+    def _deriveLangAndRegion(self):
         lang = "en"
         region = "US"
         try:
-            selectedLang = ensure_str(config.plugins.iptvplayer.youtube_ui_language.value)
-            if selectedLang == "de":
-                return "de", "DE"
-            if selectedLang == "en":
-                return "en", "US"
+            selectedLang = ensure_str(config.plugins.iptvplayer.youtube_ui_language.value).lower()
+            if selectedLang and selectedLang != "system":
+                return selectedLang, _YT_LANG_DEFAULT_REGION.get(selectedLang, selectedLang.upper())
             locale = ensure_str(language.getLanguage())
             if "_" in locale:
                 tmp = locale.split("_", 1)
@@ -785,23 +831,146 @@ class YouTubeParser:
         return lang, region
 
     def _getAcceptLanguage(self):
-        try:
-            selectedLang = ensure_str(config.plugins.iptvplayer.youtube_ui_language.value)
-            if selectedLang == "de":
-                return "de-DE,de;q=0.9"
-            if selectedLang == "en":
-                return "en-US,en;q=0.9"
-        except Exception:
-            printExc()
         lang, region = self._getDefaultLangAndRegion()
         return "%s-%s,%s;q=0.9" % (lang, region, lang)
+
+    def _getAuthHeader(self):
+        try:
+            if not hasattr(self, "_oauth"):
+                self._oauth = YouTubeOAuth()
+            return self._oauth.getAuthHeader()
+        except Exception:
+            printExc()
+            return {}
 
     def _applyYoutubeHeaders(self, http_params=None, accept_language=None):
         params = self.http_params if http_params is None else dict(http_params)
         hdr = dict(params.get("header", {}))
         hdr["Accept-Language"] = accept_language if accept_language is not None else self._getAcceptLanguage()
+        cfg = self._getYtConfig()
+        hdr["X-YouTube-Client-Name"] = "1"
+        hdr["X-YouTube-Client-Version"] = cfg["client_version"]
+        hdr["Origin"] = "https://www.youtube.com"
+        # NB: the OAuth bearer token is deliberately NOT added here - InnerTube
+        # rejects it on the WEB client (browse/search/continuations all 400).
+        # It is only usable on the TVHTML5 client (see _tvBrowse) and on the
+        # player request (see getDirectLinks -> _real_extract authHeader=).
+        hdr["X-Youtube-Bootstrap-Logged-In"] = "false"
+        if cfg["visitor_data"]:
+            hdr["X-Goog-Visitor-Id"] = cfg["visitor_data"]
         params["header"] = hdr
         return params
+
+    def _ytContext(self):
+        hl, gl = self._getDefaultLangAndRegion()
+        cfg = self._getYtConfig(fetchIfMissing=True)
+        client = {"clientName": "WEB", "clientVersion": cfg["client_version"], "hl": hl, "gl": gl}
+        if cfg["visitor_data"]:
+            client["visitorData"] = cfg["visitor_data"]
+        context = {"client": client}
+        if config.plugins.iptvplayer.youtube_safe_search.value:
+            context["user"] = {"enableSafetyMode": True}
+        return cfg, context
+
+    # ---- signed-in personal feeds (TVHTML5) ------------------------------
+    # The OAuth token from the "sign in on TV" flow is only honoured by
+    # InnerTube for the TVHTML5 client; the WEB client answers 400 to it. A
+    # TVHTML5 browse reply uses the living-room "tile" renderers, not the web
+    # ytInitialData shape, so it gets its own small walk here.
+    YT_TV_CLIENT_VERSION = "7.20250312.16.00"
+
+    def _tvBrowse(self, browseId, continuation=None):
+        auth = self._getAuthHeader()
+        if not auth:
+            return {}
+        hl, gl = self._getDefaultLangAndRegion()
+        context = {"client": {"clientName": "TVHTML5", "clientVersion": self.YT_TV_CLIENT_VERSION, "hl": hl, "gl": gl}}
+        if config.plugins.iptvplayer.youtube_safe_search.value:
+            context["user"] = {"enableSafetyMode": True}
+        body = {"context": context}
+        if continuation:
+            body["continuation"] = continuation
+        else:
+            body["browseId"] = browseId
+        hdr = {"Content-Type": "application/json",
+               "User-Agent": "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version",
+               "Origin": "https://www.youtube.com",
+               "X-YouTube-Client-Name": "7",
+               "X-YouTube-Client-Version": self.YT_TV_CLIENT_VERSION}
+        hdr.update(auth)
+        http_params = {"header": hdr, "raw_post_data": True}
+        sts, data = self.cm.getPage("https://www.youtube.com/youtubei/v1/browse", http_params, json_dumps(body).encode("utf-8"))
+        if not sts:
+            return {}
+        try:
+            return json_loads(data)
+        except Exception:
+            printExc()
+            return {}
+
+    def _firstFind(self, node, key):
+        return next(self.findKeys(node, key), None)
+
+    def _tvTileToVideo(self, tile):
+        videoId = self._firstFind(tile.get("onSelectCommand", {}), "videoId") or ""
+        if not videoId:
+            return {}
+        md = tile.get("metadata", {}).get("tileMetadataRenderer", {})
+        title = self._getSimpleText(md.get("title", {}))
+        lines = []
+        for line in md.get("lines", []):
+            parts = [self._getSimpleText(it.get("lineItemRenderer", {}).get("text", {}))
+                     for it in line.get("lineRenderer", {}).get("items", [])]
+            parts = [p for p in parts if p]
+            if parts:
+                lines.append(" ".join(parts))
+        # first line is the channel name, the rest are views / age / etc.
+        owner = ensure_str(lines[0]) if lines else ""
+        descLines = lines[1:] if len(lines) > 1 else []
+        icon = ""
+        thumbs = self._firstFind(tile.get("header", {}), "thumbnails")
+        if isinstance(thumbs, list) and thumbs:
+            icon = thumbs[-1].get("url", "")
+        desc = " | ".join(descLines)
+        if owner:
+            desc = (desc + "\n" + owner) if desc else owner
+        return {
+            "type": "video",
+            "category": "video",
+            "title": self._normalizeText(ensure_str(title)),
+            "url": "https://www.youtube.com/watch?v=%s" % videoId,
+            "icon": ensure_str(icon),
+            "time": "",
+            "desc": self._normalizeText(desc),
+            "channel": owner,
+            "channel_title": owner,
+            "video_id": ensure_str(videoId),
+        }
+
+    def getTvFeed(self, browseId, page, cItem):
+        printDBG("YouTubeParser.getTvFeed browseId[%s] page[%s]" % (browseId, page))
+        currList = []
+        response = self._tvBrowse(browseId, cItem.get("tv_continuation", "") or None)
+        if not response:
+            return currList
+        seen = set()
+        for tile in self.findKeys(response, "tileRenderer"):
+            params = self._tvTileToVideo(tile)
+            if params and params["video_id"] not in seen:
+                seen.add(params["video_id"])
+                currList.append(params)
+        # "load more" for this list: the token carried by a
+        # continuationItemRenderer (ignore unrelated continuationCommands
+        # elsewhere in the shell)
+        nextToken = ""
+        for cir in self.findKeys(response, "continuationItemRenderer"):
+            tok = self._firstFind(cir, "token")
+            if tok:
+                nextToken = tok
+        if nextToken and currList:
+            currList.append({"type": "more", "category": cItem.get("category", ""), "title": _("Next page"),
+                             "page": str(int(page) + 1), "tv_continuation": nextToken})
+        return currList
 
     def _extractEntriesFromBrowse(self, response):
         entries = []
@@ -885,18 +1054,9 @@ class YouTubeParser:
                 except Exception:
                     label = _("Next page")
                 # continuation page for channel list
-                hl, gl = self._getDefaultLangAndRegion()
-                urlNextPage = "https://www.youtube.com/youtubei/v1/browse?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
-                post_data = {
-                    "context": {
-                        "client": {
-                            "clientName": "WEB",
-                            "clientVersion": "2.20201021.03.00",
-                            "hl": hl,
-                            "gl": gl,
-                        }
-                    },
-                }
+                cfg, context = self._ytContext()
+                urlNextPage = "https://www.youtube.com/youtubei/v1/browse?key=" + cfg["api_key"]
+                post_data = {"context": context}
                 post_data["continuation"] = ctoken
                 post_data["context"]["clickTracking"] = {"clickTrackingParams": ctit}
                 post_data = json_dumps(post_data).encode("utf-8")
@@ -918,174 +1078,191 @@ class YouTubeParser:
         printDBG("YouTubeParser.getSearchResult pattern[%s], searchType[%s], page[%s]" % (pattern, searchType, page))
         currList = []
         try:
-            # next page / continuation handling
-            if url:
-                url = strwithmeta(url)
-                if "post_data" in url.meta:
-                    http_params = dict(self.http_params)
-                    http_params["header"]["Content-Type"] = "application/json"
-                    http_params["raw_post_data"] = True
-                    http_params = self._applyYoutubeHeaders(http_params)
-                    sts, data = self.cm.getPage(url, http_params, url.meta["post_data"])
-                else:
-                    self.http_params = self._applyYoutubeHeaders(self.http_params)
-                    sts, data = self.cm.getPage(url, self.http_params, self.postdata)
-                if not sts:
-                    return []
-                response = json_loads(data)
-            else:
-                # first search request
-                url = "https://www.youtube.com/results?search_query=" + pattern + "&sp="
-                if searchType == "video":
-                    url += "CA%sSAhAB" % sortBy
-                if searchType == "channel":
-                    url += "CA%sSAhAC" % sortBy
-                if searchType == "playlist":
-                    url += "CA%sSAhAD" % sortBy
-                if searchType == "live":
-                    url += "EgJAAQ%253D%253D"
-                self.http_params = self._applyYoutubeHeaders(self.http_params)
-                sts, data = self.cm.getPage(url, self.http_params)
-                if not sts:
-                    return []
-                self.checkSessionToken(data)
-                data2 = self.cm.ph.getDataBeetwenMarkers(data, 'window["ytInitialData"] =', "};", False)[1]
-                if len(data2) == 0:
-                    data2 = self.cm.ph.getDataBeetwenMarkers(data, "var ytInitialData =", "};", False)[1]
-                data2 = ensure_str(data2.strip())
-                # json simple schema verification and correction
-                jsonStarts = data2.count("{")
-                jsonEnds = data2.count("}")
-                printDBG('youtuberparser.YouTubeParser().getSearchResult correcting json string by adding "}" %s time(s) at the end' % (jsonStarts - jsonEnds))
-                while jsonEnds < jsonStarts:
-                    data2 = data2 + "}"
-                    jsonEnds += 1
-                response = json_loads(data2)
-
-            # search videos
-            r2 = list(self.findKeys(response, "videoRenderer"))
-            printDBG("---------Returned DICT ------------")
-            for item in r2:
-                printDBG(str(item))
-            printDBG("---------------------")
-            for item in r2:
-                params = self.getVideoData(item)
-                if params:
-                    printDBG(str(params))
-                    currList.append(params)
-
-            # search channels
-            r2 = list(self.findKeys(response, "channelRenderer"))
-            printDBG("---------------------")
-            printDBG(json_dumps(r2))
-            printDBG("---------------------")
-            for item in r2:
-                params = self.getChannelData(item)
-                if params:
-                    printDBG(str(params))
-                    currList.append(params)
-
-            # search playlists
-            r2 = list(self.findKeys(response, "playlistRenderer"))
-            printDBG("---------------------")
-            printDBG(json_dumps(r2))
-            printDBG("---------------------")
-            for item in r2:
-                params = self.getPlaylistData(item)
-                if params:
-                    printDBG(str(params))
-                    currList.append(params)
-
-            # New feature: lockupViewModel for playlists and channels in search
-            r2 = list(self.findKeys(response, "lockupViewModel"))
-            printDBG("---------lockupViewModel in search ------------")
-            for item in r2:
-                printDBG(str(item)[:500])
-            printDBG("---------------------")
-            for item in r2:
-                content_type = item.get("contentType", "")
-                if content_type == "LOCKUP_CONTENT_TYPE_PLAYLIST":
-                    try:
-                        playlist_id = item.get("contentId", "")
-                        title = item.get("metadata", {}).get("lockupMetadataViewModel", {}).get("title", {}).get("content", "")
-                        if playlist_id and title:
-                            url2 = "https://www.youtube.com/playlist?list=%s" % playlist_id
-                            icon = ""
-                            try:
-                                sources = item.get("contentImage", {}).get("collectionThumbnailViewModel", {}).get("primaryThumbnail", {}).get("thumbnailViewModel", {}).get("image", {}).get("sources", [])
-                                if sources:
-                                    icon = ensure_str(sources[-1].get("url", ""))
-                                    icon = self._normalizeThumbnailUrl(icon)
-                            except Exception:
-                                try:
-                                    sources = item.get("contentImage", {}).get("thumbnailViewModel", {}).get("image", {}).get("sources", [])
-                                    if sources:
-                                        icon = ensure_str(sources[-1].get("url", ""))
-                                        icon = self._normalizeThumbnailUrl(icon)
-                                except Exception:
-                                    pass
-                            currList.append({"type": "category", "category": "playlist", "title": title, "url": ensure_str(url2), "icon": icon, "time": "", "desc": ""})
-                    except Exception:
-                        printExc()
-                elif content_type == "LOCKUP_CONTENT_TYPE_CHANNEL":
-                    try:
-                        channel_id = item.get("contentId", "")
-                        title = item.get("metadata", {}).get("lockupMetadataViewModel", {}).get("title", {}).get("content", "")
-                        if channel_id and title:
-                            url2 = "https://www.youtube.com/channel/%s" % channel_id
-                            icon = ""
-                            try:
-                                sources = item.get("contentImage", {}).get("thumbnailViewModel", {}).get("image", {}).get("sources", [])
-                                if sources:
-                                    icon = ensure_str(sources[-1].get("url", ""))
-                                    icon = self._normalizeThumbnailUrl(icon)
-                            except Exception:
-                                pass
-                            currList.append({"type": "category", "category": "channel", "title": title, "url": ensure_str(url2), "icon": icon, "time": "", "desc": ""})
-                    except Exception:
-                        printExc()
-
-            # next page handling
-            nP = list(self.findKeys(response, "nextContinuationData"))
-            nP_new = list(self.findKeys(response, "continuationEndpoint"))
-            if nP:
-                nextPage = nP[0]
-                ctoken = nextPage["continuation"]
-                itct = nextPage["clickTrackingParams"]
-                try:
-                    label = nextPage["label"]["runs"][0]["text"]
-                except Exception:
-                    label = _("Next page")
-                urlNextPage = self.updateQueryUrl(url, {"pbj": "1", "ctoken": ctoken, "continuation": ctoken, "itct": itct})
-                currList.append({"type": "more", "category": "search_next_page", "title": label, "page": str(int(page) + 1), "url": ensure_str(urlNextPage)})
-            elif nP_new:
-                printDBG("-------------------------------------------------")
-                printDBG(json_dumps(nP_new))
-                printDBG("-------------------------------------------------")
-                nextPage = nP_new[0]
-                ctoken = nextPage["continuationCommand"]["token"]
-                itct = nextPage["clickTrackingParams"]
-                label = _("Next page")
-                hl, gl = self._getDefaultLangAndRegion()
-                urlNextPage = "https://www.youtube.com/youtubei/v1/search?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
-                post_data = {
-                    "context": {
-                        "client": {
-                            "clientName": "WEB",
-                            "clientVersion": "2.20201021.03.00",
-                            "hl": hl,
-                            "gl": gl,
-                        }
-                    },
-                }
-                post_data["continuation"] = ctoken
-                post_data["context"]["clickTracking"] = {"clickTrackingParams": itct}
-                post_data = json_dumps(post_data).encode("utf-8")
-                urlNextPage = strwithmeta(urlNextPage, {"post_data": post_data})
-                currList.append({"type": "more", "category": "search_next_page", "title": label, "page": str(int(page) + 1), "url": ensure_str(urlNextPage)})
+            response, url = self._fetchSearchResponse(pattern, searchType, sortBy, url)
+            if response is None:
+                return []
+            # currList is mutated in place from here on (not returned+merged)
+            # so a mid-parse exception still keeps whatever was already found,
+            # same as when all of this sat inline in one try block.
+            self._parseSearchRenderers(response, currList)
+            self._appendSearchNextPage(response, url, page, currList)
         except Exception:
             printExc()
         return currList
+
+    def _fetchSearchResponse(self, pattern, searchType, sortBy, url):
+        # Returns (response, url) - url is the possibly-rewritten request URL
+        # (an old-style nextContinuationData continuation is built from it
+        # later via updateQueryUrl). (None, url) on a failed fetch.
+        if url:
+            # next page / continuation handling
+            url = strwithmeta(url)
+            if "post_data" in url.meta:
+                http_params = dict(self.http_params)
+                http_params["header"]["Content-Type"] = "application/json"
+                http_params["raw_post_data"] = True
+                http_params = self._applyYoutubeHeaders(http_params)
+                sts, data = self.cm.getPage(url, http_params, url.meta["post_data"])
+            else:
+                self.http_params = self._applyYoutubeHeaders(self.http_params)
+                sts, data = self.cm.getPage(url, self.http_params, self.postdata)
+            if not sts:
+                return None, url
+            return json_loads(data), url
+
+        # first search request - plain HTML GET of /results + scrape
+        # ytInitialData, kept identical to the plain python3 host. An
+        # InnerTube POST here reads as more bot-like and got the box
+        # walled faster. (safe-search / region only take effect from
+        # page 2 on via the continuation context - acceptable.)
+        url = "https://www.youtube.com/results?search_query=" + pattern + "&sp="
+        if searchType == "video":
+            url += "CA%sSAhAB" % sortBy
+        if searchType == "channel":
+            url += "CA%sSAhAC" % sortBy
+        if searchType == "playlist":
+            url += "CA%sSAhAD" % sortBy
+        if searchType == "live":
+            url += "EgJAAQ%253D%253D"
+        # minimal headers only (a plain page navigation) - built from the
+        # pristine HTTP_HEADER, not the session-accumulated self.http_params,
+        # and without _applyYoutubeHeaders' Origin / bootstrap / visitor-id
+        # (those read as XHR)
+        hdr = dict(self.HTTP_HEADER)
+        hdr["Accept-Language"] = self._getAcceptLanguage()
+        sts, data = self.cm.getPage(url, {"header": hdr, "return_data": True})
+        if not sts:
+            return None, url
+        self.checkSessionToken(data)
+        data2 = self.cm.ph.getDataBeetwenMarkers(data, 'window["ytInitialData"] =', "};", False)[1]
+        if len(data2) == 0:
+            data2 = self.cm.ph.getDataBeetwenMarkers(data, "var ytInitialData =", "};", False)[1]
+        data2 = ensure_str(data2.strip())
+        # json simple schema verification and correction
+        jsonStarts = data2.count("{")
+        jsonEnds = data2.count("}")
+        printDBG('YouTubeParser.getSearchResult correcting json string by adding "}" %s time(s) at the end' % (jsonStarts - jsonEnds))
+        while jsonEnds < jsonStarts:
+            data2 = data2 + "}"
+            jsonEnds += 1
+        return json_loads(data2), url
+
+    def _parseSearchRenderers(self, response, currList):
+        # search videos
+        r2 = list(self.findKeys(response, "videoRenderer"))
+        printDBG("---------Returned DICT ------------")
+        for item in r2:
+            printDBG(str(item))
+        printDBG("---------------------")
+        for item in r2:
+            params = self.getVideoData(item)
+            if params:
+                printDBG(str(params))
+                currList.append(params)
+
+        # search channels
+        r2 = list(self.findKeys(response, "channelRenderer"))
+        printDBG("---------------------")
+        printDBG(json_dumps(r2))
+        printDBG("---------------------")
+        for item in r2:
+            params = self.getChannelData(item)
+            if params:
+                printDBG(str(params))
+                currList.append(params)
+
+        # search playlists
+        r2 = list(self.findKeys(response, "playlistRenderer"))
+        printDBG("---------------------")
+        printDBG(json_dumps(r2))
+        printDBG("---------------------")
+        for item in r2:
+            params = self.getPlaylistData(item)
+            if params:
+                printDBG(str(params))
+                currList.append(params)
+
+        # New feature: lockupViewModel for playlists and channels in search
+        r2 = list(self.findKeys(response, "lockupViewModel"))
+        printDBG("---------lockupViewModel in search ------------")
+        for item in r2:
+            printDBG(str(item)[:500])
+        printDBG("---------------------")
+        for item in r2:
+            self._appendLockupSearchItem(item, currList)
+
+    def _appendLockupSearchItem(self, item, currList):
+        content_type = item.get("contentType", "")
+        if content_type == "LOCKUP_CONTENT_TYPE_PLAYLIST":
+            try:
+                playlist_id = item.get("contentId", "")
+                title = item.get("metadata", {}).get("lockupMetadataViewModel", {}).get("title", {}).get("content", "")
+                if playlist_id and title:
+                    url2 = "https://www.youtube.com/playlist?list=%s" % playlist_id
+                    icon = ""
+                    try:
+                        sources = item.get("contentImage", {}).get("collectionThumbnailViewModel", {}).get("primaryThumbnail", {}).get("thumbnailViewModel", {}).get("image", {}).get("sources", [])
+                        if sources:
+                            icon = ensure_str(sources[-1].get("url", ""))
+                            icon = self._normalizeThumbnailUrl(icon)
+                    except Exception:
+                        try:
+                            sources = item.get("contentImage", {}).get("thumbnailViewModel", {}).get("image", {}).get("sources", [])
+                            if sources:
+                                icon = ensure_str(sources[-1].get("url", ""))
+                                icon = self._normalizeThumbnailUrl(icon)
+                        except Exception:
+                            pass
+                    currList.append({"type": "category", "category": "playlist", "title": title, "url": ensure_str(url2), "icon": icon, "time": "", "desc": ""})
+            except Exception:
+                printExc()
+        elif content_type == "LOCKUP_CONTENT_TYPE_CHANNEL":
+            try:
+                channel_id = item.get("contentId", "")
+                title = item.get("metadata", {}).get("lockupMetadataViewModel", {}).get("title", {}).get("content", "")
+                if channel_id and title:
+                    url2 = "https://www.youtube.com/channel/%s" % channel_id
+                    icon = ""
+                    try:
+                        sources = item.get("contentImage", {}).get("thumbnailViewModel", {}).get("image", {}).get("sources", [])
+                        if sources:
+                            icon = ensure_str(sources[-1].get("url", ""))
+                            icon = self._normalizeThumbnailUrl(icon)
+                    except Exception:
+                        pass
+                    currList.append({"type": "category", "category": "channel", "title": title, "url": ensure_str(url2), "icon": icon, "time": "", "desc": ""})
+            except Exception:
+                printExc()
+
+    def _appendSearchNextPage(self, response, url, page, currList):
+        nP = list(self.findKeys(response, "nextContinuationData"))
+        nP_new = list(self.findKeys(response, "continuationEndpoint"))
+        if nP:
+            nextPage = nP[0]
+            ctoken = nextPage["continuation"]
+            itct = nextPage["clickTrackingParams"]
+            try:
+                label = nextPage["label"]["runs"][0]["text"]
+            except Exception:
+                label = _("Next page")
+            urlNextPage = self.updateQueryUrl(url, {"pbj": "1", "ctoken": ctoken, "continuation": ctoken, "itct": itct})
+            currList.append({"type": "more", "category": "search_next_page", "title": label, "page": str(int(page) + 1), "url": ensure_str(urlNextPage)})
+        elif nP_new:
+            printDBG("-------------------------------------------------")
+            printDBG(json_dumps(nP_new))
+            printDBG("-------------------------------------------------")
+            nextPage = nP_new[0]
+            ctoken = nextPage["continuationCommand"]["token"]
+            itct = nextPage["clickTrackingParams"]
+            label = _("Next page")
+            cfg, context = self._ytContext()
+            urlNextPage = "https://www.youtube.com/youtubei/v1/search?key=" + cfg["api_key"]
+            post_data = {"context": context}
+            post_data["continuation"] = ctoken
+            post_data["context"]["clickTracking"] = {"clickTrackingParams": itct}
+            post_data = json_dumps(post_data).encode("utf-8")
+            urlNextPage = strwithmeta(urlNextPage, {"post_data": post_data})
+            currList.append({"type": "more", "category": "search_next_page", "title": label, "page": str(int(page) + 1), "url": ensure_str(urlNextPage)})
 
     # PLAYLIST API PARSER
     def getVideosApiPlayList(self, url, category, page, cItem):

--- a/IPTVPlayer/subproviders/subprov_youtubecom.py
+++ b/IPTVPlayer/subproviders/subprov_youtubecom.py
@@ -33,7 +33,7 @@ def GetConfigList():
 class YoutubeComProvider(CBaseSubProviderClass):
 
     def __init__(self, params={}):
-        self.MAIN_URL = 'http://youtube.com/'
+        self.MAIN_URL = 'https://youtube.com/'
         self.USER_AGENT = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/37.0.2062.120 Chrome/37.0.2062.120 Safari/537.36'
         self.HTTP_HEADER = {'User-Agent': self.USER_AGENT, 'Referer': self.MAIN_URL, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate'}
 
@@ -54,10 +54,10 @@ class YoutubeComProvider(CBaseSubProviderClass):
         from Plugins.Extensions.IPTVPlayer.libs.youtube_dl.extractor.youtube import YoutubeIE
 
         ytExtractor = YoutubeIE()
-        # get normal langs
-        tab = ytExtractor._get_subtitles(self.youtubeId)
-        tab2 = ytExtractor._get_automatic_captions(self.youtubeId)
-        for item in tab2:
+        # one listing, split into manually authored vs auto-generated tracks
+        tracks = ytExtractor._extract_caption_tracks(self.youtubeId)
+        tab = ytExtractor._caption_tracks_to_subs(tracks, want_asr=False)
+        for item in ytExtractor._caption_tracks_to_subs(tracks, want_asr=True, start_idx=len(tab)):
             item['title'] = '[%s] %s' % (_('Auto-translate'), item['title'])
             tab.append(item)
         defaultLang = GetDefaultLang()

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.12.02"
+IPTV_VERSION = "2026.09.12.03"


### PR DESCRIPTION
…es rewrite

New features:
- Google account sign-in (OAuth device-code flow) from the host config screen - sign in/out unlocks age-restricted and members-only videos, subscriptions, liked videos, watch later, and watch history.
- Signed-in feeds (subscriptions/liked/watch-later/history) via the TVHTML5 InnerTube client's tile-based browse layout.
- Search results region filter (25 countries + Automatic) and a Safe Search (restricted mode) toggle.
- Full display-language list (~27 languages, native + English names), up from just German/English.
- Live streams play via the HLS manifest instead of the (unsuitable) DASH merge:// path.
- Subtitles rewritten: manually-authored and auto-generated caption tracks are correctly split and labelled, with unique per-track IDs.

Reliability:
- The InnerTube client config (client version, API key, visitor ID) is now harvested at runtime from live youtube.com responses instead of hardcoded, so it stops rotting as YouTube updates its site.

Cleanup along the way:
- Removed dead code: unused legacy format tables, the no-longer- functional anonymous age-gate bypass toggle, the unused video- format config option, an unused FFMPEG FIFO-mux experiment for no-buffer merge:// playback.
- Long functions split into named helper methods for readability, with no behaviour change.