### PR TITLE
NOSONAR the public Google OAuth device-flow credentials and InnerTube…

### DIFF
--- a/IPTVPlayer/libs/youtube_oauth.py
+++ b/IPTVPlayer/libs/youtube_oauth.py
@@ -26,8 +26,12 @@ from Components.config import config, ConfigText
 
 config.plugins.iptvplayer.youtube_oauth_refresh_token = ConfigText(default="", fixed_size=False)
 
-_CLIENT_ID = "861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com"
-_CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT"
+_CLIENT_ID = "861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com"  # NOSONAR
+# public "installed app" OAuth credential for Google's TV/limited-input-device
+# flow - the OAuth 2.0 device-flow spec has no mechanism for these clients to
+# keep a secret confidential, so Google issues them expecting exactly this;
+# yt-dlp, Kodi's YouTube plugin and others ship this identical pair
+_CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT"  # NOSONAR
 # OAuth scope identifiers, not fetched URLs - "http://gdata.youtube.com" is
 # Google's own legacy scope name (same string yt-dlp / Kodi use)
 _SCOPE = "http://gdata.youtube.com https://www.googleapis.com/auth/youtube"  # NOSONAR

--- a/IPTVPlayer/libs/youtubeparser.py
+++ b/IPTVPlayer/libs/youtubeparser.py
@@ -36,7 +36,7 @@ config.plugins.iptvplayer.youtube_safe_search = ConfigYesNo(default=False)
 # visitorData rot and are refreshed at runtime from ytcfg - see
 # YouTubeParser._absorbPageConfig() / _getYtConfig(). These are only the
 # fallbacks for when that scrape fails.
-YT_INNERTUBE_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+YT_INNERTUBE_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"  # NOSONAR
 YT_CLIENT_VERSION_FALLBACK = "2.20260904.01.00"
 
 # Fallback region (YouTube gl=) per selectable UI language - only the codes

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.09.12.03"
+IPTV_VERSION = "2026.09.12.04"


### PR DESCRIPTION
… API key

SonarCloud flags youtube_oauth.py's _CLIENT_ID/_CLIENT_SECRET and youtubeparser.py's YT_INNERTUBE_API_KEY as disclosed secrets. None of the three are actually secret:

- YT_INNERTUBE_API_KEY is YouTube's long-lived public web API key, shipped in every youtube.com page and hardcoded identically in yt-dlp and most other third-party clients.
- _CLIENT_ID/_CLIENT_SECRET are Google's public "TV/limited-input device" OAuth client credentials. The OAuth 2.0 device-flow spec gives installed/TV clients no way to keep a secret confidential, so Google issues them expecting exactly this; yt-dlp, Kodi's YouTube plugin and other open-source tools ship this identical pair.

Matches the existing NOSONAR precedent already on this file's _SCOPE/_DEVICE_GRANT identifiers.